### PR TITLE
ci: fix broken action versions, add fmt check and security scanning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,20 @@ jobs:
           cargo check --package parkhub-common --all-targets
           cargo check --package parkhub-server --no-default-features --features headless --all-targets
 
+  fmt:
+    name: Cargo Format Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+
   clippy:
     name: Cargo Clippy
     runs-on: ubuntu-latest
@@ -107,13 +121,17 @@ jobs:
   ci:
     name: CI
     if: always()
-    needs: [check, clippy, test, frontend]
+    needs: [check, fmt, clippy, test, frontend]
     runs-on: ubuntu-latest
     steps:
       - name: Check results
         run: |
           if [[ "${{ needs.check.result }}" != "success" ]]; then
             echo "check failed: ${{ needs.check.result }}"
+            exit 1
+          fi
+          if [[ "${{ needs.fmt.result }}" != "success" ]]; then
+            echo "fmt failed: ${{ needs.fmt.result }}"
             exit 1
           fi
           if [[ "${{ needs.clippy.result }}" != "success" ]]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -32,7 +32,7 @@ jobs:
           sudo apt-get install -y cmake libfontconfig1-dev
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: '22'
 
@@ -59,7 +59,7 @@ jobs:
           tar -czvf parkhub-linux-x64.tar.gz parkhub-linux-x64
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: parkhub-linux-x64
           path: parkhub-linux-x64.tar.gz
@@ -71,13 +71,13 @@ jobs:
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: '22'
 
@@ -106,7 +106,7 @@ jobs:
           Compress-Archive -Path parkhub-windows-x64 -DestinationPath parkhub-windows-x64.zip
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: parkhub-windows-x64
           path: parkhub-windows-x64.zip
@@ -119,12 +119,12 @@ jobs:
       contents: write
     steps:
       - name: Download Linux artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v4
         with:
           name: parkhub-linux-x64
 
       - name: Download Windows artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v4
         with:
           name: parkhub-windows-x64
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,70 @@
+name: Security Scanning
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Run weekly on Monday at 08:00 UTC to catch new CVEs
+    - cron: '0 8 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  cargo-audit:
+    name: Cargo Audit (CVE Check)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+
+      - name: Install cargo-audit
+        run: cargo install cargo-audit --locked
+
+      - name: Run cargo audit
+        run: cargo audit
+
+  cargo-deny:
+    name: Cargo Deny (License + Dependency Policy)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run cargo-deny
+        uses: EmbarkStudios/cargo-deny-action@v2
+        with:
+          log-level: warn
+          command: check
+          arguments: --all-features
+
+  trivy-fs:
+    name: Trivy Filesystem Scan
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run Trivy filesystem scan
+        uses: aquasecurity/trivy-action@master
+        with:
+          scan-type: 'fs'
+          scan-ref: '.'
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+          severity: 'CRITICAL,HIGH'
+
+      - name: Upload Trivy results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        if: always()
+        with:
+          sarif_file: 'trivy-results.sarif'


### PR DESCRIPTION
## Summary

- **Fixes broken release pipeline** — `release.yml` referenced non-existent GitHub Action versions (v6, v7, v8), causing all tagged releases to fail
- **Parity between Gitea and GitHub CI** — adds `cargo fmt` check that Gitea CI has but GitHub CI was missing
- **Security scanning** — new `security.yml` workflow with cargo-audit, cargo-deny, and Trivy

## Changes

### `release.yml` — Fix non-existent action versions
| Action | Before | After |
|--------|--------|-------|
| `actions/checkout` | v6 ❌ | v4 ✓ |
| `actions/setup-node` | v6 ❌ | v4 ✓ |
| `actions/upload-artifact` | v7 ❌ | v4 ✓ |
| `actions/download-artifact` | v8 ❌ | v4 ✓ |

### `ci.yml` — Add `cargo fmt --check` job
- New `fmt` job: `cargo fmt --all -- --check`
- Added to gate job (`ci`) so format failures block merge

### `security.yml` (new)
- **`cargo-audit`**: checks all dependencies against RustSec advisory database
- **`cargo-deny`**: license compliance + duplicate dependency detection
- **Trivy**: filesystem scan, SARIF output uploaded to GitHub Security tab
- Runs on push to main/develop, all PRs, and weekly schedule (Monday 08:00 UTC)

## Linked Issues

Closes #65 (broken action versions)
Closes #66 (missing fmt check)
Closes #67 (no security scanning)

## Test plan

- [ ] Verify all 3 jobs in `security.yml` run without error on first push
- [ ] Verify release pipeline works end-to-end on next tag push
- [ ] Introduce a formatting violation on a test branch → confirm `fmt` job fails