### PR TITLE
feat(credits): add admin credit transaction history endpoint

### DIFF
--- a/parkhub-server/src/api/credits.rs
+++ b/parkhub-server/src/api/credits.rs
@@ -1,11 +1,11 @@
 //! Credits handlers: user balance, admin grant, refill, quota management.
 
 use axum::{
-    extract::{Path, State},
+    extract::{Path, Query, State},
     http::StatusCode,
     Extension, Json,
 };
-use chrono::Utc;
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
@@ -540,4 +540,55 @@ pub async fn admin_update_user_quota(
         StatusCode::OK,
         Json(ApiResponse::success(AdminUserResponse::from(&target_user))),
     )
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Admin: credit transaction history
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Deserialize)]
+pub struct AdminCreditTransactionsQuery {
+    pub user_id: Option<Uuid>,
+    pub transaction_type: Option<CreditTransactionType>,
+    pub from: Option<DateTime<Utc>>,
+    pub to: Option<DateTime<Utc>>,
+}
+
+/// `GET /api/v1/admin/credits/transactions` — list all credit transactions (admin only)
+#[utoipa::path(
+    get,
+    path = "/api/v1/admin/credits/transactions",
+    tag = "Credits",
+    summary = "List all credit transactions (admin)",
+    description = "Returns all credit transactions across all users, with optional filtering.",
+    responses(
+        (status = 200, description = "Transaction list"),
+        (status = 403, description = "Admin access required"),
+    )
+)]
+pub async fn admin_list_credit_transactions(
+    State(state): State<SharedState>,
+    Extension(auth_user): Extension<AuthUser>,
+    Query(params): Query<AdminCreditTransactionsQuery>,
+) -> (StatusCode, Json<ApiResponse<Vec<CreditTransaction>>>) {
+    let state_guard = state.read().await;
+
+    if let Err(resp) = check_admin(&state_guard.db, &auth_user).await {
+        return (StatusCode::FORBIDDEN, Json(resp));
+    }
+
+    match state_guard
+        .db
+        .list_all_credit_transactions(params.user_id, params.transaction_type, params.from, params.to)
+        .await
+    {
+        Ok(txs) => (StatusCode::OK, Json(ApiResponse::success(txs))),
+        Err(e) => {
+            tracing::error!("Failed to list credit transactions: {e}");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ApiResponse::error("SERVER_ERROR", "Failed to list transactions")),
+            )
+        }
+    }
 }

--- a/parkhub-server/src/api/mod.rs
+++ b/parkhub-server/src/api/mod.rs
@@ -91,7 +91,8 @@ pub mod zones;
 // Re-import handler functions so the router can reference them unqualified.
 use auth::{forgot_password, login, refresh_token, register, reset_password};
 use credits::{
-    admin_grant_credits, admin_refill_all_credits, admin_update_user_quota, get_user_credits,
+    admin_grant_credits, admin_list_credit_transactions, admin_refill_all_credits,
+    admin_update_user_quota, get_user_credits,
 };
 use export::{admin_export_bookings_csv, admin_export_revenue_csv, admin_export_users_csv};
 use favorites::{add_favorite, list_favorites, remove_favorite};
@@ -296,6 +297,10 @@ pub fn create_router(state: SharedState) -> (Router, demo::SharedDemoState) {
         .route(
             "/api/v1/admin/credits/refill-all",
             post(admin_refill_all_credits),
+        )
+        .route(
+            "/api/v1/admin/credits/transactions",
+            get(admin_list_credit_transactions),
         )
         .route(
             "/api/v1/admin/users/{id}/quota",

--- a/parkhub-server/src/db.rs
+++ b/parkhub-server/src/db.rs
@@ -1723,6 +1723,48 @@ impl Database {
         Ok(transactions)
     }
 
+    /// List all credit transactions across all users, with optional filters.
+    pub async fn list_all_credit_transactions(
+        &self,
+        user_id_filter: Option<uuid::Uuid>,
+        type_filter: Option<parkhub_common::models::CreditTransactionType>,
+        from: Option<chrono::DateTime<chrono::Utc>>,
+        to: Option<chrono::DateTime<chrono::Utc>>,
+    ) -> Result<Vec<parkhub_common::models::CreditTransaction>> {
+        let db = self.inner.read().await;
+        let read_txn = db.begin_read()?;
+        drop(db);
+        let table = read_txn.open_table(CREDIT_TRANSACTIONS)?;
+        let mut transactions = Vec::new();
+        for entry in table.iter()? {
+            let (_, value) = entry?;
+            let tx: parkhub_common::models::CreditTransaction = self.deserialize(value.value())?;
+            if let Some(uid) = user_id_filter {
+                if tx.user_id != uid {
+                    continue;
+                }
+            }
+            if let Some(ref t) = type_filter {
+                if &tx.transaction_type != t {
+                    continue;
+                }
+            }
+            if let Some(f) = from {
+                if tx.created_at < f {
+                    continue;
+                }
+            }
+            if let Some(t) = to {
+                if tx.created_at > t {
+                    continue;
+                }
+            }
+            transactions.push(tx);
+        }
+        transactions.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+        Ok(transactions)
+    }
+
     // ═══════════════════════════════════════════════════════════════════════════
     // WEBHOOK OPERATIONS
     // ═══════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
Closes #51

## Summary
- \`GET /api/v1/admin/credits/transactions\` with optional filters: \`user_id\`, \`transaction_type\`, \`from\`, \`to\`
- Added \`list_all_credit_transactions\` to \`Database\` (scans full table, applies filters)
- Admin-only via \`check_admin\`

## Test plan
- [ ] \`cargo build\` passes
- [ ] \`cargo test\` passes