### PR TITLE
feat(qr, pwa, branding): per-slot QR code, PWA manifest, branding endpoints

### DIFF
--- a/parkhub-server/src/api/branding.rs
+++ b/parkhub-server/src/api/branding.rs
@@ -1,0 +1,345 @@
+//! Branding configuration and logo endpoints.
+//!
+//! Stores branding config in admin settings under keys:
+//!   - `branding_app_name`
+//!   - `branding_primary_color`
+//!   - `branding_logo_base64`
+
+use axum::{
+    body::Body,
+    extract::State,
+    http::{header, StatusCode},
+    response::{IntoResponse, Json, Response},
+    Extension,
+};
+use base64::Engine as _;
+use serde::{Deserialize, Serialize};
+
+use parkhub_common::{ApiResponse, UserRole};
+
+use super::{AuthUser, SharedState};
+
+const MAX_LOGO_BYTES: usize = 2 * 1024 * 1024; // 2 MB raw
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct BrandingConfig {
+    pub app_name: String,
+    pub primary_color: String,
+    pub logo_url: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct BrandingUpdate {
+    pub app_name: Option<String>,
+    pub primary_color: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct LogoUpload {
+    /// Base64-encoded image data, optionally with a `data:<mime>;base64,` prefix.
+    pub logo: String,
+}
+
+fn strip_data_uri(input: &str) -> &str {
+    input
+        .find(";base64,")
+        .map_or(input, |pos| &input[pos + 8..])
+}
+
+fn detect_mime(bytes: &[u8]) -> Option<&'static str> {
+    if bytes.len() >= 3 && bytes[0] == 0xFF && bytes[1] == 0xD8 && bytes[2] == 0xFF {
+        Some("image/jpeg")
+    } else if bytes.len() >= 4
+        && bytes[0] == 0x89
+        && bytes[1] == 0x50
+        && bytes[2] == 0x4E
+        && bytes[3] == 0x47
+    {
+        Some("image/png")
+    } else {
+        None
+    }
+}
+
+/// `GET /api/v1/admin/branding` — read current branding config.
+#[utoipa::path(
+    get,
+    path = "/api/v1/admin/branding",
+    tag = "Admin",
+    summary = "Get branding configuration",
+    security(("bearer_auth" = [])),
+    responses(
+        (status = 200, description = "Branding config"),
+        (status = 401, description = "Unauthorized"),
+        (status = 403, description = "Forbidden")
+    )
+)]
+pub async fn admin_get_branding(
+    State(state): State<SharedState>,
+    Extension(auth_user): Extension<AuthUser>,
+) -> (StatusCode, Json<ApiResponse<BrandingConfig>>) {
+    let state_guard = state.read().await;
+
+    // Admin-only
+    match state_guard.db.get_user(&auth_user.user_id.to_string()).await {
+        Ok(Some(u)) if u.role == UserRole::Admin || u.role == UserRole::SuperAdmin => {}
+        _ => {
+            return (
+                StatusCode::FORBIDDEN,
+                Json(ApiResponse::error("FORBIDDEN", "Admin access required")),
+            );
+        }
+    }
+
+    let app_name = state_guard
+        .db
+        .get_setting("branding_app_name")
+        .await
+        .ok()
+        .flatten()
+        .unwrap_or_else(|| "ParkHub".to_string());
+
+    let primary_color = state_guard
+        .db
+        .get_setting("branding_primary_color")
+        .await
+        .ok()
+        .flatten()
+        .unwrap_or_else(|| "#2563eb".to_string());
+
+    let logo_url = state_guard
+        .db
+        .get_setting("branding_logo_base64")
+        .await
+        .ok()
+        .flatten()
+        .map(|v| if v.is_empty() { None } else { Some("/api/v1/branding/logo".to_string()) })
+        .flatten();
+
+    (
+        StatusCode::OK,
+        Json(ApiResponse::success(BrandingConfig {
+            app_name,
+            primary_color,
+            logo_url,
+        })),
+    )
+}
+
+/// `PUT /api/v1/admin/branding` — update branding config.
+#[utoipa::path(
+    put,
+    path = "/api/v1/admin/branding",
+    tag = "Admin",
+    summary = "Update branding configuration",
+    security(("bearer_auth" = [])),
+    responses(
+        (status = 200, description = "Updated branding config"),
+        (status = 401, description = "Unauthorized"),
+        (status = 403, description = "Forbidden")
+    )
+)]
+pub async fn admin_update_branding(
+    State(state): State<SharedState>,
+    Extension(auth_user): Extension<AuthUser>,
+    Json(req): Json<BrandingUpdate>,
+) -> (StatusCode, Json<ApiResponse<BrandingConfig>>) {
+    let state_guard = state.read().await;
+
+    // Admin-only
+    match state_guard.db.get_user(&auth_user.user_id.to_string()).await {
+        Ok(Some(u)) if u.role == UserRole::Admin || u.role == UserRole::SuperAdmin => {}
+        _ => {
+            return (
+                StatusCode::FORBIDDEN,
+                Json(ApiResponse::error("FORBIDDEN", "Admin access required")),
+            );
+        }
+    }
+
+    if let Some(ref name) = req.app_name {
+        if let Err(e) = state_guard.db.set_setting("branding_app_name", name).await {
+            tracing::error!("Failed to save branding_app_name: {}", e);
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ApiResponse::error("SERVER_ERROR", "Failed to save branding")),
+            );
+        }
+    }
+
+    if let Some(ref color) = req.primary_color {
+        if let Err(e) = state_guard.db.set_setting("branding_primary_color", color).await {
+            tracing::error!("Failed to save branding_primary_color: {}", e);
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ApiResponse::error("SERVER_ERROR", "Failed to save branding")),
+            );
+        }
+    }
+
+    let app_name = state_guard
+        .db
+        .get_setting("branding_app_name")
+        .await
+        .ok()
+        .flatten()
+        .unwrap_or_else(|| "ParkHub".to_string());
+
+    let primary_color = state_guard
+        .db
+        .get_setting("branding_primary_color")
+        .await
+        .ok()
+        .flatten()
+        .unwrap_or_else(|| "#2563eb".to_string());
+
+    let logo_url = state_guard
+        .db
+        .get_setting("branding_logo_base64")
+        .await
+        .ok()
+        .flatten()
+        .map(|v| if v.is_empty() { None } else { Some("/api/v1/branding/logo".to_string()) })
+        .flatten();
+
+    (
+        StatusCode::OK,
+        Json(ApiResponse::success(BrandingConfig {
+            app_name,
+            primary_color,
+            logo_url,
+        })),
+    )
+}
+
+/// `POST /api/v1/admin/branding/logo` — upload a logo (base64, max 2MB, PNG/JPEG).
+#[utoipa::path(
+    post,
+    path = "/api/v1/admin/branding/logo",
+    tag = "Admin",
+    summary = "Upload branding logo",
+    security(("bearer_auth" = [])),
+    responses(
+        (status = 200, description = "Logo uploaded"),
+        (status = 400, description = "Invalid image or too large"),
+        (status = 401, description = "Unauthorized"),
+        (status = 403, description = "Forbidden")
+    )
+)]
+pub async fn admin_upload_logo(
+    State(state): State<SharedState>,
+    Extension(auth_user): Extension<AuthUser>,
+    Json(req): Json<LogoUpload>,
+) -> (StatusCode, Json<ApiResponse<serde_json::Value>>) {
+    let state_guard = state.read().await;
+
+    // Admin-only
+    match state_guard.db.get_user(&auth_user.user_id.to_string()).await {
+        Ok(Some(u)) if u.role == UserRole::Admin || u.role == UserRole::SuperAdmin => {}
+        _ => {
+            return (
+                StatusCode::FORBIDDEN,
+                Json(ApiResponse::error("FORBIDDEN", "Admin access required")),
+            );
+        }
+    }
+
+    let b64 = strip_data_uri(&req.logo);
+
+    let raw_bytes = match base64::engine::general_purpose::STANDARD.decode(b64) {
+        Ok(b) => b,
+        Err(_) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(ApiResponse::error("INVALID_INPUT", "Invalid base64 data")),
+            );
+        }
+    };
+
+    if raw_bytes.len() > MAX_LOGO_BYTES {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(ApiResponse::error("PAYLOAD_TOO_LARGE", "Logo exceeds 2 MB limit")),
+        );
+    }
+
+    if detect_mime(&raw_bytes).is_none() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(ApiResponse::error(
+                "INVALID_INPUT",
+                "Unsupported image format. Only JPEG and PNG are accepted.",
+            )),
+        );
+    }
+
+    if let Err(e) = state_guard.db.set_setting("branding_logo_base64", b64).await {
+        tracing::error!("Failed to save branding logo: {}", e);
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ApiResponse::error("SERVER_ERROR", "Failed to save logo")),
+        );
+    }
+
+    tracing::info!(bytes = raw_bytes.len(), "Branding logo uploaded");
+    (
+        StatusCode::OK,
+        Json(ApiResponse::success(serde_json::json!({
+            "url": "/api/v1/branding/logo",
+            "bytes": raw_bytes.len()
+        }))),
+    )
+}
+
+/// `GET /api/v1/branding/logo` — serve the current branding logo (public, cached).
+#[utoipa::path(
+    get,
+    path = "/api/v1/branding/logo",
+    tag = "Branding",
+    summary = "Get branding logo",
+    description = "Returns the stored logo image with appropriate Content-Type and Cache-Control headers.",
+    responses(
+        (status = 200, description = "Logo image"),
+        (status = 404, description = "No logo configured")
+    )
+)]
+pub async fn get_branding_logo(State(state): State<SharedState>) -> Response {
+    let state_guard = state.read().await;
+
+    let stored = match state_guard.db.get_setting("branding_logo_base64").await {
+        Ok(Some(v)) if !v.is_empty() => v,
+        _ => {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(ApiResponse::<()>::error("NOT_FOUND", "No logo configured")),
+            )
+                .into_response();
+        }
+    };
+
+    drop(state_guard);
+
+    let b64 = strip_data_uri(&stored);
+
+    let raw_bytes = match base64::engine::general_purpose::STANDARD.decode(b64) {
+        Ok(b) => b,
+        Err(_) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ApiResponse::<()>::error("SERVER_ERROR", "Corrupt logo data")),
+            )
+                .into_response();
+        }
+    };
+
+    let content_type = detect_mime(&raw_bytes).unwrap_or("application/octet-stream");
+
+    Response::builder()
+        .status(StatusCode::OK)
+        .header(header::CONTENT_TYPE, content_type)
+        .header(header::CACHE_CONTROL, "public, max-age=3600")
+        .body(Body::from(raw_bytes))
+        .unwrap_or_else(|_| {
+            (StatusCode::INTERNAL_SERVER_ERROR, "Failed to build response").into_response()
+        })
+}

--- a/parkhub-server/src/api/mod.rs
+++ b/parkhub-server/src/api/mod.rs
@@ -72,12 +72,14 @@ type SharedState = Arc<RwLock<AppState>>;
 pub mod admin;
 pub mod auth;
 mod bookings;
+pub mod branding;
 pub mod credits;
 pub mod export;
 pub mod favorites;
 pub mod lots;
 pub mod payments;
 pub mod push;
+pub mod pwa;
 pub mod qr;
 pub mod recommendations;
 pub mod setup;
@@ -202,6 +204,11 @@ pub fn create_router(state: SharedState) -> (Router, demo::SharedDemoState) {
         .route("/api/v1/public/display", get(public_display))
         // VAPID public key (no auth — frontend needs it before login)
         .route("/api/v1/push/vapid-key", get(push::get_vapid_key))
+        // PWA manifest and service worker (no auth)
+        .route("/manifest.json", get(pwa::pwa_manifest))
+        .route("/sw.js", get(pwa::service_worker))
+        // Branding logo (public, cached)
+        .route("/api/v1/branding/logo", get(branding::get_branding_logo))
         // WebSocket real-time events
         .route("/api/v1/ws", get(ws::ws_handler));
 
@@ -238,6 +245,8 @@ pub fn create_router(state: SharedState) -> (Router, demo::SharedDemoState) {
         )
         // QR code for lot
         .route("/api/v1/lots/{id}/qr", get(lot_qr_code))
+        // QR code for individual slot
+        .route("/api/v1/lots/{lot_id}/slots/{slot_id}/qr", get(qr::slot_qr_code))
         // Zones (admin-only CRUD, nested under lots)
         .route(
             "/api/v1/lots/{lot_id}/zones",
@@ -434,6 +443,15 @@ pub fn create_router(state: SharedState) -> (Router, demo::SharedDemoState) {
         .route(
             "/api/v1/admin/privacy",
             get(admin_get_privacy).put(admin_update_privacy),
+        )
+        // Admin: branding config
+        .route(
+            "/api/v1/admin/branding",
+            get(branding::admin_get_branding).put(branding::admin_update_branding),
+        )
+        .route(
+            "/api/v1/admin/branding/logo",
+            post(branding::admin_upload_logo),
         )
         // Admin: update user
         .route("/api/v1/admin/users/{id}/update", put(admin_update_user))

--- a/parkhub-server/src/api/pwa.rs
+++ b/parkhub-server/src/api/pwa.rs
@@ -1,0 +1,58 @@
+//! PWA support — manifest.json and service worker.
+
+use axum::{
+    extract::State,
+    http::header,
+    response::{IntoResponse, Json},
+};
+use serde_json::json;
+
+use super::SharedState;
+
+/// `GET /manifest.json` — Web App Manifest for PWA installation.
+pub async fn pwa_manifest(State(state): State<SharedState>) -> impl IntoResponse {
+    let state_guard = state.read().await;
+    let app_name = if let Ok(Some(v)) = state_guard.db.get_setting("branding_app_name").await {
+        if v.is_empty() { "ParkHub".to_string() } else { v }
+    } else {
+        "ParkHub".to_string()
+    };
+    drop(state_guard);
+
+    let manifest = json!({
+        "name": app_name,
+        "short_name": app_name,
+        "start_url": "/",
+        "display": "standalone",
+        "background_color": "#ffffff",
+        "theme_color": "#2563eb",
+        "icons": [
+            {"src": "/icons/icon-192.png", "sizes": "192x192", "type": "image/png"},
+            {"src": "/icons/icon-512.png", "sizes": "512x512", "type": "image/png"}
+        ]
+    });
+
+    (
+        [(header::CONTENT_TYPE, "application/manifest+json")],
+        Json(manifest),
+    )
+}
+
+/// `GET /sw.js` — Service Worker for offline caching.
+pub async fn service_worker() -> impl IntoResponse {
+    let sw_js = r#"const CACHE_NAME = 'parkhub-v1';
+const STATIC_ASSETS = ['/'];
+self.addEventListener('install', e => e.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(STATIC_ASSETS))
+));
+self.addEventListener('fetch', e => {
+    if (e.request.method !== 'GET') return;
+    e.respondWith(fetch(e.request).catch(() => caches.match(e.request)));
+});
+"#;
+
+    (
+        [(header::CONTENT_TYPE, "application/javascript")],
+        sw_js,
+    )
+}

--- a/parkhub-server/src/api/qr.rs
+++ b/parkhub-server/src/api/qr.rs
@@ -197,6 +197,135 @@ pub async fn booking_qr_code(
         })
 }
 
+/// JSON payload embedded in the slot QR code.
+#[derive(Debug, Serialize)]
+struct QrSlotPayload {
+    r#type: String,
+    slot_id: String,
+    lot_id: String,
+}
+
+/// `GET /api/v1/lots/{lot_id}/slots/{slot_id}/qr` — QR code PNG for a parking slot.
+#[utoipa::path(
+    get,
+    path = "/api/v1/lots/{lot_id}/slots/{slot_id}/qr",
+    tag = "Lots",
+    summary = "Generate QR code for a parking slot",
+    description = "Returns a PNG image containing a QR code encoding the slot identity. Requires authentication.",
+    params(
+        ("lot_id" = String, Path, description = "Lot UUID"),
+        ("slot_id" = String, Path, description = "Slot UUID")
+    ),
+    responses(
+        (status = 200, description = "QR code PNG image", content_type = "image/png"),
+        (status = 401, description = "Unauthorized"),
+        (status = 404, description = "Slot not found"),
+        (status = 500, description = "QR generation failed")
+    ),
+    security(("bearer_auth" = []))
+)]
+pub async fn slot_qr_code(
+    State(state): State<SharedState>,
+    Extension(_auth_user): Extension<AuthUser>,
+    Path((lot_id, slot_id)): Path<(String, String)>,
+) -> Response {
+    let state_guard = state.read().await;
+
+    // Look up the slot
+    let slot = match state_guard.db.get_parking_slot(&slot_id).await {
+        Ok(Some(s)) => s,
+        Ok(None) => {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(ApiResponse::<()>::error("NOT_FOUND", "Parking slot not found")),
+            )
+                .into_response();
+        }
+        Err(e) => {
+            tracing::error!("Database error fetching slot for QR: {}", e);
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ApiResponse::<()>::error("SERVER_ERROR", "Internal server error")),
+            )
+                .into_response();
+        }
+    };
+
+    // Verify slot belongs to the given lot
+    if slot.lot_id.to_string() != lot_id {
+        return (
+            StatusCode::NOT_FOUND,
+            Json(ApiResponse::<()>::error("NOT_FOUND", "Parking slot not found in this lot")),
+        )
+            .into_response();
+    }
+
+    drop(state_guard);
+
+    // Build QR payload
+    let payload = QrSlotPayload {
+        r#type: "slot".to_string(),
+        slot_id: slot.id.to_string(),
+        lot_id: slot.lot_id.to_string(),
+    };
+
+    let json = match serde_json::to_string(&payload) {
+        Ok(j) => j,
+        Err(e) => {
+            tracing::error!("Failed to serialize slot QR payload: {}", e);
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ApiResponse::<()>::error("SERVER_ERROR", "QR generation failed")),
+            )
+                .into_response();
+        }
+    };
+
+    // Generate QR code
+    let code = match QrCode::new(json.as_bytes()) {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::error!("Slot QR code generation failed: {}", e);
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ApiResponse::<()>::error("SERVER_ERROR", "QR generation failed")),
+            )
+                .into_response();
+        }
+    };
+
+    // Render to PNG bytes in memory
+    let image = code.render::<Luma<u8>>().min_dimensions(300, 300).build();
+
+    let mut png_bytes: Vec<u8> = Vec::new();
+    let mut cursor = Cursor::new(&mut png_bytes);
+    if let Err(e) = image.write_to(&mut cursor, image::ImageFormat::Png) {
+        tracing::error!("PNG encoding failed for slot QR: {}", e);
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ApiResponse::<()>::error("SERVER_ERROR", "QR generation failed")),
+        )
+            .into_response();
+    }
+
+    Response::builder()
+        .status(StatusCode::OK)
+        .header(header::CONTENT_TYPE, "image/png")
+        .header(header::CACHE_CONTROL, "private, max-age=300")
+        .header(
+            header::CONTENT_DISPOSITION,
+            format!("inline; filename=\"slot-qr-{}.png\"", slot.id),
+        )
+        .body(Body::from(png_bytes))
+        .unwrap_or_else(|_| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Failed to build response",
+            )
+                .into_response()
+        })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
Closes #49
Closes #44
Closes #43

## Summary
- \`GET /api/v1/lots/{lot_id}/slots/{slot_id}/qr\` — QR code PNG per slot (JSON payload: \`{"type":"slot","slot_id":...,"lot_id":...}\`, lot membership validated, same PNG pipeline as booking QR)
- \`GET /manifest.json\` + \`GET /sw.js\` — PWA Web App Manifest (name from branding settings) + Service Worker with offline fallback cache, no auth required
- \`GET/PUT /api/v1/admin/branding\` — branding config (app_name, primary_color), admin-only
- \`POST /api/v1/admin/branding/logo\` — base64 logo upload (max 2MB, PNG/JPEG validated via magic bytes), admin-only
- \`GET /api/v1/branding/logo\` — serve stored logo with \`Cache-Control: public, max-age=3600\`, public

Branding values stored in admin settings DB under \`branding_app_name\`, \`branding_primary_color\`, \`branding_logo_base64\`.

## Test plan
- [ ] cargo build passes
- [ ] cargo test passes
- [ ] \`GET /manifest.json\` returns valid PWA manifest JSON
- [ ] \`GET /sw.js\` returns JavaScript service worker
- [ ] \`GET /api/v1/lots/{lot_id}/slots/{slot_id}/qr\` returns PNG for valid slot, 404 for wrong lot
- [ ] \`GET/PUT /api/v1/admin/branding\` CRUD round-trip
- [ ] \`POST /api/v1/admin/branding/logo\` rejects oversized or non-image uploads
- [ ] \`GET /api/v1/branding/logo\` returns 404 when no logo configured, image bytes when set