### PR TITLE
fix(tech-debt): downgrade unnecessary write locks to read locks + close SMTP config

### DIFF
--- a/parkhub-server/src/api/credits.rs
+++ b/parkhub-server/src/api/credits.rs
@@ -111,7 +111,8 @@ pub async fn admin_grant_credits(
     Path(user_id): Path<String>,
     Json(req): Json<AdminGrantCreditsRequest>,
 ) -> (StatusCode, Json<ApiResponse<()>>) {
-    let state_guard = state.write().await;
+    // Read lock suffices: Database handles its own internal locking.
+    let state_guard = state.read().await;
 
     if let Err((status, msg)) = check_admin(&state_guard, &auth_user).await {
         return (status, Json(ApiResponse::error("FORBIDDEN", msg)));
@@ -382,7 +383,8 @@ pub async fn admin_refill_all_credits(
     State(state): State<SharedState>,
     Extension(auth_user): Extension<AuthUser>,
 ) -> (StatusCode, Json<ApiResponse<serde_json::Value>>) {
-    let state_guard = state.write().await;
+    // Read lock suffices: Database handles its own internal locking.
+    let state_guard = state.read().await;
 
     if let Err((status, msg)) = check_admin(&state_guard, &auth_user).await {
         return (status, Json(ApiResponse::error("FORBIDDEN", msg)));
@@ -474,7 +476,8 @@ pub async fn admin_update_user_quota(
         );
     }
 
-    let state_guard = state.write().await;
+    // Read lock suffices: Database handles its own internal locking.
+    let state_guard = state.read().await;
 
     if let Err((status, msg)) = check_admin(&state_guard, &auth_user).await {
         return (status, Json(ApiResponse::error("FORBIDDEN", msg)));

--- a/parkhub-server/src/api/lots.rs
+++ b/parkhub-server/src/api/lots.rs
@@ -94,7 +94,10 @@ pub async fn create_lot(
         );
     }
 
-    let state_guard = state.write().await;
+    // The outer AppState RwLock is held as a read lock here: individual DB
+    // operations use the Database's internal Arc<RwLock<RedbDatabase>>, so a
+    // write lock on AppState is not needed for atomicity on creation.
+    let state_guard = state.read().await;
 
     // Check if user is admin
     let Ok(Some(user)) = state_guard
@@ -290,7 +293,8 @@ pub async fn update_lot(
         );
     }
 
-    let state_guard = state.write().await;
+    // Read lock suffices: Database handles its own internal locking.
+    let state_guard = state.read().await;
 
     // Check if user is admin
     let Ok(Some(user)) = state_guard
@@ -424,7 +428,8 @@ pub async fn delete_lot(
     Extension(auth_user): Extension<AuthUser>,
     Path(id): Path<String>,
 ) -> (StatusCode, Json<ApiResponse<()>>) {
-    let state_guard = state.write().await;
+    // Read lock suffices: Database handles its own internal locking.
+    let state_guard = state.read().await;
 
     // Check if user is admin
     let Ok(Some(user)) = state_guard
@@ -557,7 +562,8 @@ pub async fn create_slot(
     Path(lot_id): Path<String>,
     Json(req): Json<serde_json::Value>,
 ) -> (StatusCode, Json<ApiResponse<ParkingSlot>>) {
-    let state_guard = state.write().await;
+    // Read lock suffices: Database handles its own internal locking.
+    let state_guard = state.read().await;
 
     // Admin check
     match state_guard
@@ -683,7 +689,8 @@ pub async fn update_slot(
     Path((lot_id, slot_id)): Path<(String, String)>,
     Json(req): Json<serde_json::Value>,
 ) -> (StatusCode, Json<ApiResponse<ParkingSlot>>) {
-    let state_guard = state.write().await;
+    // Read lock suffices: Database handles its own internal locking.
+    let state_guard = state.read().await;
 
     // Admin check
     match state_guard
@@ -790,7 +797,8 @@ pub async fn delete_slot(
     Extension(auth_user): Extension<AuthUser>,
     Path((lot_id, slot_id)): Path<(String, String)>,
 ) -> (StatusCode, Json<ApiResponse<()>>) {
-    let state_guard = state.write().await;
+    // Read lock suffices: Database handles its own internal locking.
+    let state_guard = state.read().await;
 
     // Admin check
     match state_guard

--- a/parkhub-server/src/api/mod.rs
+++ b/parkhub-server/src/api/mod.rs
@@ -2318,7 +2318,8 @@ pub async fn update_vehicle(
     Path(id): Path<String>,
     Json(req): Json<serde_json::Value>,
 ) -> (StatusCode, Json<ApiResponse<Vehicle>>) {
-    let state_guard = state.write().await;
+    // Read lock suffices: Database handles its own internal locking.
+    let state_guard = state.read().await;
 
     let mut vehicle = match state_guard.db.get_vehicle(&id).await {
         Ok(Some(v)) => v,
@@ -4108,7 +4109,8 @@ pub async fn admin_update_features(
     Extension(auth_user): Extension<AuthUser>,
     Json(body): Json<UpdateFeaturesRequest>,
 ) -> (StatusCode, Json<ApiResponse<serde_json::Value>>) {
-    let state_guard = state.write().await;
+    // Read lock suffices: Database handles its own internal locking.
+    let state_guard = state.read().await;
     if let Err((status, msg)) = check_admin(&state_guard, &auth_user).await {
         return (status, Json(ApiResponse::error("FORBIDDEN", msg)));
     }
@@ -6897,7 +6899,8 @@ pub async fn booking_checkin(
     Extension(auth_user): Extension<AuthUser>,
     Path(id): Path<String>,
 ) -> (StatusCode, Json<ApiResponse<Booking>>) {
-    let state_guard = state.write().await;
+    // Read lock suffices: Database handles its own internal locking.
+    let state_guard = state.read().await;
 
     let mut booking = match state_guard.db.get_booking(&id).await {
         Ok(Some(b)) => b,
@@ -6980,7 +6983,8 @@ pub async fn admin_reset(
     Extension(auth_user): Extension<AuthUser>,
     Json(req): Json<AdminResetRequest>,
 ) -> (StatusCode, Json<ApiResponse<()>>) {
-    let state_guard = state.write().await;
+    // Read lock suffices: Database handles its own internal locking.
+    let state_guard = state.read().await;
     if let Err((status, msg)) = check_admin(&state_guard, &auth_user).await {
         return (status, Json(ApiResponse::error("FORBIDDEN", msg)));
     }

--- a/parkhub-server/src/api/setup.rs
+++ b/parkhub-server/src/api/setup.rs
@@ -92,7 +92,8 @@ pub async fn setup_init(
     State(state): State<SharedState>,
     Json(req): Json<SetupRequest>,
 ) -> (StatusCode, Json<ApiResponse<serde_json::Value>>) {
-    let state_guard = state.write().await;
+    // Read lock suffices: Database handles its own internal locking.
+    let state_guard = state.read().await;
 
     // Guard: only allow setup once
     if !state_guard.db.is_fresh().await.unwrap_or(false) {

--- a/parkhub-server/src/api/webhooks.rs
+++ b/parkhub-server/src/api/webhooks.rs
@@ -250,7 +250,8 @@ pub async fn create_webhook(
     Extension(auth_user): Extension<AuthUser>,
     Json(req): Json<CreateWebhookRequest>,
 ) -> (StatusCode, Json<ApiResponse<WebhookResponse>>) {
-    let state_guard = state.write().await;
+    // Read lock suffices: Database handles its own internal locking.
+    let state_guard = state.read().await;
 
     // Admin check
     match state_guard
@@ -351,7 +352,8 @@ pub async fn update_webhook(
     Path(id): Path<String>,
     Json(req): Json<UpdateWebhookRequest>,
 ) -> (StatusCode, Json<ApiResponse<WebhookResponse>>) {
-    let state_guard = state.write().await;
+    // Read lock suffices: Database handles its own internal locking.
+    let state_guard = state.read().await;
 
     // Admin check
     match state_guard
@@ -467,7 +469,8 @@ pub async fn delete_webhook(
     Extension(auth_user): Extension<AuthUser>,
     Path(id): Path<String>,
 ) -> (StatusCode, Json<ApiResponse<()>>) {
-    let state_guard = state.write().await;
+    // Read lock suffices: Database handles its own internal locking.
+    let state_guard = state.read().await;
 
     // Admin check
     match state_guard

--- a/parkhub-server/src/api/zones.rs
+++ b/parkhub-server/src/api/zones.rs
@@ -83,7 +83,8 @@ pub async fn create_zone(
     Path(lot_id): Path<String>,
     Json(req): Json<CreateZoneRequest>,
 ) -> (StatusCode, Json<ApiResponse<Zone>>) {
-    let state_guard = state.write().await;
+    // Read lock suffices: Database handles its own internal locking.
+    let state_guard = state.read().await;
 
     // Admin check
     match state_guard
@@ -175,7 +176,8 @@ pub async fn delete_zone(
     Extension(auth_user): Extension<AuthUser>,
     Path((lot_id, zone_id)): Path<(String, String)>,
 ) -> (StatusCode, Json<ApiResponse<()>>) {
-    let state_guard = state.write().await;
+    // Read lock suffices: Database handles its own internal locking.
+    let state_guard = state.read().await;
 
     // Admin check
     match state_guard

--- a/parkhub-server/src/main.rs
+++ b/parkhub-server/src/main.rs
@@ -60,7 +60,29 @@ use tray_icon::{
     Icon, TrayIconBuilder, TrayIconEvent,
 };
 
-/// Application state shared across handlers
+/// Application state shared across handlers.
+///
+/// # Locking strategy (Tech Debt #64)
+///
+/// `AppState` is wrapped in `Arc<RwLock<AppState>>` (aliased as `SharedState`).
+/// Most fields are logically read-only after startup:
+/// - `config` is never mutated after the server starts.
+/// - `db` wraps its own `Arc<RwLock<RedbDatabase>>` internally, so DB calls do
+///   not require holding the outer lock at all.
+/// - `ws_events` is a `tokio::sync::broadcast::Sender` whose `.clone()` /
+///   `.send()` are already thread-safe.
+/// - `mdns` and `scheduler` are only written once during startup.
+///
+/// Handlers that perform simple CRUD via `db.*` should use `state.read().await`.
+/// Write locks (`state.write().await`) are reserved for multi-step atomic
+/// sequences that must not interleave with concurrent requests, e.g.:
+/// - `create_booking` / `cancel_booking` — slot availability check + status
+///   update must be atomic to prevent double-booking.
+/// - `quick_book` — auto-pick + create must be atomic.
+/// - `update_swap_request` — swap acceptance swaps two bookings atomically.
+///
+/// Future: consider removing the outer `RwLock` entirely and replacing the
+/// booking-level atomicity with DB-layer transactions once redb supports them.
 pub struct AppState {
     pub config: ServerConfig,
     pub db: Database,


### PR DESCRIPTION
Closes #36
Closes #64

## Summary

### #36 — SMTP Admin Config
`admin_get_email_settings` / `admin_update_email_settings` already fully implemented and routed at `GET/PUT /api/v1/admin/email-settings`, managing all 6 SMTP keys. No code changes needed — closing the issue.

### #64 — AppState Arc<RwLock> tech debt
13 handlers held `write()` locks while only calling `db.*` methods. `Database` already has its own `Arc<RwLock<RedbDatabase>>` internally, so the outer write lock was redundant for non-atomic operations.

Converted write → read in:
- `lots.rs`: `create_lot`, `update_lot`, `delete_lot`, `create_slot`, `update_slot`, `delete_slot`
- `zones.rs`: `create_zone`, `delete_zone`
- `credits.rs`: `admin_grant_credits`, `admin_refill_all_credits`, `admin_update_user_quota`
- `webhooks.rs`: `create_webhook`, `update_webhook`, `delete_webhook`
- `setup.rs`: `setup_init`
- `mod.rs`: `update_vehicle`, `admin_update_features`, `booking_checkin`, `admin_reset`

Write locks retained only for the 4 booking atomicity handlers (`create_booking`, `cancel_booking`, `quick_book`, `update_swap_request`).

Added doc comment on `AppState` documenting the locking strategy and future migration path.

## Test plan
- [ ] `cargo build -p parkhub-server` passes
- [ ] `cargo test -p parkhub-server` passes
- [ ] Concurrent booking requests for same slot — only one succeeds
- [ ] `GET/PUT /api/v1/admin/email-settings` — SMTP settings readable/writable