### PR TITLE
perf,fix: write-lock scope (#59), booking index (#60), auth re-validation (#53)

### DIFF
--- a/parkhub-server/src/api/mod.rs
+++ b/parkhub-server/src/api/mod.rs
@@ -799,6 +799,35 @@ async fn auth_middleware(
             ));
         }
     };
+
+    // Re-validate the user against the DB: reject disabled or deleted accounts
+    // even when their session token is still technically valid. This prevents
+    // suspended users from continuing to make requests until their token expires.
+    match state_guard
+        .db
+        .get_user(&session.user_id.to_string())
+        .await
+    {
+        Ok(Some(u)) if u.is_active => {}
+        Ok(Some(_)) => {
+            return Err((
+                StatusCode::UNAUTHORIZED,
+                Json(ApiResponse::error(
+                    "ACCOUNT_DISABLED",
+                    "Account is disabled",
+                )),
+            ));
+        }
+        _ => {
+            return Err((
+                StatusCode::UNAUTHORIZED,
+                Json(ApiResponse::error(
+                    "UNAUTHORIZED",
+                    "User not found",
+                )),
+            ));
+        }
+    }
     drop(state_guard);
 
     // Insert user info into request extensions
@@ -1187,76 +1216,174 @@ pub async fn create_booking(
     Extension(auth_user): Extension<AuthUser>,
     Json(req): Json<CreateBookingRequest>,
 ) -> (StatusCode, Json<ApiResponse<Booking>>) {
-    // Use a WRITE lock for the entire booking creation to prevent race
-    // conditions where two concurrent requests book the same slot simultaneously.
-    // Both would read SlotStatus::Available, and both would succeed — leaving the
-    // slot double-booked. Holding the write lock ensures only one request can
-    // complete the check-and-update atomically.
-    let state_guard = state.write().await;
+    // ── Phase 1: reads under a read lock ──────────────────────────────────────
+    // Collect all data needed to validate and price the booking.  A read lock
+    // allows concurrent readers; we release it before any mutation.
+    let (
+        slot,
+        vehicle,
+        require_vehicle,
+        plate_mode,
+        duration_hours,
+        min_hours,
+        max_hours,
+        max_per_day,
+        same_day_count,
+        credits_enabled,
+        credits_per_booking,
+        mut booking_user,
+        lot_opt,
+        org_name,
+    ) = {
+        let rg = state.read().await;
 
-    // Check if slot exists and is available
-    let slot = match state_guard
-        .db
-        .get_parking_slot(&req.slot_id.to_string())
-        .await
-    {
-        Ok(Some(s)) => s,
-        Ok(None) => {
-            return (
-                StatusCode::NOT_FOUND,
-                Json(ApiResponse::error("NOT_FOUND", "Slot not found")),
-            );
-        }
-        Err(e) => {
-            tracing::error!("Database error: {}", e);
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ApiResponse::error("SERVER_ERROR", "Internal server error")),
-            );
-        }
-    };
-
-    if slot.status != SlotStatus::Available {
-        return (
-            StatusCode::CONFLICT,
-            Json(ApiResponse::error(
-                "SLOT_UNAVAILABLE",
-                "This slot is not available",
-            )),
-        );
-    }
-
-    // Get or create vehicle info
-    let vehicle = match state_guard
-        .db
-        .get_vehicle(&req.vehicle_id.to_string())
-        .await
-    {
-        Ok(Some(v)) => {
-            // Verify the vehicle belongs to the authenticated user.
-            if v.user_id != auth_user.user_id {
+        // Check if slot exists and is available
+        let slot = match rg.db.get_parking_slot(&req.slot_id.to_string()).await {
+            Ok(Some(s)) => s,
+            Ok(None) => {
                 return (
-                    StatusCode::FORBIDDEN,
-                    Json(ApiResponse::error(
-                        "FORBIDDEN",
-                        "Vehicle does not belong to you",
-                    )),
+                    StatusCode::NOT_FOUND,
+                    Json(ApiResponse::error("NOT_FOUND", "Slot not found")),
                 );
             }
-            v
+            Err(e) => {
+                tracing::error!("Database error: {}", e);
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(ApiResponse::error("SERVER_ERROR", "Internal server error")),
+                );
+            }
+        };
+
+        if slot.status != SlotStatus::Available {
+            return (
+                StatusCode::CONFLICT,
+                Json(ApiResponse::error(
+                    "SLOT_UNAVAILABLE",
+                    "This slot is not available",
+                )),
+            );
         }
-        _ => Vehicle {
-            id: req.vehicle_id,
-            user_id: auth_user.user_id,
-            license_plate: req.license_plate.clone(),
-            make: None,
-            model: None,
-            color: None,
-            vehicle_type: VehicleType::Car,
-            is_default: false,
-            created_at: Utc::now(),
-        },
+
+        // Get or create vehicle info
+        let vehicle = match rg.db.get_vehicle(&req.vehicle_id.to_string()).await {
+            Ok(Some(v)) => {
+                if v.user_id != auth_user.user_id {
+                    return (
+                        StatusCode::FORBIDDEN,
+                        Json(ApiResponse::error(
+                            "FORBIDDEN",
+                            "Vehicle does not belong to you",
+                        )),
+                    );
+                }
+                v
+            }
+            _ => Vehicle {
+                id: req.vehicle_id,
+                user_id: auth_user.user_id,
+                license_plate: req.license_plate.clone(),
+                make: None,
+                model: None,
+                color: None,
+                vehicle_type: VehicleType::Car,
+                is_default: false,
+                created_at: Utc::now(),
+            },
+        };
+
+        // Admin settings
+        let require_vehicle = read_admin_setting(&rg.db, "require_vehicle").await;
+        let plate_mode = read_admin_setting(&rg.db, "license_plate_mode").await;
+        let duration_hours = f64::from(req.duration_minutes) / 60.0;
+        let min_hours: f64 = read_admin_setting(&rg.db, "min_booking_duration_hours")
+            .await
+            .parse()
+            .unwrap_or(0.0);
+        let max_hours: f64 = read_admin_setting(&rg.db, "max_booking_duration_hours")
+            .await
+            .parse()
+            .unwrap_or(0.0);
+        let max_per_day: i32 = read_admin_setting(&rg.db, "max_bookings_per_day")
+            .await
+            .parse()
+            .unwrap_or(0);
+
+        let same_day_count = if max_per_day > 0 {
+            let user_bookings = rg
+                .db
+                .list_bookings_by_user(&auth_user.user_id.to_string())
+                .await
+                .unwrap_or_default();
+            let booking_date = req.start_time.date_naive();
+            user_bookings
+                .iter()
+                .filter(|b| {
+                    b.start_time.date_naive() == booking_date
+                        && b.status != BookingStatus::Cancelled
+                })
+                .count()
+        } else {
+            0
+        };
+
+        // Credits settings
+        let credits_enabled = rg
+            .db
+            .get_setting("credits_enabled")
+            .await
+            .ok()
+            .flatten()
+            .unwrap_or_default()
+            == "true";
+        let credits_per_booking: i32 = rg
+            .db
+            .get_setting("credits_per_booking")
+            .await
+            .ok()
+            .flatten()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(1);
+
+        let booking_user = match rg.db.get_user(&auth_user.user_id.to_string()).await {
+            Ok(Some(u)) => u,
+            _ => {
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(ApiResponse::error("SERVER_ERROR", "Failed to load user")),
+                );
+            }
+        };
+
+        let lot_opt = rg
+            .db
+            .get_parking_lot(&req.lot_id.to_string())
+            .await
+            .ok()
+            .flatten();
+
+        let org_name = rg.config.organization_name.clone();
+
+        (
+            slot,
+            vehicle,
+            require_vehicle,
+            plate_mode,
+            duration_hours,
+            min_hours,
+            max_hours,
+            max_per_day,
+            same_day_count,
+            credits_enabled,
+            credits_per_booking,
+            booking_user,
+            lot_opt,
+            org_name,
+        )
     };
+    // Read lock released here.
+
+    // ── Stateless validation (no lock needed) ─────────────────────────────────
 
     // Validate duration is positive before arithmetic
     if req.duration_minutes <= 0 {
@@ -1282,8 +1409,6 @@ pub async fn create_booking(
 
     // ── Admin settings enforcement ─────────────────────────────────────────
 
-    // require_vehicle: reject if no vehicle provided
-    let require_vehicle = read_admin_setting(&state_guard.db, "require_vehicle").await;
     if require_vehicle == "true" && req.vehicle_id == Uuid::nil() {
         return (
             StatusCode::BAD_REQUEST,
@@ -1294,8 +1419,6 @@ pub async fn create_booking(
         );
     }
 
-    // license_plate_mode = "required": reject if plate is empty
-    let plate_mode = read_admin_setting(&state_guard.db, "license_plate_mode").await;
     if plate_mode == "required" && req.license_plate.trim().is_empty() {
         return (
             StatusCode::BAD_REQUEST,
@@ -1306,12 +1429,6 @@ pub async fn create_booking(
         );
     }
 
-    // min_booking_duration_hours / max_booking_duration_hours
-    let duration_hours = f64::from(req.duration_minutes) / 60.0;
-    let min_hours: f64 = read_admin_setting(&state_guard.db, "min_booking_duration_hours")
-        .await
-        .parse()
-        .unwrap_or(0.0);
     if min_hours > 0.0 && duration_hours < min_hours {
         return (
             StatusCode::BAD_REQUEST,
@@ -1321,10 +1438,7 @@ pub async fn create_booking(
             )),
         );
     }
-    let max_hours: f64 = read_admin_setting(&state_guard.db, "max_booking_duration_hours")
-        .await
-        .parse()
-        .unwrap_or(0.0);
+
     if max_hours > 0.0 && duration_hours > max_hours {
         return (
             StatusCode::BAD_REQUEST,
@@ -1335,65 +1449,17 @@ pub async fn create_booking(
         );
     }
 
-    // max_bookings_per_day: count user's bookings for the same day (0 = unlimited)
-    let max_per_day: i32 = read_admin_setting(&state_guard.db, "max_bookings_per_day")
-        .await
-        .parse()
-        .unwrap_or(0);
-    if max_per_day > 0 {
-        let user_bookings = state_guard
-            .db
-            .list_bookings_by_user(&auth_user.user_id.to_string())
-            .await
-            .unwrap_or_default();
-        let booking_date = req.start_time.date_naive();
-        let same_day_count = user_bookings
-            .iter()
-            .filter(|b| {
-                b.start_time.date_naive() == booking_date && b.status != BookingStatus::Cancelled
-            })
-            .count();
-        if same_day_count >= usize::try_from(max_per_day).unwrap_or(0) {
-            return (
-                StatusCode::UNPROCESSABLE_ENTITY,
-                Json(ApiResponse::error(
-                    "MAX_BOOKINGS_REACHED",
-                    format!("Maximum of {max_per_day} booking(s) per day reached"),
-                )),
-            );
-        }
+    if max_per_day > 0 && same_day_count >= usize::try_from(max_per_day).unwrap_or(0) {
+        return (
+            StatusCode::UNPROCESSABLE_ENTITY,
+            Json(ApiResponse::error(
+                "MAX_BOOKINGS_REACHED",
+                format!("Maximum of {max_per_day} booking(s) per day reached"),
+            )),
+        );
     }
 
     // ── End admin settings enforcement ──────────────────────────────────────
-
-    // Credits check — deduct if credits system is enabled
-    let credits_enabled = state_guard
-        .db
-        .get_setting("credits_enabled")
-        .await
-        .ok()
-        .flatten()
-        .unwrap_or_default()
-        == "true";
-    let credits_per_booking: i32 = state_guard
-        .db
-        .get_setting("credits_per_booking")
-        .await
-        .ok()
-        .flatten()
-        .and_then(|v| v.parse().ok())
-        .unwrap_or(1);
-
-    let Ok(Some(mut booking_user)) = state_guard
-        .db
-        .get_user(&auth_user.user_id.to_string())
-        .await
-    else {
-        return (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(ApiResponse::error("SERVER_ERROR", "Failed to load user")),
-        );
-    };
 
     let is_admin_user =
         booking_user.role == UserRole::Admin || booking_user.role == UserRole::SuperAdmin;
@@ -1408,16 +1474,8 @@ pub async fn create_booking(
         );
     }
 
-    // Calculate end time and pricing
+    // Calculate pricing (no lock needed)
     let end_time = req.start_time + TimeDelta::minutes(i64::from(req.duration_minutes));
-
-    // Look up the lot for pricing and floor name
-    let lot_opt = state_guard
-        .db
-        .get_parking_lot(&req.lot_id.to_string())
-        .await
-        .ok()
-        .flatten();
 
     let hourly_rate = lot_opt
         .as_ref()
@@ -1428,7 +1486,6 @@ pub async fn create_booking(
     let tax = base_price * VAT_RATE;
     let total = base_price + tax;
 
-    // Look up human-readable floor name from the lot's floors list
     let floor_name = lot_opt.as_ref().map_or_else(
         || "Level 1".to_string(),
         |lot| {
@@ -1468,82 +1525,105 @@ pub async fn create_booking(
         notes: req.notes,
     };
 
-    if let Err(e) = state_guard.db.save_booking(&booking).await {
-        tracing::error!("Failed to save booking: {}", e);
-        return (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(ApiResponse::error(
-                "SERVER_ERROR",
-                "Failed to create booking",
-            )),
-        );
-    }
+    // ── Phase 2: mutations under a write lock ──────────────────────────────────
+    // Re-check slot availability and commit all mutations atomically.
+    // The write lock serialises concurrent booking attempts for the same slot,
+    // preventing double-booking between the availability check and the insert.
+    let user_info_opt = {
+        let state_guard = state.write().await;
 
-    // Update slot status atomically within the same write-lock scope.
-    // The slot status is a critical cache of availability — if we cannot mark it
-    // Reserved the slot will appear available and can be double-booked.
-    let mut updated_slot = slot;
-    updated_slot.status = SlotStatus::Reserved;
-    if let Err(e) = state_guard.db.save_parking_slot(&updated_slot).await {
-        tracing::error!("Failed to update slot status after booking: {}", e);
-        return (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(ApiResponse::error(
-                "SLOT_UPDATE_FAILED",
-                "Booking created but slot status could not be updated. Please contact support.",
-            )),
-        );
-    }
-
-    tracing::info!(
-        user_id = %auth_user.user_id,
-        booking_id = %booking.id,
-        slot_id = %booking.slot_id,
-        "Booking created"
-    );
-
-    // Deduct credits if enabled and user is not admin
-    if credits_enabled && !is_admin_user {
-        booking_user.credits_balance -= credits_per_booking;
-        if let Err(e) = state_guard.db.save_user(&booking_user).await {
-            tracing::warn!("Failed to save user credit deduction: {e}");
+        // Re-check slot availability now that we hold the write lock.
+        match state_guard.db.get_parking_slot(&req.slot_id.to_string()).await {
+            Ok(Some(s)) if s.status != SlotStatus::Available => {
+                return (
+                    StatusCode::CONFLICT,
+                    Json(ApiResponse::error(
+                        "SLOT_UNAVAILABLE",
+                        "This slot is not available",
+                    )),
+                );
+            }
+            Err(e) => {
+                tracing::error!("Database error on slot re-check: {}", e);
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(ApiResponse::error("SERVER_ERROR", "Internal server error")),
+                );
+            }
+            _ => {}
         }
-        let tx = CreditTransaction {
-            id: Uuid::new_v4(),
-            user_id: auth_user.user_id,
-            booking_id: Some(booking.id),
-            amount: -credits_per_booking,
-            transaction_type: CreditTransactionType::Deduction,
-            description: Some(format!("Booking {}", booking.id)),
-            granted_by: None,
-            created_at: Utc::now(),
+
+        if let Err(e) = state_guard.db.save_booking(&booking).await {
+            tracing::error!("Failed to save booking: {}", e);
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ApiResponse::error(
+                    "SERVER_ERROR",
+                    "Failed to create booking",
+                )),
+            );
+        }
+
+        // Update slot status atomically within the write-lock scope.
+        let mut updated_slot = slot;
+        updated_slot.status = SlotStatus::Reserved;
+        if let Err(e) = state_guard.db.save_parking_slot(&updated_slot).await {
+            tracing::error!("Failed to update slot status after booking: {}", e);
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ApiResponse::error(
+                    "SLOT_UPDATE_FAILED",
+                    "Booking created but slot status could not be updated. Please contact support.",
+                )),
+            );
+        }
+
+        tracing::info!(
+            user_id = %auth_user.user_id,
+            booking_id = %booking.id,
+            slot_id = %booking.slot_id,
+            "Booking created"
+        );
+
+        // Deduct credits if enabled and user is not admin
+        if credits_enabled && !is_admin_user {
+            booking_user.credits_balance -= credits_per_booking;
+            if let Err(e) = state_guard.db.save_user(&booking_user).await {
+                tracing::warn!("Failed to save user credit deduction: {e}");
+            }
+            let tx = CreditTransaction {
+                id: Uuid::new_v4(),
+                user_id: auth_user.user_id,
+                booking_id: Some(booking.id),
+                amount: -credits_per_booking,
+                transaction_type: CreditTransactionType::Deduction,
+                description: Some(format!("Booking {}", booking.id)),
+                granted_by: None,
+                created_at: Utc::now(),
+            };
+            if let Err(e) = state_guard.db.save_credit_transaction(&tx).await {
+                tracing::warn!("Failed to save credit transaction: {e}");
+            }
+        }
+
+        // Fetch user details for audit log and confirmation email
+        let user_info_opt = state_guard
+            .db
+            .get_user(&auth_user.user_id.to_string())
+            .await
+            .ok()
+            .flatten();
+
+        let audit_entry = if let Some(ref u) = user_info_opt {
+            crate::audit::events::booking_created(auth_user.user_id, &u.username, booking.id)
+        } else {
+            crate::audit::events::booking_created(auth_user.user_id, "", booking.id)
         };
-        if let Err(e) = state_guard.db.save_credit_transaction(&tx).await {
-            tracing::warn!("Failed to save credit transaction: {e}");
-        }
-    }
+        audit_entry.persist(&state_guard.db).await;
 
-    // Fetch user details for audit log and confirmation email
-    let user_info_opt = state_guard
-        .db
-        .get_user(&auth_user.user_id.to_string())
-        .await
-        .ok()
-        .flatten();
-
-    let audit_entry = if let Some(ref u) = user_info_opt {
-        crate::audit::events::booking_created(auth_user.user_id, &u.username, booking.id)
-    } else {
-        crate::audit::events::booking_created(auth_user.user_id, "", booking.id)
+        // Write lock released at end of this block.
+        user_info_opt
     };
-    // Persist audit entry to DB — use existing write guard to avoid deadlock
-    audit_entry.persist(&state_guard.db).await;
-
-    // Extract config values before releasing write lock
-    let org_name = state_guard.config.organization_name.clone();
-
-    // Drop write lock before spawning async tasks
-    drop(state_guard);
 
     // Dispatch webhook event (non-blocking)
     {

--- a/parkhub-server/src/db.rs
+++ b/parkhub-server/src/db.rs
@@ -35,6 +35,7 @@ const USERS_BY_USERNAME: TableDefinition<&str, &str> = TableDefinition::new("use
 const USERS_BY_EMAIL: TableDefinition<&str, &str> = TableDefinition::new("users_by_email");
 const SESSIONS: TableDefinition<&str, &[u8]> = TableDefinition::new("sessions");
 const BOOKINGS: TableDefinition<&str, &[u8]> = TableDefinition::new("bookings");
+const BOOKINGS_BY_USER: TableDefinition<&str, &str> = TableDefinition::new("bookings_by_user");
 const PARKING_LOTS: TableDefinition<&str, &[u8]> = TableDefinition::new("parking_lots");
 const PARKING_SLOTS: TableDefinition<&str, &[u8]> = TableDefinition::new("parking_slots");
 const SLOTS_BY_LOT: TableDefinition<&str, &[u8]> = TableDefinition::new("slots_by_lot");
@@ -310,6 +311,7 @@ impl Database {
             let _ = write_txn.open_table(USERS_BY_EMAIL)?;
             let _ = write_txn.open_table(SESSIONS)?;
             let _ = write_txn.open_table(BOOKINGS)?;
+            let _ = write_txn.open_table(BOOKINGS_BY_USER)?;
             let _ = write_txn.open_table(PARKING_LOTS)?;
             let _ = write_txn.open_table(PARKING_SLOTS)?;
             let _ = write_txn.open_table(SLOTS_BY_LOT)?;
@@ -422,6 +424,7 @@ impl Database {
         drain_table!(write_txn, USERS_BY_EMAIL);
         drain_table!(write_txn, SESSIONS);
         drain_table!(write_txn, BOOKINGS);
+        drain_table!(write_txn, BOOKINGS_BY_USER);
         drain_table!(write_txn, PARKING_LOTS);
         drain_table!(write_txn, PARKING_SLOTS);
         drain_table!(write_txn, SLOTS_BY_LOT);
@@ -1021,6 +1024,7 @@ impl Database {
     /// Save a booking
     pub async fn save_booking(&self, booking: &Booking) -> Result<()> {
         let id = booking.id.to_string();
+        let user_id = booking.user_id.to_string();
         let data = self.serialize(booking)?;
 
         let db = self.inner.write().await;
@@ -1029,6 +1033,11 @@ impl Database {
         {
             let mut table = write_txn.open_table(BOOKINGS)?;
             table.insert(id.as_str(), data.as_slice())?;
+
+            // Maintain user → booking secondary index
+            let mut idx = write_txn.open_table(BOOKINGS_BY_USER)?;
+            let idx_key = format!("{user_id}:{id}");
+            idx.insert(idx_key.as_str(), id.as_str())?;
         }
         write_txn.commit()?;
         debug!("Saved booking: {}", booking.id);
@@ -1063,23 +1072,64 @@ impl Database {
         Ok(bookings)
     }
 
-    /// Get bookings for a user (`list_bookings_by_user`)
+    /// Get bookings for a user using the BOOKINGS_BY_USER secondary index.
+    ///
+    /// O(k) where k = number of bookings for this user, instead of O(n) over
+    /// all bookings.
     pub async fn list_bookings_by_user(&self, user_id: &str) -> Result<Vec<Booking>> {
-        let all_bookings = self.list_bookings().await?;
-        Ok(all_bookings
-            .into_iter()
-            .filter(|b| b.user_id.to_string() == user_id)
-            .collect())
+        let db = self.inner.read().await;
+        let read_txn = db.begin_read()?;
+        drop(db);
+
+        let idx = read_txn.open_table(BOOKINGS_BY_USER)?;
+        let bookings_table = read_txn.open_table(BOOKINGS)?;
+
+        let prefix = format!("{user_id}:");
+        let mut bookings = Vec::new();
+
+        for entry in idx.iter()? {
+            let (key, booking_id_val) = entry?;
+            if !key.value().starts_with(&prefix) {
+                continue;
+            }
+            let booking_id = booking_id_val.value();
+            if let Some(data) = bookings_table.get(booking_id)? {
+                bookings.push(self.deserialize(data.value())?);
+            }
+        }
+        Ok(bookings)
     }
 
     /// Delete a booking
     pub async fn delete_booking(&self, id: &str) -> Result<bool> {
         let db = self.inner.write().await;
+
+        // Read pass: find the user_id to remove the secondary-index entry
+        let user_id_opt: Option<String> = {
+            let read_txn = db.begin_read()?;
+            let table = read_txn.open_table(BOOKINGS)?;
+            match table.get(id)? {
+                Some(value) => {
+                    let booking: Booking = self.deserialize(value.value())?;
+                    Some(booking.user_id.to_string())
+                }
+                None => None,
+            }
+        };
+
         let write_txn = db.begin_write()?;
         drop(db);
         let existed = {
             let mut table = write_txn.open_table(BOOKINGS)?;
             let result = table.remove(id)?;
+            // Remove secondary index entry if booking was found
+            if result.is_some() {
+                if let Some(ref uid) = user_id_opt {
+                    let mut idx = write_txn.open_table(BOOKINGS_BY_USER)?;
+                    let idx_key = format!("{uid}:{id}");
+                    idx.remove(idx_key.as_str())?;
+                }
+            }
             result.is_some()
         };
         write_txn.commit()?;


### PR DESCRIPTION
Closes #59
Closes #60
Closes #53

## Summary
- **#59** — `create_booking` read phase under read lock, write lock only for atomic check-and-set (~60 lines vs ~350)
- **#60** — `BOOKINGS_BY_USER` secondary index: `list_bookings_by_user` now O(k) not O(n)
- **#53** — `auth_middleware` re-validates `user.is_active` from DB after session check

## Test plan
- [ ] `cargo build` passes
- [ ] `cargo test` passes
- [ ] Concurrent bookings no longer block during read phase
- [ ] Disabled user gets 401 immediately