### PR TITLE
fix(reliability): exponential-backoff retry for email & webhook delivery

### DIFF
--- a/parkhub-server/src/api/mod.rs
+++ b/parkhub-server/src/api/mod.rs
@@ -1545,7 +1545,7 @@ pub async fn create_booking(
     // Drop write lock before spawning async tasks
     drop(state_guard);
 
-    // Dispatch webhook event (non-blocking)
+    // Dispatch webhook event (non-blocking, with retry + failure tracking)
     {
         let state_clone = state.clone();
         let booking_json = serde_json::json!({
@@ -1557,12 +1557,17 @@ pub async fn create_booking(
             "end_time": booking.end_time,
         });
         tokio::spawn(async move {
-            webhooks::dispatch_webhook_event(&state_clone, "booking.created", booking_json).await;
+            webhooks::dispatch_webhook_event_with_retry(
+                &state_clone,
+                "booking.created",
+                booking_json,
+            )
+            .await;
         });
     }
     metrics::record_booking_event("created");
 
-    // Send booking confirmation email (non-blocking, fire-and-forget).
+    // Send booking confirmation email (non-blocking, with exponential-backoff retry).
     if let Some(u) = user_info_opt {
         let booking_id_str = booking.id.to_string();
         let floor_name = booking.floor_name.clone();
@@ -1581,10 +1586,14 @@ pub async fn create_booking(
                 &end_time_str,
                 &org_name,
             );
-            if let Err(e) =
-                email::send_email(&user_email, "Booking Confirmation — ParkHub", &email_html).await
+            if let Err(e) = email::send_email_with_retry(
+                &user_email,
+                "Booking Confirmation — ParkHub",
+                &email_html,
+            )
+            .await
             {
-                tracing::warn!("Failed to send booking confirmation email: {}", e);
+                tracing::error!("Failed to send booking confirmation email after retries: {e}");
             }
         });
     }
@@ -1781,7 +1790,7 @@ pub async fn cancel_booking(
         "Booking cancelled"
     );
 
-    // Send cancellation confirmation email (async, best-effort)
+    // Send cancellation confirmation email (async, with exponential-backoff retry)
     if let Some(ref user) = user {
         let user_email = user.email.clone();
         let user_name = user.name.clone();
@@ -1801,15 +1810,19 @@ pub async fn cancel_booking(
                 &end_time,
                 &org_name,
             );
-            if let Err(e) =
-                email::send_email(&user_email, "Booking Cancelled — ParkHub", &email_html).await
+            if let Err(e) = email::send_email_with_retry(
+                &user_email,
+                "Booking Cancelled — ParkHub",
+                &email_html,
+            )
+            .await
             {
-                tracing::warn!("Failed to send cancellation email: {}", e);
+                tracing::error!("Failed to send cancellation email after retries: {e}");
             }
         });
     }
 
-    // Dispatch webhook event
+    // Dispatch webhook event (with retry + failure tracking)
     {
         let state_clone = state.clone();
         let payload = serde_json::json!({
@@ -1818,7 +1831,12 @@ pub async fn cancel_booking(
             "action": "cancelled",
         });
         tokio::spawn(async move {
-            webhooks::dispatch_webhook_event(&state_clone, "booking.cancelled", payload).await;
+            webhooks::dispatch_webhook_event_with_retry(
+                &state_clone,
+                "booking.cancelled",
+                payload,
+            )
+            .await;
         });
     }
     metrics::record_booking_event("cancelled");

--- a/parkhub-server/src/api/webhooks.rs
+++ b/parkhub-server/src/api/webhooks.rs
@@ -706,6 +706,134 @@ pub async fn dispatch_webhook_event(
     }
 }
 
+/// Dispatch a webhook event with per-webhook exponential-backoff retry.
+///
+/// Each matching webhook is attempted up to 3 times (100 ms / 200 ms / 400 ms
+/// between retries).  On permanent failure the cumulative failure count is
+/// persisted to the settings store under key `webhook_failure_<id>` so
+/// operators can observe it via the admin API.
+///
+/// The spawned tasks are non-blocking with respect to the HTTP handler.
+pub async fn dispatch_webhook_event_with_retry(
+    state: &SharedState,
+    event_type: &str,
+    payload: serde_json::Value,
+) {
+    const MAX_ATTEMPTS: u32 = 3;
+
+    let webhooks = {
+        let state_guard = state.read().await;
+        match state_guard.db.list_webhooks().await {
+            Ok(w) => w,
+            Err(e) => {
+                tracing::error!("Failed to list webhooks for dispatch: {}", e);
+                return;
+            }
+        }
+    };
+
+    let matching: Vec<Webhook> = webhooks
+        .into_iter()
+        .filter(|w| w.active && w.events.iter().any(|e| e == event_type || e == "*"))
+        .collect();
+
+    if matching.is_empty() {
+        return;
+    }
+
+    let event_type = event_type.to_string();
+    let body = serde_json::to_string(&serde_json::json!({
+        "event": event_type,
+        "timestamp": Utc::now().to_rfc3339(),
+        "data": payload,
+    }))
+    .unwrap_or_default();
+
+    for webhook in matching {
+        let body = body.clone();
+        let url = webhook.url.clone();
+        let secret = webhook.secret.clone();
+        let event = event_type.clone();
+        let state_for_task = state.clone();
+
+        tokio::spawn(async move {
+            let signature = compute_signature(&secret, &body);
+            let client = reqwest::Client::builder()
+                .timeout(std::time::Duration::from_secs(10))
+                .build()
+                .unwrap_or_default();
+
+            let mut delivered = false;
+            for attempt in 1..=MAX_ATTEMPTS {
+                let result = client
+                    .post(&url)
+                    .header("Content-Type", "application/json")
+                    .header("X-Webhook-Signature", &signature)
+                    .body(body.clone())
+                    .send()
+                    .await;
+
+                match result {
+                    Ok(resp) => {
+                        tracing::info!(
+                            "Webhook {} delivered '{}' to {} — HTTP {} (attempt {attempt})",
+                            webhook.id,
+                            event,
+                            url,
+                            resp.status()
+                        );
+                        delivered = true;
+                        break;
+                    }
+                    Err(e) => {
+                        if attempt < MAX_ATTEMPTS {
+                            let backoff_ms = 100u64 * (1u64 << (attempt - 1));
+                            tracing::warn!(
+                                "Webhook {} failed attempt {attempt}/{MAX_ATTEMPTS} for '{}' to \
+                                 {}: {e}. Retrying in {backoff_ms}ms",
+                                webhook.id,
+                                event,
+                                url
+                            );
+                            tokio::time::sleep(std::time::Duration::from_millis(backoff_ms))
+                                .await;
+                        } else {
+                            tracing::error!(
+                                "Webhook {} permanently failed '{}' to {} after {MAX_ATTEMPTS} \
+                                 attempts: {e}",
+                                webhook.id,
+                                event,
+                                url
+                            );
+                        }
+                    }
+                }
+            }
+
+            // Persist failure count so operators can observe via admin API.
+            if !delivered {
+                let key = format!("webhook_failure_{}", webhook.id);
+                let prev: u64 = {
+                    let g = state_for_task.read().await;
+                    g.db.get_setting(&key)
+                        .await
+                        .ok()
+                        .flatten()
+                        .and_then(|v| v.parse().ok())
+                        .unwrap_or(0)
+                };
+                let g = state_for_task.write().await;
+                if let Err(e) = g.db.set_setting(&key, &(prev + 1).to_string()).await {
+                    tracing::warn!(
+                        "Failed to persist webhook failure count for {}: {e}",
+                        webhook.id
+                    );
+                }
+            }
+        });
+    }
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Tests
 // ─────────────────────────────────────────────────────────────────────────────

--- a/parkhub-server/src/email.rs
+++ b/parkhub-server/src/email.rs
@@ -88,6 +88,41 @@ pub async fn send_email(to: &str, subject: &str, html_body: &str) -> Result<()> 
     Ok(())
 }
 
+/// Send an HTML email with exponential-backoff retry.
+///
+/// Attempts up to 3 times, sleeping 100 ms, 200 ms, 400 ms between attempts.
+/// Returns `Ok(())` as soon as one attempt succeeds.
+/// If all attempts fail, the last error is returned.
+pub async fn send_email_with_retry(to: &str, subject: &str, html_body: &str) -> Result<()> {
+    const MAX_ATTEMPTS: u32 = 3;
+    let mut last_err = anyhow::anyhow!("send_email_with_retry: no attempts made");
+    for attempt in 1..=MAX_ATTEMPTS {
+        match send_email(to, subject, html_body).await {
+            Ok(()) => return Ok(()),
+            Err(e) => {
+                last_err = e;
+                if attempt < MAX_ATTEMPTS {
+                    let backoff_ms = 100u64 * (1u64 << (attempt - 1)); // 100 ms, 200 ms, 400 ms
+                    warn!(
+                        to = %to,
+                        subject = %subject,
+                        attempt,
+                        backoff_ms,
+                        "Email send failed, retrying after backoff"
+                    );
+                    tokio::time::sleep(std::time::Duration::from_millis(backoff_ms)).await;
+                }
+            }
+        }
+    }
+    tracing::error!(
+        to = %to,
+        subject = %subject,
+        "Email send failed after {MAX_ATTEMPTS} attempts: {last_err}"
+    );
+    Err(last_err)
+}
+
 /// Build a booking confirmation email body.
 #[allow(clippy::too_many_arguments)]
 pub fn build_booking_confirmation_email(


### PR DESCRIPTION
## Summary

- Adds `send_email_with_retry` to `email.rs`: 3 attempts with 100 ms / 200 ms / 400 ms exponential backoff; logs error after all attempts exhausted
- Adds `dispatch_webhook_event_with_retry` to `webhooks.rs`: 3 attempts per webhook endpoint with same backoff; on permanent failure persists cumulative failure count to settings store as `webhook_failure_<id>` for operator visibility
- Replaces the 4 fire-and-forget `tokio::spawn` blocks in `api/mod.rs` (`create_booking` and `cancel_booking`) with the new retry helpers

Closes #69

## Test plan

- [ ] Verify booking confirmation email is retried on transient SMTP failure
- [ ] Verify booking cancellation email is retried on transient SMTP failure
- [ ] Verify webhook delivery is retried (check logs for `attempt 1/3` messages)
- [ ] Verify `webhook_failure_<id>` is incremented in settings store on persistent webhook failure
- [ ] CI `cargo check` and `cargo clippy` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)