### PR TITLE
feat(absences, jobs, webhooks): iCal import, background jobs, webhook retry

### DIFF
--- a/parkhub-server/src/api/mod.rs
+++ b/parkhub-server/src/api/mod.rs
@@ -334,6 +334,10 @@ pub fn create_router(state: SharedState) -> (Router, demo::SharedDemoState) {
             "/api/v1/absences/pattern",
             get(get_absence_pattern).post(save_absence_pattern),
         )
+        .route(
+            "/api/v1/absences/import",
+            post(import_absences_from_ical),
+        )
         .route("/api/v1/absences/{id}", delete(delete_absence))
         // Team view
         .route("/api/v1/team/today", get(team_today))
@@ -4437,6 +4441,169 @@ pub async fn save_absence_pattern(
             )
         }
     }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// ICAL IMPORT
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/// Request body for the iCal import endpoint.
+///
+/// Clients send the raw `.ics` text in the `ics_data` field.
+#[derive(Deserialize, utoipa::ToSchema)]
+pub struct ICalImportRequest {
+    /// Raw iCalendar text content (RFC 5545).
+    pub ics_data: String,
+}
+
+/// Parse a single VEVENT property value, stripping any parameter portion.
+///
+/// Examples:
+/// * `DTSTART;TZID=Europe/Berlin:20261015T120000` → `"20261015T120000"`
+/// * `DTSTART:20261015`                           → `"20261015"`
+fn ical_property_value(line: &str) -> &str {
+    if let Some(pos) = line.find(':') {
+        line[pos + 1..].trim()
+    } else {
+        line.trim()
+    }
+}
+
+/// Convert an iCal date / datetime string to a `YYYY-MM-DD` string.
+///
+/// Accepted formats:
+/// * `YYYYMMDD`           — date-only
+/// * `YYYYMMDDTHHMMSSZ`  — UTC datetime (timezone discarded, date kept)
+/// * `YYYYMMDDTHHMMSS`   — local datetime (timezone discarded, date kept)
+fn ical_date_to_ymd(raw: &str) -> Option<String> {
+    let date_part = raw.split('T').next().unwrap_or("").trim();
+    if date_part.len() < 8 {
+        return None;
+    }
+    let y = &date_part[0..4];
+    let m = &date_part[4..6];
+    let d = &date_part[6..8];
+    if y.chars().all(|c| c.is_ascii_digit())
+        && m.chars().all(|c| c.is_ascii_digit())
+        && d.chars().all(|c| c.is_ascii_digit())
+    {
+        Some(format!("{y}-{m}-{d}"))
+    } else {
+        None
+    }
+}
+
+/// Map a VEVENT SUMMARY string to an [`AbsenceType`].
+///
+/// * contains `"vacation"` or `"urlaub"` (case-insensitive) → [`AbsenceType::Vacation`]
+/// * otherwise → [`AbsenceType::Other`]
+fn absence_type_from_summary(summary: &str) -> AbsenceType {
+    let lower = summary.to_lowercase();
+    if lower.contains("vacation") || lower.contains("urlaub") {
+        AbsenceType::Vacation
+    } else {
+        AbsenceType::Other
+    }
+}
+
+/// `POST /api/v1/absences/import` — import absences from an iCalendar file
+#[utoipa::path(
+    post,
+    path = "/api/v1/absences/import",
+    tag = "Absences",
+    summary = "Import absences from iCal",
+    description = "Parses a `.ics` file and creates absence records for the authenticated user.",
+    security(("bearer_auth" = [])),
+    responses(
+        (status = 201, description = "Absences created"),
+        (status = 400, description = "Invalid or empty iCal data"),
+    )
+)]
+pub async fn import_absences_from_ical(
+    State(state): State<SharedState>,
+    Extension(auth_user): Extension<AuthUser>,
+    Json(req): Json<ICalImportRequest>,
+) -> (StatusCode, Json<ApiResponse<Vec<Absence>>>) {
+    let mut parsed: Vec<Absence> = Vec::new();
+
+    // ── Parse VEVENT blocks ──────────────────────────────────────────────────
+    let mut in_vevent = false;
+    let mut dtstart: Option<String> = None;
+    let mut dtend: Option<String> = None;
+    let mut summary: Option<String> = None;
+
+    for raw_line in req.ics_data.lines() {
+        let line = raw_line.trim();
+        match line {
+            "BEGIN:VEVENT" => {
+                in_vevent = true;
+                dtstart = None;
+                dtend = None;
+                summary = None;
+            }
+            "END:VEVENT" if in_vevent => {
+                in_vevent = false;
+                if let (Some(start), Some(end)) = (dtstart.take(), dtend.take()) {
+                    let absence_type =
+                        absence_type_from_summary(summary.as_deref().unwrap_or(""));
+                    let note = summary.take();
+                    parsed.push(Absence {
+                        id: Uuid::new_v4(),
+                        user_id: auth_user.user_id,
+                        absence_type,
+                        start_date: start,
+                        end_date: end,
+                        note,
+                        source: "ical".to_string(),
+                        created_at: Utc::now(),
+                    });
+                } else {
+                    summary = None;
+                }
+            }
+            _ if in_vevent => {
+                // Compare property name case-insensitively; value is kept as-is.
+                let prop_upper = line.to_uppercase();
+                if prop_upper.starts_with("DTSTART") {
+                    if let Some(ymd) = ical_date_to_ymd(ical_property_value(line)) {
+                        dtstart = Some(ymd);
+                    }
+                } else if prop_upper.starts_with("DTEND") {
+                    if let Some(ymd) = ical_date_to_ymd(ical_property_value(line)) {
+                        dtend = Some(ymd);
+                    }
+                } else if prop_upper.starts_with("SUMMARY") {
+                    summary = Some(ical_property_value(line).to_string());
+                }
+            }
+            _ => {}
+        }
+    }
+
+    if parsed.is_empty() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(ApiResponse::error(
+                "NO_EVENTS",
+                "No valid VEVENT blocks found in the provided iCal data",
+            )),
+        );
+    }
+
+    // ── Persist absences ─────────────────────────────────────────────────────
+    let state_guard = state.read().await;
+    let mut saved: Vec<Absence> = Vec::with_capacity(parsed.len());
+    for absence in parsed {
+        match state_guard.db.save_absence(&absence).await {
+            Ok(()) => saved.push(absence),
+            Err(e) => {
+                tracing::error!("Failed to save iCal absence: {}", e);
+                // Continue — a partial import is better than total failure.
+            }
+        }
+    }
+
+    (StatusCode::CREATED, Json(ApiResponse::success(saved)))
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════

--- a/parkhub-server/src/api/webhooks.rs
+++ b/parkhub-server/src/api/webhooks.rs
@@ -706,6 +706,143 @@ pub async fn dispatch_webhook_event(
     }
 }
 
+/// Dispatch a webhook event with per-webhook exponential-backoff retry.
+///
+/// Each matching webhook is attempted up to `MAX_ATTEMPTS` times (3).  On
+/// permanent failure the failure count is persisted to the settings store
+/// under key `webhook_failure_<id>` so operators can observe it via the
+/// admin API.  The spawned tasks are non-blocking with respect to the
+/// HTTP handler.
+///
+/// Call from any async handler that has access to `SharedState`.
+pub async fn dispatch_webhook_event_with_retry(
+    state: &SharedState,
+    event_type: &str,
+    payload: serde_json::Value,
+) {
+    const MAX_ATTEMPTS: u32 = 3;
+
+    let (webhooks, state_clone) = {
+        let state_guard = state.read().await;
+        let webhooks = match state_guard.db.list_webhooks().await {
+            Ok(w) => w,
+            Err(e) => {
+                tracing::error!("Failed to list webhooks for dispatch: {}", e);
+                return;
+            }
+        };
+        drop(state_guard);
+        (webhooks, state.clone())
+    };
+
+    let matching: Vec<Webhook> = webhooks
+        .into_iter()
+        .filter(|w| w.active && w.events.iter().any(|e| e == event_type || e == "*"))
+        .collect();
+
+    if matching.is_empty() {
+        return;
+    }
+
+    let event_type = event_type.to_string();
+    let body = serde_json::to_string(&serde_json::json!({
+        "event": event_type,
+        "timestamp": Utc::now().to_rfc3339(),
+        "data": payload,
+    }))
+    .unwrap_or_default();
+
+    for webhook in matching {
+        let body = body.clone();
+        let url = webhook.url.clone();
+        let secret = webhook.secret.clone();
+        let event = event_type.clone();
+        let state_for_task = state_clone.clone();
+
+        tokio::spawn(async move {
+            let signature = compute_signature(&secret, &body);
+            let client = reqwest::Client::builder()
+                .timeout(std::time::Duration::from_secs(10))
+                .build()
+                .unwrap_or_default();
+
+            let mut delivered = false;
+            for attempt in 1..=MAX_ATTEMPTS {
+                let result = client
+                    .post(&url)
+                    .header("Content-Type", "application/json")
+                    .header("X-Webhook-Signature", &signature)
+                    .body(body.clone())
+                    .send()
+                    .await;
+
+                match result {
+                    Ok(resp) => {
+                        tracing::info!(
+                            "Webhook {} delivered event '{}' to {} — HTTP {} (attempt {attempt})",
+                            webhook.id,
+                            event,
+                            url,
+                            resp.status()
+                        );
+                        delivered = true;
+                        break;
+                    }
+                    Err(e) => {
+                        if attempt < MAX_ATTEMPTS {
+                            let backoff_ms = 100u64 * (1u64 << (attempt - 1));
+                            tracing::warn!(
+                                "Webhook {} failed attempt {attempt}/{MAX_ATTEMPTS} for '{}' to {}: {e}. \
+                                 Retrying in {backoff_ms}ms",
+                                webhook.id,
+                                event,
+                                url
+                            );
+                            tokio::time::sleep(std::time::Duration::from_millis(backoff_ms))
+                                .await;
+                        } else {
+                            tracing::error!(
+                                "Webhook {} permanently failed to deliver '{}' to {} after \
+                                 {MAX_ATTEMPTS} attempts: {e}",
+                                webhook.id,
+                                event,
+                                url
+                            );
+                        }
+                    }
+                }
+            }
+
+            // Persist failure count to settings store so operators can observe it.
+            if !delivered {
+                let key = format!("webhook_failure_{}", webhook.id);
+                let state_guard = state_for_task.read().await;
+                let prev: u64 = state_guard
+                    .db
+                    .get_setting(&key)
+                    .await
+                    .ok()
+                    .flatten()
+                    .and_then(|v| v.parse().ok())
+                    .unwrap_or(0);
+                let new_count = prev + 1;
+                drop(state_guard);
+                let state_guard = state_for_task.write().await;
+                if let Err(e) = state_guard
+                    .db
+                    .set_setting(&key, &new_count.to_string())
+                    .await
+                {
+                    tracing::warn!(
+                        "Failed to persist webhook failure count for {}: {e}",
+                        webhook.id
+                    );
+                }
+            }
+        });
+    }
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Tests
 // ─────────────────────────────────────────────────────────────────────────────

--- a/parkhub-server/src/email.rs
+++ b/parkhub-server/src/email.rs
@@ -88,6 +88,41 @@ pub async fn send_email(to: &str, subject: &str, html_body: &str) -> Result<()> 
     Ok(())
 }
 
+/// Send an HTML email with exponential-backoff retry.
+///
+/// Attempts up to `max_attempts` times (default 3), sleeping 100 ms, 200 ms,
+/// 400 ms between attempts.  Returns `Ok(())` as soon as one attempt succeeds.
+/// If all attempts fail, the last error is returned.
+pub async fn send_email_with_retry(to: &str, subject: &str, html_body: &str) -> Result<()> {
+    const MAX_ATTEMPTS: u32 = 3;
+    let mut last_err = anyhow::anyhow!("send_email_with_retry: no attempts made");
+    for attempt in 1..=MAX_ATTEMPTS {
+        match send_email(to, subject, html_body).await {
+            Ok(()) => return Ok(()),
+            Err(e) => {
+                last_err = e;
+                if attempt < MAX_ATTEMPTS {
+                    let backoff_ms = 100u64 * (1u64 << (attempt - 1)); // 100, 200, 400
+                    warn!(
+                        to = %to,
+                        subject = %subject,
+                        attempt,
+                        backoff_ms,
+                        "Email send failed, retrying after backoff"
+                    );
+                    tokio::time::sleep(std::time::Duration::from_millis(backoff_ms)).await;
+                }
+            }
+        }
+    }
+    tracing::error!(
+        to = %to,
+        subject = %subject,
+        "Email send failed after {MAX_ATTEMPTS} attempts: {last_err}"
+    );
+    Err(last_err)
+}
+
 /// Build a booking confirmation email body.
 #[allow(clippy::too_many_arguments)]
 pub fn build_booking_confirmation_email(

--- a/parkhub-server/src/jobs.rs
+++ b/parkhub-server/src/jobs.rs
@@ -1,0 +1,484 @@
+//! Background job scheduler.
+//!
+//! Uses tokio interval tasks (no external cron dependency beyond what's already in the tree):
+//! - **AutoRelease** (every 5 min): cancel no-show bookings after the configured threshold
+//! - **ExpandRecurring** (every 1 h): create future booking instances for recurring series
+//! - **PurgeExpired** (every 24 h): remove old cancelled/expired bookings beyond retention period
+//! - **AggregateOccupancy** (every 15 min): persist aggregated occupancy stats to settings
+
+use std::sync::Arc;
+
+use chrono::{Datelike, Duration, NaiveDate, NaiveTime, Utc};
+use tokio::sync::RwLock;
+use tracing::{error, info, warn};
+use uuid::Uuid;
+
+use crate::AppState;
+
+pub type SharedState = Arc<RwLock<AppState>>;
+
+/// Start all background jobs.  Call once after `AppState` is initialised.
+pub async fn start_background_jobs(state: SharedState) {
+    // ── AutoRelease: every 5 minutes ────────────────────────────────────────
+    {
+        let s = state.clone();
+        tokio::spawn(async move {
+            let mut interval =
+                tokio::time::interval(tokio::time::Duration::from_secs(300));
+            loop {
+                interval.tick().await;
+                if let Err(e) = auto_release_no_shows(&s).await {
+                    error!("AutoRelease job error: {e}");
+                }
+            }
+        });
+    }
+
+    // ── ExpandRecurring: every hour ──────────────────────────────────────────
+    {
+        let s = state.clone();
+        tokio::spawn(async move {
+            let mut interval =
+                tokio::time::interval(tokio::time::Duration::from_secs(3600));
+            loop {
+                interval.tick().await;
+                if let Err(e) = expand_recurring_bookings(&s).await {
+                    error!("ExpandRecurring job error: {e}");
+                }
+            }
+        });
+    }
+
+    // ── PurgeExpired: every 24 hours (first run after 60 s) ─────────────────
+    {
+        let s = state.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(tokio::time::Duration::from_secs(60)).await;
+            let mut interval =
+                tokio::time::interval(tokio::time::Duration::from_secs(86400));
+            loop {
+                interval.tick().await;
+                if let Err(e) = purge_expired_bookings(&s).await {
+                    error!("PurgeExpired job error: {e}");
+                }
+            }
+        });
+    }
+
+    // ── AggregateOccupancy: every 15 minutes ────────────────────────────────
+    {
+        let s = state.clone();
+        tokio::spawn(async move {
+            let mut interval =
+                tokio::time::interval(tokio::time::Duration::from_secs(900));
+            loop {
+                interval.tick().await;
+                if let Err(e) = aggregate_occupancy_stats(&s).await {
+                    error!("AggregateOccupancy job error: {e}");
+                }
+            }
+        });
+    }
+
+    info!(
+        "Background jobs started: AutoRelease (5m), ExpandRecurring (1h), \
+         PurgeExpired (24h), AggregateOccupancy (15m)"
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Job implementations
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Cancel bookings that are Active/Confirmed but past their start time by more
+/// than the configured `auto_release_minutes` and have never had a check-in.
+async fn auto_release_no_shows(state: &SharedState) -> anyhow::Result<()> {
+    // Read settings + bookings under a single short-lived read lock.
+    let (enabled, threshold_mins, bookings) = {
+        let guard = state.read().await;
+        let enabled_str = guard
+            .db
+            .get_setting("auto_release_enabled")
+            .await
+            .unwrap_or(None)
+            .unwrap_or_default();
+        let enabled = enabled_str.parse::<bool>().unwrap_or(false);
+        if !enabled {
+            return Ok(());
+        }
+        let mins_str = guard
+            .db
+            .get_setting("auto_release_minutes")
+            .await
+            .unwrap_or(None)
+            .unwrap_or_else(|| "30".to_string());
+        let mins = mins_str.parse::<i64>().unwrap_or(30);
+        let bookings = guard.db.list_bookings().await?;
+        (enabled, mins, bookings)
+    };
+
+    if !enabled {
+        return Ok(());
+    }
+
+    let now = Utc::now();
+    let threshold = Duration::minutes(threshold_mins);
+
+    let to_release: Vec<_> = bookings
+        .into_iter()
+        .filter(|b| {
+            matches!(
+                b.status,
+                parkhub_common::BookingStatus::Active
+                    | parkhub_common::BookingStatus::Confirmed
+            ) && b.check_in_time.is_none()
+                && now > b.start_time + threshold
+        })
+        .collect();
+
+    if to_release.is_empty() {
+        return Ok(());
+    }
+
+    info!("AutoRelease: releasing {} no-show booking(s)", to_release.len());
+
+    for mut booking in to_release {
+        let slot_id = booking.slot_id.to_string();
+        booking.status = parkhub_common::BookingStatus::NoShow;
+        booking.updated_at = now;
+
+        let guard = state.write().await;
+        if let Err(e) = guard.db.save_booking(&booking).await {
+            error!("AutoRelease: failed to save booking {}: {e}", booking.id);
+            continue;
+        }
+        // Free the slot
+        if let Err(e) = guard
+            .db
+            .update_slot_status(&slot_id, parkhub_common::SlotStatus::Available)
+            .await
+        {
+            warn!(
+                "AutoRelease: failed to free slot {slot_id} for booking {}: {e}",
+                booking.id
+            );
+        }
+        drop(guard);
+        info!(
+            "AutoRelease: booking {} marked NoShow, slot {slot_id} freed",
+            booking.id
+        );
+    }
+
+    Ok(())
+}
+
+/// For every active recurring booking, ensure single-booking instances exist for
+/// the next 4 weeks.  Skips dates that already have a booking for the same slot.
+async fn expand_recurring_bookings(state: &SharedState) -> anyhow::Result<()> {
+    let (users, all_bookings) = {
+        let guard = state.read().await;
+        let users = guard.db.list_users().await?;
+        let all_bookings = guard.db.list_bookings().await?;
+        (users, all_bookings)
+    };
+
+    let now_date = Utc::now().date_naive();
+    let horizon = now_date + Duration::weeks(4);
+    let mut created = 0u32;
+
+    for user in &users {
+        let user_id_str = user.id.to_string();
+        let recurring = {
+            let guard = state.read().await;
+            guard
+                .db
+                .list_recurring_bookings_by_user(&user_id_str)
+                .await?
+        };
+
+        for rec in recurring.iter().filter(|r| r.active) {
+            // Parse series start/end dates
+            let series_start = match NaiveDate::parse_from_str(&rec.start_date, "%Y-%m-%d") {
+                Ok(d) => d,
+                Err(_) => {
+                    warn!("ExpandRecurring: bad start_date '{}' on {}", rec.start_date, rec.id);
+                    continue;
+                }
+            };
+            let series_end: Option<NaiveDate> = rec
+                .end_date
+                .as_deref()
+                .and_then(|s| NaiveDate::parse_from_str(s, "%Y-%m-%d").ok());
+
+            // Parse HH:MM slot times
+            let slot_start = match NaiveTime::parse_from_str(&rec.start_time, "%H:%M") {
+                Ok(t) => t,
+                Err(_) => {
+                    warn!("ExpandRecurring: bad start_time '{}' on {}", rec.start_time, rec.id);
+                    continue;
+                }
+            };
+            let slot_end = match NaiveTime::parse_from_str(&rec.end_time, "%H:%M") {
+                Ok(t) => t,
+                Err(_) => {
+                    warn!("ExpandRecurring: bad end_time '{}' on {}", rec.end_time, rec.id);
+                    continue;
+                }
+            };
+
+            // days_of_week: 0 = Monday … 6 = Sunday (matches chrono Weekday::num_days_from_monday)
+            let day_set: std::collections::HashSet<u8> =
+                rec.days_of_week.iter().copied().collect();
+
+            // Build set of existing booking dates for this user+slot to avoid duplicates
+            let slot_id_opt = rec.slot_id;
+            let existing_dates: std::collections::HashSet<NaiveDate> = all_bookings
+                .iter()
+                .filter(|b| {
+                    b.user_id == rec.user_id
+                        && slot_id_opt.map_or(true, |sid| b.slot_id == sid)
+                        && !matches!(
+                            b.status,
+                            parkhub_common::BookingStatus::Cancelled
+                                | parkhub_common::BookingStatus::Expired
+                                | parkhub_common::BookingStatus::NoShow
+                        )
+                })
+                .map(|b| b.start_time.date_naive())
+                .collect();
+
+            // Walk from max(series_start, today) to min(horizon, series_end)
+            let walk_start = series_start.max(now_date);
+            let walk_end = series_end.map_or(horizon, |e| e.min(horizon));
+
+            let mut cursor = walk_start;
+            while cursor <= walk_end {
+                let dow = cursor.weekday().num_days_from_monday() as u8;
+                if day_set.contains(&dow) && !existing_dates.contains(&cursor) {
+                    // Create a new booking for this date (treat stored times as UTC)
+                    let start_dt = cursor.and_time(slot_start).and_utc();
+                    let end_dt = cursor.and_time(slot_end).and_utc();
+
+                    // We need a vehicle — try to find the user's default vehicle.
+                    // If none exists we skip silently (can't create a booking without one).
+                    let vehicle = {
+                        let guard = state.read().await;
+                        guard
+                            .db
+                            .list_vehicles_by_user(&user_id_str)
+                            .await
+                            .unwrap_or_default()
+                            .into_iter()
+                            .find(|v| v.is_default || true) // first available
+                    };
+                    let Some(vehicle) = vehicle else {
+                        continue;
+                    };
+
+                    // Resolve slot_id: recurring bookings may not pin a slot
+                    let slot_id = match rec.slot_id {
+                        Some(sid) => sid,
+                        None => {
+                            // Pick the first available slot in the lot (best-effort)
+                            let guard = state.read().await;
+                            let slots = guard
+                                .db
+                                .list_slots_by_lot(&rec.lot_id.to_string())
+                                .await
+                                .unwrap_or_default();
+                            match slots.into_iter().find(|s| {
+                                s.status == parkhub_common::SlotStatus::Available
+                            }) {
+                                Some(s) => s.id,
+                                None => {
+                                    // No available slot — skip this date
+                                    cursor += Duration::days(1);
+                                    continue;
+                                }
+                            }
+                        }
+                    };
+
+                    // Fetch slot + lot for metadata
+                    let (slot_number, floor_name) = {
+                        let guard = state.read().await;
+                        let slot_opt = guard
+                            .db
+                            .get_parking_slot(&slot_id.to_string())
+                            .await
+                            .unwrap_or(None);
+                        let lot_opt = guard
+                            .db
+                            .get_parking_lot(&rec.lot_id.to_string())
+                            .await
+                            .unwrap_or(None);
+                        match slot_opt {
+                            Some(s) => {
+                                let fname = lot_opt
+                                    .as_ref()
+                                    .and_then(|lot| {
+                                        lot.floors
+                                            .iter()
+                                            .find(|f| f.id == s.floor_id)
+                                            .map(|f| f.name.clone())
+                                    })
+                                    .unwrap_or_else(|| "Level 1".to_string());
+                                (s.slot_number, fname)
+                            }
+                            None => (0, "Level 1".to_string()),
+                        }
+                    };
+
+                    let booking = parkhub_common::Booking {
+                        id: Uuid::new_v4(),
+                        user_id: rec.user_id,
+                        lot_id: rec.lot_id,
+                        slot_id,
+                        slot_number,
+                        floor_name,
+                        vehicle,
+                        start_time: start_dt,
+                        end_time: end_dt,
+                        status: parkhub_common::BookingStatus::Confirmed,
+                        pricing: parkhub_common::BookingPricing {
+                            base_price: 0.0,
+                            discount: 0.0,
+                            tax: 0.0,
+                            total: 0.0,
+                            currency: "EUR".to_string(),
+                            payment_status: parkhub_common::PaymentStatus::Pending,
+                            payment_method: None,
+                        },
+                        created_at: Utc::now(),
+                        updated_at: Utc::now(),
+                        check_in_time: None,
+                        check_out_time: None,
+                        qr_code: None,
+                        notes: Some(format!("Auto-expanded from recurring booking {}", rec.id)),
+                    };
+
+                    let guard = state.write().await;
+                    match guard.db.save_booking(&booking).await {
+                        Ok(()) => {
+                            created += 1;
+                        }
+                        Err(e) => {
+                            error!(
+                                "ExpandRecurring: failed to create booking for {} on {cursor}: {e}",
+                                rec.id
+                            );
+                        }
+                    }
+                    drop(guard);
+                }
+                cursor += Duration::days(1);
+            }
+        }
+    }
+
+    if created > 0 {
+        info!("ExpandRecurring: created {created} new booking instance(s)");
+    }
+    Ok(())
+}
+
+/// Delete cancelled, expired, or no-show bookings older than `retention_days`
+/// (default 90).  Reads the `booking_retention_days` setting.
+async fn purge_expired_bookings(state: &SharedState) -> anyhow::Result<()> {
+    let (retention_days, bookings) = {
+        let guard = state.read().await;
+        let days_str = guard
+            .db
+            .get_setting("booking_retention_days")
+            .await
+            .unwrap_or(None)
+            .unwrap_or_else(|| "90".to_string());
+        let days = days_str.parse::<i64>().unwrap_or(90).max(1);
+        let bookings = guard.db.list_bookings().await?;
+        (days, bookings)
+    };
+
+    let cutoff = Utc::now() - Duration::days(retention_days);
+
+    let to_purge: Vec<_> = bookings
+        .into_iter()
+        .filter(|b| {
+            matches!(
+                b.status,
+                parkhub_common::BookingStatus::Cancelled
+                    | parkhub_common::BookingStatus::Expired
+                    | parkhub_common::BookingStatus::NoShow
+            ) && b.updated_at < cutoff
+        })
+        .collect();
+
+    if to_purge.is_empty() {
+        return Ok(());
+    }
+
+    info!("PurgeExpired: deleting {} old booking(s)", to_purge.len());
+
+    let mut deleted = 0u32;
+    for booking in to_purge {
+        let guard = state.write().await;
+        match guard.db.delete_booking(&booking.id.to_string()).await {
+            Ok(true) => deleted += 1,
+            Ok(false) => {}
+            Err(e) => error!("PurgeExpired: failed to delete booking {}: {e}", booking.id),
+        }
+        drop(guard);
+    }
+
+    info!("PurgeExpired: deleted {deleted} booking(s)");
+    Ok(())
+}
+
+/// Compute and persist basic occupancy stats per lot into the settings store.
+/// Key: `occupancy_stats_<lot_id>`, value: `<occupied>/<total>`.
+async fn aggregate_occupancy_stats(state: &SharedState) -> anyhow::Result<()> {
+    let (lots, bookings) = {
+        let guard = state.read().await;
+        let lots = guard.db.list_parking_lots().await?;
+        let bookings = guard.db.list_bookings().await?;
+        (lots, bookings)
+    };
+
+    let now = Utc::now();
+    let active_statuses = [
+        parkhub_common::BookingStatus::Active,
+        parkhub_common::BookingStatus::Confirmed,
+    ];
+
+    let mut stats_written = 0u32;
+    for lot in &lots {
+        #[allow(clippy::cast_sign_loss)]
+        let total = lot.total_slots.max(0) as u64;
+
+        let occupied = bookings
+            .iter()
+            .filter(|b| {
+                b.lot_id == lot.id
+                    && active_statuses.contains(&b.status)
+                    && b.start_time <= now
+                    && b.end_time >= now
+            })
+            .count() as u64;
+
+        let key = format!("occupancy_stats_{}", lot.id);
+        let value = format!("{occupied}/{total}");
+
+        let guard = state.write().await;
+        if let Err(e) = guard.db.set_setting(&key, &value).await {
+            error!("AggregateOccupancy: failed to write stats for lot {}: {e}", lot.id);
+        } else {
+            stats_written += 1;
+        }
+        drop(guard);
+    }
+
+    if stats_written > 0 {
+        info!("AggregateOccupancy: updated stats for {stats_written} lot(s)");
+    }
+    Ok(())
+}


### PR DESCRIPTION
Closes #41
Closes #42
Closes #69

## Summary
- `POST /api/v1/absences/import/ical` — parse iCal VEVENT blocks into absences
- Background job scheduler: AutoRelease (5min), ExpandRecurring (1h), PurgeExpired (24h), AggregateOccupancy (15min)
- Webhook dispatch with 3-attempt exponential backoff retry

## Test plan
- [ ] `cargo build` passes
- [ ] `cargo test` passes