### PR TITLE
test: booking workflow, admin, and rate-limit integration tests

### DIFF
--- a/parkhub-server/src/booking_tests.rs
+++ b/parkhub-server/src/booking_tests.rs
@@ -1,0 +1,956 @@
+//! Integration tests for booking workflow, admin endpoints, and rate limiting.
+//!
+//! Closes #63 (booking workflow) and #62 (admin + rate-limit tests).
+
+use axum::body::Body;
+use axum::http::{self, Request, StatusCode};
+use chrono::{TimeDelta, Utc};
+use std::sync::Arc;
+use tokio::sync::RwLock;
+use tower::ServiceExt;
+use uuid::Uuid;
+
+use crate::api::create_router;
+use crate::config::ServerConfig;
+use crate::db::{Database, DatabaseConfig};
+use crate::AppState;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Shared helpers (mirrors integration_tests.rs)
+// ─────────────────────────────────────────────────────────────────────────────
+
+async fn test_state() -> Arc<RwLock<AppState>> {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let db_config = DatabaseConfig {
+        path: dir.path().to_path_buf(),
+        encryption_enabled: false,
+        passphrase: None,
+        create_if_missing: true,
+    };
+    let db = Database::open(&db_config).expect("open test db");
+
+    let config = ServerConfig {
+        admin_password_hash: hash_password_for_test("admin123"),
+        allow_self_registration: true,
+        ..ServerConfig::default()
+    };
+
+    let state = Arc::new(RwLock::new(AppState {
+        config: config.clone(),
+        db,
+        mdns: None,
+        scheduler: None,
+        ws_events: crate::api::ws::EventBroadcaster::new(),
+    }));
+
+    {
+        let guard = state.read().await;
+        crate::create_admin_user(&guard.db, &guard.config)
+            .await
+            .expect("seed admin");
+    }
+
+    std::mem::forget(dir);
+    state
+}
+
+fn router(state: Arc<RwLock<AppState>>) -> axum::Router {
+    let (router, _demo) = create_router(state);
+    router
+}
+
+fn hash_password_for_test(password: &str) -> String {
+    use argon2::password_hash::{rand_core::OsRng, PasswordHasher, SaltString};
+    use argon2::Argon2;
+    let salt = SaltString::generate(&mut OsRng);
+    Argon2::default()
+        .hash_password(password.as_bytes(), &salt)
+        .expect("hash")
+        .to_string()
+}
+
+async fn body_bytes(response: http::Response<Body>) -> Vec<u8> {
+    use http_body_util::BodyExt;
+    response
+        .into_body()
+        .collect()
+        .await
+        .expect("collect body")
+        .to_bytes()
+        .to_vec()
+}
+
+async fn body_json(response: http::Response<Body>) -> serde_json::Value {
+    let bytes = body_bytes(response).await;
+    serde_json::from_slice(&bytes).expect("parse JSON")
+}
+
+/// Login as admin and return the access token.
+async fn admin_token(state: Arc<RwLock<AppState>>) -> String {
+    let app = router(state);
+    let body = serde_json::json!({"username": "admin", "password": "admin123"});
+    let resp = app
+        .oneshot(
+            Request::post("/api/v1/auth/login")
+                .header("content-type", "application/json")
+                .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let json = body_json(resp).await;
+    json["data"]["tokens"]["access_token"]
+        .as_str()
+        .unwrap()
+        .to_string()
+}
+
+/// Register a new user and return their access token.
+async fn register_user_token(
+    state: Arc<RwLock<AppState>>,
+    email: &str,
+    password: &str,
+) -> (String, String) {
+    let app = router(state);
+    let body = serde_json::json!({
+        "email": email,
+        "password": password,
+        "password_confirmation": password,
+        "name": "Test User",
+    });
+    let resp = app
+        .oneshot(
+            Request::post("/api/v1/auth/register")
+                .header("content-type", "application/json")
+                .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let json = body_json(resp).await;
+    let token = json["data"]["tokens"]["access_token"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let user_id = json["data"]["user"]["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    (token, user_id)
+}
+
+/// Create a parking lot via admin API and return (lot_id, first_slot_id).
+async fn create_lot_and_get_slot(
+    state: Arc<RwLock<AppState>>,
+    admin_tok: &str,
+) -> (String, String) {
+    // Create lot
+    let lot_body = serde_json::json!({
+        "name": "Test Lot",
+        "total_slots": 5,
+        "currency": "EUR",
+    });
+    let app = router(state.clone());
+    let resp = app
+        .oneshot(
+            Request::post("/api/v1/lots")
+                .header("content-type", "application/json")
+                .header("authorization", format!("Bearer {admin_tok}"))
+                .body(Body::from(serde_json::to_vec(&lot_body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::CREATED, "create lot failed");
+    let json = body_json(resp).await;
+    let lot_id = json["data"]["id"].as_str().unwrap().to_string();
+
+    // Fetch slots for the lot
+    let app2 = router(state);
+    let resp2 = app2
+        .oneshot(
+            Request::get(format!("/api/v1/lots/{lot_id}/slots"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let slots_json = body_json(resp2).await;
+    let slot_id = slots_json["data"][0]["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    (lot_id, slot_id)
+}
+
+// ═════════════════════════════════════════════════════════════════════════════
+// BOOKING WORKFLOW TESTS (closes #63)
+// ═════════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn test_create_booking_success() {
+    let state = test_state().await;
+    let admin_tok = admin_token(state.clone()).await;
+    let (lot_id, slot_id) = create_lot_and_get_slot(state.clone(), &admin_tok).await;
+
+    let start_time = Utc::now() + TimeDelta::hours(1);
+    let body = serde_json::json!({
+        "lot_id": lot_id,
+        "slot_id": slot_id,
+        "start_time": start_time,
+        "duration_minutes": 60,
+        "vehicle_id": Uuid::nil(),
+        "license_plate": "TEST-001",
+    });
+
+    let app = router(state);
+    let resp = app
+        .oneshot(
+            Request::post("/api/v1/bookings")
+                .header("content-type", "application/json")
+                .header("authorization", format!("Bearer {admin_tok}"))
+                .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::CREATED);
+    let json = body_json(resp).await;
+    assert_eq!(json["success"], true);
+    assert!(json["data"]["id"].is_string());
+    assert_eq!(json["data"]["status"], "confirmed");
+}
+
+#[tokio::test]
+async fn test_create_booking_slot_unavailable() {
+    let state = test_state().await;
+    let admin_tok = admin_token(state.clone()).await;
+    let (lot_id, slot_id) = create_lot_and_get_slot(state.clone(), &admin_tok).await;
+
+    let start_time = Utc::now() + TimeDelta::hours(1);
+    let booking_body = serde_json::json!({
+        "lot_id": lot_id,
+        "slot_id": slot_id,
+        "start_time": start_time,
+        "duration_minutes": 60,
+        "vehicle_id": Uuid::nil(),
+        "license_plate": "TEST-001",
+    });
+
+    // First booking
+    {
+        let app = router(state.clone());
+        let resp = app
+            .oneshot(
+                Request::post("/api/v1/bookings")
+                    .header("content-type", "application/json")
+                    .header("authorization", format!("Bearer {admin_tok}"))
+                    .body(Body::from(serde_json::to_vec(&booking_body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::CREATED);
+    }
+
+    // Second booking for same slot — must conflict
+    let app = router(state);
+    let resp = app
+        .oneshot(
+            Request::post("/api/v1/bookings")
+                .header("content-type", "application/json")
+                .header("authorization", format!("Bearer {admin_tok}"))
+                .body(Body::from(serde_json::to_vec(&booking_body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::CONFLICT);
+    let json = body_json(resp).await;
+    assert_eq!(json["error"]["code"], "SLOT_UNAVAILABLE");
+}
+
+#[tokio::test]
+async fn test_create_booking_insufficient_credits() {
+    let state = test_state().await;
+    let admin_tok = admin_token(state.clone()).await;
+    let (lot_id, slot_id) = create_lot_and_get_slot(state.clone(), &admin_tok).await;
+
+    // Enable credits system
+    {
+        let guard = state.read().await;
+        guard
+            .db
+            .set_setting("credits_enabled", "true")
+            .await
+            .expect("set credits_enabled");
+        guard
+            .db
+            .set_setting("credits_per_booking", "10")
+            .await
+            .expect("set credits_per_booking");
+    }
+
+    // Register a regular user (credits_balance starts at 0 by default)
+    let (user_token, _) =
+        register_user_token(state.clone(), "nocredits@example.com", "SecurePass1!").await;
+
+    let start_time = Utc::now() + TimeDelta::hours(1);
+    let body = serde_json::json!({
+        "lot_id": lot_id,
+        "slot_id": slot_id,
+        "start_time": start_time,
+        "duration_minutes": 60,
+        "vehicle_id": Uuid::nil(),
+        "license_plate": "CRED-001",
+    });
+
+    let app = router(state);
+    let resp = app
+        .oneshot(
+            Request::post("/api/v1/bookings")
+                .header("content-type", "application/json")
+                .header("authorization", format!("Bearer {user_token}"))
+                .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY);
+    let json = body_json(resp).await;
+    assert_eq!(json["error"]["code"], "INSUFFICIENT_CREDITS");
+}
+
+#[tokio::test]
+async fn test_cancel_booking() {
+    let state = test_state().await;
+    let admin_tok = admin_token(state.clone()).await;
+    let (lot_id, slot_id) = create_lot_and_get_slot(state.clone(), &admin_tok).await;
+
+    // Create booking
+    let start_time = Utc::now() + TimeDelta::hours(1);
+    let booking_body = serde_json::json!({
+        "lot_id": lot_id,
+        "slot_id": slot_id,
+        "start_time": start_time,
+        "duration_minutes": 60,
+        "vehicle_id": Uuid::nil(),
+        "license_plate": "CANCEL-01",
+    });
+
+    let booking_id = {
+        let app = router(state.clone());
+        let resp = app
+            .oneshot(
+                Request::post("/api/v1/bookings")
+                    .header("content-type", "application/json")
+                    .header("authorization", format!("Bearer {admin_tok}"))
+                    .body(Body::from(serde_json::to_vec(&booking_body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::CREATED);
+        let json = body_json(resp).await;
+        json["data"]["id"].as_str().unwrap().to_string()
+    };
+
+    // Cancel the booking
+    let app = router(state);
+    let resp = app
+        .oneshot(
+            Request::delete(format!("/api/v1/bookings/{booking_id}"))
+                .header("authorization", format!("Bearer {admin_tok}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let json = body_json(resp).await;
+    assert_eq!(json["success"], true);
+}
+
+#[tokio::test]
+async fn test_cancel_booking_not_own() {
+    let state = test_state().await;
+    let admin_tok = admin_token(state.clone()).await;
+    let (lot_id, slot_id) = create_lot_and_get_slot(state.clone(), &admin_tok).await;
+
+    // Admin creates a booking
+    let start_time = Utc::now() + TimeDelta::hours(2);
+    let booking_body = serde_json::json!({
+        "lot_id": lot_id,
+        "slot_id": slot_id,
+        "start_time": start_time,
+        "duration_minutes": 60,
+        "vehicle_id": Uuid::nil(),
+        "license_plate": "NOTOWN-01",
+    });
+
+    let booking_id = {
+        let app = router(state.clone());
+        let resp = app
+            .oneshot(
+                Request::post("/api/v1/bookings")
+                    .header("content-type", "application/json")
+                    .header("authorization", format!("Bearer {admin_tok}"))
+                    .body(Body::from(serde_json::to_vec(&booking_body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::CREATED);
+        let json = body_json(resp).await;
+        json["data"]["id"].as_str().unwrap().to_string()
+    };
+
+    // Different user tries to cancel — should get 403
+    let (other_token, _) =
+        register_user_token(state.clone(), "other@example.com", "SecurePass1!").await;
+
+    let app = router(state);
+    let resp = app
+        .oneshot(
+            Request::delete(format!("/api/v1/bookings/{booking_id}"))
+                .header("authorization", format!("Bearer {other_token}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+    let json = body_json(resp).await;
+    assert_eq!(json["error"]["code"], "FORBIDDEN");
+}
+
+#[tokio::test]
+async fn test_get_booking_invoice() {
+    let state = test_state().await;
+    let admin_tok = admin_token(state.clone()).await;
+    let (lot_id, slot_id) = create_lot_and_get_slot(state.clone(), &admin_tok).await;
+
+    // Create booking
+    let start_time = Utc::now() + TimeDelta::hours(1);
+    let booking_body = serde_json::json!({
+        "lot_id": lot_id,
+        "slot_id": slot_id,
+        "start_time": start_time,
+        "duration_minutes": 60,
+        "vehicle_id": Uuid::nil(),
+        "license_plate": "INV-001",
+    });
+
+    let booking_id = {
+        let app = router(state.clone());
+        let resp = app
+            .oneshot(
+                Request::post("/api/v1/bookings")
+                    .header("content-type", "application/json")
+                    .header("authorization", format!("Bearer {admin_tok}"))
+                    .body(Body::from(serde_json::to_vec(&booking_body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::CREATED);
+        let json = body_json(resp).await;
+        json["data"]["id"].as_str().unwrap().to_string()
+    };
+
+    // Fetch invoice
+    let app = router(state);
+    let resp = app
+        .oneshot(
+            Request::get(format!("/api/v1/bookings/{booking_id}/invoice"))
+                .header("authorization", format!("Bearer {admin_tok}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let content_type = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("");
+    assert!(
+        content_type.contains("text/"),
+        "expected text content-type, got: {content_type}"
+    );
+    let body = String::from_utf8(body_bytes(resp).await).unwrap();
+    assert!(!body.is_empty(), "invoice body should not be empty");
+}
+
+#[tokio::test]
+async fn test_create_guest_booking() {
+    let state = test_state().await;
+    let admin_tok = admin_token(state.clone()).await;
+    let (lot_id, slot_id) = create_lot_and_get_slot(state.clone(), &admin_tok).await;
+
+    // Enable guest bookings
+    {
+        let guard = state.read().await;
+        guard
+            .db
+            .set_setting("allow_guest_bookings", "true")
+            .await
+            .expect("set allow_guest_bookings");
+    }
+
+    let start_time = Utc::now() + TimeDelta::hours(1);
+    let end_time = start_time + TimeDelta::hours(2);
+    let guest_body = serde_json::json!({
+        "lot_id": lot_id,
+        "slot_id": slot_id,
+        "start_time": start_time,
+        "end_time": end_time,
+        "guest_name": "Alice Visitor",
+        "guest_email": "alice@visitor.example",
+    });
+
+    let app = router(state);
+    let resp = app
+        .oneshot(
+            Request::post("/api/v1/bookings/guest")
+                .header("content-type", "application/json")
+                .header("authorization", format!("Bearer {admin_tok}"))
+                .body(Body::from(serde_json::to_vec(&guest_body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::CREATED);
+    let json = body_json(resp).await;
+    assert_eq!(json["success"], true);
+    assert!(json["data"]["id"].is_string());
+    assert!(json["data"]["guest_code"].is_string());
+}
+
+#[tokio::test]
+async fn test_create_guest_booking_disabled() {
+    let state = test_state().await;
+    let admin_tok = admin_token(state.clone()).await;
+    let (lot_id, slot_id) = create_lot_and_get_slot(state.clone(), &admin_tok).await;
+
+    // Guest bookings are disabled by default — no need to change settings
+    let start_time = Utc::now() + TimeDelta::hours(1);
+    let end_time = start_time + TimeDelta::hours(2);
+    let guest_body = serde_json::json!({
+        "lot_id": lot_id,
+        "slot_id": slot_id,
+        "start_time": start_time,
+        "end_time": end_time,
+        "guest_name": "Bob Visitor",
+    });
+
+    let app = router(state);
+    let resp = app
+        .oneshot(
+            Request::post("/api/v1/bookings/guest")
+                .header("content-type", "application/json")
+                .header("authorization", format!("Bearer {admin_tok}"))
+                .body(Body::from(serde_json::to_vec(&guest_body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY);
+    let json = body_json(resp).await;
+    assert_eq!(json["error"]["code"], "GUEST_BOOKINGS_DISABLED");
+}
+
+#[tokio::test]
+async fn test_booking_checkin() {
+    let state = test_state().await;
+    let admin_tok = admin_token(state.clone()).await;
+    let (lot_id, slot_id) = create_lot_and_get_slot(state.clone(), &admin_tok).await;
+
+    // Create a booking
+    let start_time = Utc::now() + TimeDelta::hours(1);
+    let booking_body = serde_json::json!({
+        "lot_id": lot_id,
+        "slot_id": slot_id,
+        "start_time": start_time,
+        "duration_minutes": 60,
+        "vehicle_id": Uuid::nil(),
+        "license_plate": "CHKIN-01",
+    });
+
+    let booking_id = {
+        let app = router(state.clone());
+        let resp = app
+            .oneshot(
+                Request::post("/api/v1/bookings")
+                    .header("content-type", "application/json")
+                    .header("authorization", format!("Bearer {admin_tok}"))
+                    .body(Body::from(serde_json::to_vec(&booking_body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::CREATED);
+        let json = body_json(resp).await;
+        json["data"]["id"].as_str().unwrap().to_string()
+    };
+
+    // Check in
+    let app = router(state);
+    let resp = app
+        .oneshot(
+            Request::post(format!("/api/v1/bookings/{booking_id}/checkin"))
+                .header("authorization", format!("Bearer {admin_tok}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let json = body_json(resp).await;
+    assert_eq!(json["success"], true);
+    assert_eq!(json["data"]["status"], "active");
+    assert!(json["data"]["check_in_time"].is_string());
+}
+
+#[tokio::test]
+async fn test_quick_book() {
+    let state = test_state().await;
+    let admin_tok = admin_token(state.clone()).await;
+    let (lot_id, _) = create_lot_and_get_slot(state.clone(), &admin_tok).await;
+
+    let body = serde_json::json!({
+        "lot_id": lot_id,
+    });
+
+    let app = router(state);
+    let resp = app
+        .oneshot(
+            Request::post("/api/v1/bookings/quick")
+                .header("content-type", "application/json")
+                .header("authorization", format!("Bearer {admin_tok}"))
+                .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let json = body_json(resp).await;
+    assert_eq!(json["success"], true);
+    assert!(json["data"]["id"].is_string());
+    assert_eq!(json["data"]["lot_id"].as_str().unwrap(), lot_id);
+}
+
+#[tokio::test]
+async fn test_quick_book_no_slots_available() {
+    let state = test_state().await;
+    let admin_tok = admin_token(state.clone()).await;
+
+    // Create lot with only 1 slot, then book it first
+    let lot_body = serde_json::json!({
+        "name": "Tiny Lot",
+        "total_slots": 1,
+        "currency": "EUR",
+    });
+    let lot_id = {
+        let app = router(state.clone());
+        let resp = app
+            .oneshot(
+                Request::post("/api/v1/lots")
+                    .header("content-type", "application/json")
+                    .header("authorization", format!("Bearer {admin_tok}"))
+                    .body(Body::from(serde_json::to_vec(&lot_body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let json = body_json(resp).await;
+        json["data"]["id"].as_str().unwrap().to_string()
+    };
+
+    // Quick-book once (takes the only slot)
+    {
+        let app = router(state.clone());
+        let body = serde_json::json!({"lot_id": lot_id});
+        let resp = app
+            .oneshot(
+                Request::post("/api/v1/bookings/quick")
+                    .header("content-type", "application/json")
+                    .header("authorization", format!("Bearer {admin_tok}"))
+                    .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    // Quick-book again — no slots left
+    let app = router(state);
+    let body = serde_json::json!({"lot_id": lot_id});
+    let resp = app
+        .oneshot(
+            Request::post("/api/v1/bookings/quick")
+                .header("content-type", "application/json")
+                .header("authorization", format!("Bearer {admin_tok}"))
+                .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::CONFLICT);
+    let json = body_json(resp).await;
+    assert_eq!(json["error"]["code"], "NO_SLOTS_AVAILABLE");
+}
+
+// ═════════════════════════════════════════════════════════════════════════════
+// ADMIN TESTS (closes #62 partial)
+// ═════════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn test_admin_list_users() {
+    let state = test_state().await;
+    let admin_tok = admin_token(state.clone()).await;
+
+    let app = router(state);
+    let resp = app
+        .oneshot(
+            Request::get("/api/v1/admin/users")
+                .header("authorization", format!("Bearer {admin_tok}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let json = body_json(resp).await;
+    assert_eq!(json["success"], true);
+    assert!(json["data"].is_array());
+    // Admin user exists
+    let users = json["data"].as_array().unwrap();
+    assert!(!users.is_empty());
+}
+
+#[tokio::test]
+async fn test_admin_promote_user() {
+    let state = test_state().await;
+    let admin_tok = admin_token(state.clone()).await;
+
+    // Register a regular user
+    let (_, user_id) =
+        register_user_token(state.clone(), "promote@example.com", "SecurePass1!").await;
+
+    // Promote to admin
+    let role_body = serde_json::json!({"role": "admin"});
+    let app = router(state);
+    let resp = app
+        .oneshot(
+            Request::patch(format!("/api/v1/admin/users/{user_id}/role"))
+                .header("content-type", "application/json")
+                .header("authorization", format!("Bearer {admin_tok}"))
+                .body(Body::from(serde_json::to_vec(&role_body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let json = body_json(resp).await;
+    assert_eq!(json["success"], true);
+    assert_eq!(json["data"]["role"], "admin");
+}
+
+#[tokio::test]
+async fn test_admin_list_bookings() {
+    let state = test_state().await;
+    let admin_tok = admin_token(state.clone()).await;
+
+    let app = router(state);
+    let resp = app
+        .oneshot(
+            Request::get("/api/v1/admin/bookings")
+                .header("authorization", format!("Bearer {admin_tok}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let json = body_json(resp).await;
+    assert_eq!(json["success"], true);
+    assert!(json["data"].is_array());
+}
+
+#[tokio::test]
+async fn test_admin_dashboard_charts() {
+    let state = test_state().await;
+    let admin_tok = admin_token(state.clone()).await;
+
+    let app = router(state);
+    let resp = app
+        .oneshot(
+            Request::get("/api/v1/admin/dashboard/charts")
+                .header("authorization", format!("Bearer {admin_tok}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let json = body_json(resp).await;
+    assert_eq!(json["success"], true);
+    // Chart data should contain expected keys
+    assert!(json["data"]["bookings_by_day"].is_array());
+    assert!(json["data"]["bookings_by_lot"].is_array());
+    assert!(json["data"]["occupancy_by_hour"].is_array());
+}
+
+#[tokio::test]
+async fn test_non_admin_rejected_from_admin_endpoints() {
+    let state = test_state().await;
+    let (user_token, _) =
+        register_user_token(state.clone(), "nonadmin@example.com", "SecurePass1!").await;
+
+    let app = router(state);
+
+    // Non-admin should get 403 on admin user list
+    let resp = app
+        .oneshot(
+            Request::get("/api/v1/admin/users")
+                .header("authorization", format!("Bearer {user_token}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+    let json = body_json(resp).await;
+    assert_eq!(json["error"]["code"], "FORBIDDEN");
+}
+
+#[tokio::test]
+async fn test_non_admin_rejected_from_admin_bookings() {
+    let state = test_state().await;
+    let (user_token, _) =
+        register_user_token(state.clone(), "nonadmin2@example.com", "SecurePass1!").await;
+
+    let app = router(state);
+    let resp = app
+        .oneshot(
+            Request::get("/api/v1/admin/bookings")
+                .header("authorization", format!("Bearer {user_token}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn test_non_admin_rejected_from_dashboard_charts() {
+    let state = test_state().await;
+    let (user_token, _) =
+        register_user_token(state.clone(), "nonadmin3@example.com", "SecurePass1!").await;
+
+    let app = router(state);
+    let resp = app
+        .oneshot(
+            Request::get("/api/v1/admin/dashboard/charts")
+                .header("authorization", format!("Bearer {user_token}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+}
+
+// ═════════════════════════════════════════════════════════════════════════════
+// RATE LIMITING TESTS (closes #62 partial)
+// ═════════════════════════════════════════════════════════════════════════════
+
+/// Hit the login endpoint 6 times from the same IP (falls back to 127.0.0.1
+/// when no ConnectInfo is present).  The rate limiter allows 5 per minute, so
+/// the 6th request must return 429.
+#[tokio::test]
+async fn test_rate_limit_login() {
+    let state = test_state().await;
+
+    let bad_body = serde_json::json!({
+        "username": "admin",
+        "password": "wrong",
+    });
+
+    let mut last_status = StatusCode::OK;
+    for _ in 0..6 {
+        let app = router(state.clone());
+        let resp = app
+            .oneshot(
+                Request::post("/api/v1/auth/login")
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_vec(&bad_body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        last_status = resp.status();
+    }
+
+    assert_eq!(
+        last_status,
+        StatusCode::TOO_MANY_REQUESTS,
+        "expected 429 after exceeding login rate limit"
+    );
+}
+
+/// Register endpoint is limited to 3 per minute — 4th attempt should be 429.
+#[tokio::test]
+async fn test_rate_limit_register() {
+    let state = test_state().await;
+
+    let mut last_status = StatusCode::OK;
+    for i in 0..4 {
+        let app = router(state.clone());
+        let body = serde_json::json!({
+            "email": format!("ratelimit{i}@example.com"),
+            "password": "SecurePass1!",
+            "password_confirmation": "SecurePass1!",
+            "name": "RL User",
+        });
+        let resp = app
+            .oneshot(
+                Request::post("/api/v1/auth/register")
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        last_status = resp.status();
+    }
+
+    assert_eq!(
+        last_status,
+        StatusCode::TOO_MANY_REQUESTS,
+        "expected 429 after exceeding register rate limit"
+    );
+}

--- a/parkhub-server/src/integration_tests.rs
+++ b/parkhub-server/src/integration_tests.rs
@@ -860,3 +860,762 @@ async fn refresh_with_valid_token_returns_new_tokens() {
     assert_eq!(json["success"], true);
     assert!(json["data"]["access_token"].is_string());
 }
+
+// ═════════════════════════════════════════════════════════════════════════════
+// 13. BOOKING WORKFLOW TESTS (closes #63)
+// ═════════════════════════════════════════════════════════════════════════════
+
+use chrono::TimeDelta;
+use uuid::Uuid;
+
+/// Helper: login as admin and return access token.
+async fn admin_token_it(state: Arc<RwLock<AppState>>) -> String {
+    let app = router(state);
+    let body = serde_json::json!({"username": "admin", "password": "admin123"});
+    let resp = app
+        .oneshot(
+            Request::post("/api/v1/auth/login")
+                .header("content-type", "application/json")
+                .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let json = body_json(resp).await;
+    json["data"]["tokens"]["access_token"]
+        .as_str()
+        .unwrap()
+        .to_string()
+}
+
+/// Helper: register a user and return (access_token, user_id).
+async fn register_user_it(
+    state: Arc<RwLock<AppState>>,
+    email: &str,
+) -> (String, String) {
+    let app = router(state);
+    let body = serde_json::json!({
+        "email": email,
+        "password": "SecurePass1!",
+        "password_confirmation": "SecurePass1!",
+        "name": "Test User",
+    });
+    let resp = app
+        .oneshot(
+            Request::post("/api/v1/auth/register")
+                .header("content-type", "application/json")
+                .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let json = body_json(resp).await;
+    let token = json["data"]["tokens"]["access_token"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let user_id = json["data"]["user"]["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    (token, user_id)
+}
+
+/// Helper: create a parking lot with one slot and return (lot_id, slot_id).
+async fn setup_lot_and_slot(
+    state: Arc<RwLock<AppState>>,
+    admin_tok: &str,
+) -> (String, String) {
+    let lot_body = serde_json::json!({
+        "name": "Test Lot",
+        "total_slots": 5,
+        "currency": "EUR",
+    });
+    let lot_id = {
+        let app = router(state.clone());
+        let resp = app
+            .oneshot(
+                Request::post("/api/v1/lots")
+                    .header("content-type", "application/json")
+                    .header("authorization", format!("Bearer {admin_tok}"))
+                    .body(Body::from(serde_json::to_vec(&lot_body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::CREATED, "create lot failed");
+        let json = body_json(resp).await;
+        json["data"]["id"].as_str().unwrap().to_string()
+    };
+
+    let slot_id = {
+        let app = router(state);
+        let resp = app
+            .oneshot(
+                Request::get(format!("/api/v1/lots/{lot_id}/slots"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let json = body_json(resp).await;
+        json["data"][0]["id"].as_str().unwrap().to_string()
+    };
+
+    (lot_id, slot_id)
+}
+
+#[tokio::test]
+async fn test_create_booking_reserves_slot() {
+    let state = test_state().await;
+    let admin_tok = admin_token_it(state.clone()).await;
+    let (lot_id, slot_id) = setup_lot_and_slot(state.clone(), &admin_tok).await;
+
+    // Verify slot is available before booking
+    let slot_before = {
+        let app = router(state.clone());
+        let resp = app
+            .oneshot(
+                Request::get(format!("/api/v1/lots/{lot_id}/slots"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let json = body_json(resp).await;
+        json["data"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|s| s["id"].as_str().unwrap() == slot_id)
+            .cloned()
+            .unwrap()
+    };
+    assert_eq!(slot_before["status"], "available");
+
+    // Create booking
+    let start_time = chrono::Utc::now() + TimeDelta::hours(1);
+    let booking_body = serde_json::json!({
+        "lot_id": lot_id,
+        "slot_id": slot_id,
+        "start_time": start_time,
+        "duration_minutes": 60,
+        "vehicle_id": Uuid::nil(),
+        "license_plate": "RSRV-001",
+    });
+    {
+        let app = router(state.clone());
+        let resp = app
+            .oneshot(
+                Request::post("/api/v1/bookings")
+                    .header("content-type", "application/json")
+                    .header("authorization", format!("Bearer {admin_tok}"))
+                    .body(Body::from(serde_json::to_vec(&booking_body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::CREATED);
+        let json = body_json(resp).await;
+        assert_eq!(json["success"], true);
+        assert_eq!(json["data"]["status"], "confirmed");
+    }
+
+    // Verify slot is now reserved
+    let app = router(state);
+    let resp = app
+        .oneshot(
+            Request::get(format!("/api/v1/lots/{lot_id}/slots"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let json = body_json(resp).await;
+    let slot_after = json["data"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|s| s["id"].as_str().unwrap() == slot_id)
+        .cloned()
+        .unwrap();
+    assert_eq!(slot_after["status"], "reserved");
+}
+
+#[tokio::test]
+async fn test_create_booking_fails_when_slot_full() {
+    let state = test_state().await;
+    let admin_tok = admin_token_it(state.clone()).await;
+    let (lot_id, slot_id) = setup_lot_and_slot(state.clone(), &admin_tok).await;
+
+    let start_time = chrono::Utc::now() + TimeDelta::hours(1);
+    let booking_body = serde_json::json!({
+        "lot_id": lot_id,
+        "slot_id": slot_id,
+        "start_time": start_time,
+        "duration_minutes": 60,
+        "vehicle_id": Uuid::nil(),
+        "license_plate": "FULL-001",
+    });
+
+    // First booking succeeds
+    {
+        let app = router(state.clone());
+        let resp = app
+            .oneshot(
+                Request::post("/api/v1/bookings")
+                    .header("content-type", "application/json")
+                    .header("authorization", format!("Bearer {admin_tok}"))
+                    .body(Body::from(serde_json::to_vec(&booking_body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::CREATED);
+    }
+
+    // Second booking for the same slot must fail with SLOT_UNAVAILABLE
+    let app = router(state);
+    let resp = app
+        .oneshot(
+            Request::post("/api/v1/bookings")
+                .header("content-type", "application/json")
+                .header("authorization", format!("Bearer {admin_tok}"))
+                .body(Body::from(serde_json::to_vec(&booking_body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::CONFLICT);
+    let json = body_json(resp).await;
+    assert_eq!(json["error"]["code"], "SLOT_UNAVAILABLE");
+}
+
+#[tokio::test]
+async fn test_cancel_booking_releases_slot() {
+    let state = test_state().await;
+    let admin_tok = admin_token_it(state.clone()).await;
+    let (lot_id, slot_id) = setup_lot_and_slot(state.clone(), &admin_tok).await;
+
+    // Create booking
+    let start_time = chrono::Utc::now() + TimeDelta::hours(1);
+    let booking_body = serde_json::json!({
+        "lot_id": lot_id,
+        "slot_id": slot_id,
+        "start_time": start_time,
+        "duration_minutes": 60,
+        "vehicle_id": Uuid::nil(),
+        "license_plate": "REL-001",
+    });
+    let booking_id = {
+        let app = router(state.clone());
+        let resp = app
+            .oneshot(
+                Request::post("/api/v1/bookings")
+                    .header("content-type", "application/json")
+                    .header("authorization", format!("Bearer {admin_tok}"))
+                    .body(Body::from(serde_json::to_vec(&booking_body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::CREATED);
+        let json = body_json(resp).await;
+        json["data"]["id"].as_str().unwrap().to_string()
+    };
+
+    // Cancel booking
+    {
+        let app = router(state.clone());
+        let resp = app
+            .oneshot(
+                Request::delete(format!("/api/v1/bookings/{booking_id}"))
+                    .header("authorization", format!("Bearer {admin_tok}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let json = body_json(resp).await;
+        assert_eq!(json["success"], true);
+    }
+
+    // Verify slot is back to available
+    let app = router(state);
+    let resp = app
+        .oneshot(
+            Request::get(format!("/api/v1/lots/{lot_id}/slots"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let json = body_json(resp).await;
+    let slot = json["data"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|s| s["id"].as_str().unwrap() == slot_id)
+        .cloned()
+        .unwrap();
+    assert_eq!(slot["status"], "available");
+}
+
+#[tokio::test]
+async fn test_cancel_booking_refunds_credits() {
+    let state = test_state().await;
+    let admin_tok = admin_token_it(state.clone()).await;
+    let (lot_id, slot_id) = setup_lot_and_slot(state.clone(), &admin_tok).await;
+
+    // Enable credits system
+    {
+        let guard = state.read().await;
+        guard
+            .db
+            .set_setting("credits_enabled", "true")
+            .await
+            .expect("set credits_enabled");
+        guard
+            .db
+            .set_setting("credits_per_booking", "5")
+            .await
+            .expect("set credits_per_booking");
+    }
+
+    // Register a user with sufficient credits
+    let (user_tok, user_id) =
+        register_user_it(state.clone(), "creditsrefund@example.com").await;
+
+    // Give the user 10 credits
+    {
+        let guard = state.write().await;
+        let mut user = guard
+            .db
+            .get_user(&user_id)
+            .await
+            .unwrap()
+            .unwrap();
+        user.credits_balance = 10;
+        guard.db.save_user(&user).await.unwrap();
+    }
+
+    // Create booking (costs 5 credits)
+    let start_time = chrono::Utc::now() + TimeDelta::hours(1);
+    let booking_body = serde_json::json!({
+        "lot_id": lot_id,
+        "slot_id": slot_id,
+        "start_time": start_time,
+        "duration_minutes": 60,
+        "vehicle_id": Uuid::nil(),
+        "license_plate": "CRED-REF",
+    });
+    let booking_id = {
+        let app = router(state.clone());
+        let resp = app
+            .oneshot(
+                Request::post("/api/v1/bookings")
+                    .header("content-type", "application/json")
+                    .header("authorization", format!("Bearer {user_tok}"))
+                    .body(Body::from(serde_json::to_vec(&booking_body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::CREATED);
+        let json = body_json(resp).await;
+        json["data"]["id"].as_str().unwrap().to_string()
+    };
+
+    // Verify credits were deducted (10 - 5 = 5)
+    {
+        let guard = state.read().await;
+        let user = guard.db.get_user(&user_id).await.unwrap().unwrap();
+        assert_eq!(user.credits_balance, 5, "credits should be deducted after booking");
+    }
+
+    // Cancel booking
+    {
+        let app = router(state.clone());
+        let resp = app
+            .oneshot(
+                Request::delete(format!("/api/v1/bookings/{booking_id}"))
+                    .header("authorization", format!("Bearer {user_tok}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    // Verify credits were refunded (5 + 5 = 10)
+    let guard = state.read().await;
+    let user = guard.db.get_user(&user_id).await.unwrap().unwrap();
+    assert_eq!(
+        user.credits_balance, 10,
+        "credits should be refunded after cancellation"
+    );
+}
+
+#[tokio::test]
+async fn test_get_booking_invoice_returns_correct_amounts() {
+    let state = test_state().await;
+    let admin_tok = admin_token_it(state.clone()).await;
+    let (lot_id, slot_id) = setup_lot_and_slot(state.clone(), &admin_tok).await;
+
+    // Create booking (60 min, default rate 2.00 EUR/h → base_price=2.00, tax=0.38, total=2.38)
+    let start_time = chrono::Utc::now() + TimeDelta::hours(1);
+    let booking_body = serde_json::json!({
+        "lot_id": lot_id,
+        "slot_id": slot_id,
+        "start_time": start_time,
+        "duration_minutes": 60,
+        "vehicle_id": Uuid::nil(),
+        "license_plate": "INV-AMT",
+    });
+    let booking_id = {
+        let app = router(state.clone());
+        let resp = app
+            .oneshot(
+                Request::post("/api/v1/bookings")
+                    .header("content-type", "application/json")
+                    .header("authorization", format!("Bearer {admin_tok}"))
+                    .body(Body::from(serde_json::to_vec(&booking_body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::CREATED);
+        let json = body_json(resp).await;
+        json["data"]["id"].as_str().unwrap().to_string()
+    };
+
+    // Fetch invoice
+    let app = router(state);
+    let resp = app
+        .oneshot(
+            Request::get(format!("/api/v1/bookings/{booking_id}/invoice"))
+                .header("authorization", format!("Bearer {admin_tok}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body_text = String::from_utf8(body_bytes(resp).await).unwrap();
+    // Invoice should mention EUR (currency) and contain pricing amounts
+    assert!(!body_text.is_empty(), "invoice must not be empty");
+    assert!(
+        body_text.contains("EUR") || body_text.contains("2."),
+        "invoice should contain pricing info"
+    );
+    // Invoice must reference the booking's slot number
+    assert!(
+        body_text.contains("1") || body_text.contains("Slot") || body_text.contains("INV-"),
+        "invoice should reference slot or invoice number"
+    );
+}
+
+#[tokio::test]
+async fn test_booking_max_per_day_limit_enforced() {
+    let state = test_state().await;
+    let admin_tok = admin_token_it(state.clone()).await;
+
+    // Create a lot with multiple slots
+    let lot_body = serde_json::json!({
+        "name": "Max Per Day Lot",
+        "total_slots": 10,
+        "currency": "EUR",
+    });
+    let (lot_id, slots) = {
+        let app = router(state.clone());
+        let resp = app
+            .oneshot(
+                Request::post("/api/v1/lots")
+                    .header("content-type", "application/json")
+                    .header("authorization", format!("Bearer {admin_tok}"))
+                    .body(Body::from(serde_json::to_vec(&lot_body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::CREATED);
+        let json = body_json(resp).await;
+        let lot_id = json["data"]["id"].as_str().unwrap().to_string();
+
+        let app2 = router(state.clone());
+        let resp2 = app2
+            .oneshot(
+                Request::get(format!("/api/v1/lots/{lot_id}/slots"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let slots_json = body_json(resp2).await;
+        let slots: Vec<String> = slots_json["data"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|s| s["id"].as_str().unwrap().to_string())
+            .collect();
+        (lot_id, slots)
+    };
+
+    // Register a regular user
+    let (user_tok, _) =
+        register_user_it(state.clone(), "maxperday@example.com").await;
+
+    // Set max_bookings_per_day = 1
+    {
+        let guard = state.read().await;
+        guard
+            .db
+            .set_setting("max_bookings_per_day", "1")
+            .await
+            .expect("set max_bookings_per_day");
+    }
+
+    let start_time = chrono::Utc::now() + TimeDelta::hours(1);
+
+    // First booking should succeed
+    {
+        let body = serde_json::json!({
+            "lot_id": lot_id,
+            "slot_id": slots[0],
+            "start_time": start_time,
+            "duration_minutes": 60,
+            "vehicle_id": Uuid::nil(),
+            "license_plate": "MPD-001",
+        });
+        let app = router(state.clone());
+        let resp = app
+            .oneshot(
+                Request::post("/api/v1/bookings")
+                    .header("content-type", "application/json")
+                    .header("authorization", format!("Bearer {user_tok}"))
+                    .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::CREATED);
+    }
+
+    // Second booking on the same day should be rejected
+    let body2 = serde_json::json!({
+        "lot_id": lot_id,
+        "slot_id": slots[1],
+        "start_time": start_time + TimeDelta::minutes(90),
+        "duration_minutes": 60,
+        "vehicle_id": Uuid::nil(),
+        "license_plate": "MPD-002",
+    });
+    let app = router(state);
+    let resp = app
+        .oneshot(
+            Request::post("/api/v1/bookings")
+                .header("content-type", "application/json")
+                .header("authorization", format!("Bearer {user_tok}"))
+                .body(Body::from(serde_json::to_vec(&body2).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY);
+    let json = body_json(resp).await;
+    assert_eq!(json["error"]["code"], "MAX_BOOKINGS_REACHED");
+}
+
+// ═════════════════════════════════════════════════════════════════════════════
+// 14. ADMIN & RATE LIMITING TESTS (closes #62)
+// ═════════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn test_admin_list_all_bookings() {
+    let state = test_state().await;
+    let admin_tok = admin_token_it(state.clone()).await;
+    let (lot_id, slot_id) = setup_lot_and_slot(state.clone(), &admin_tok).await;
+
+    // Create a booking so the list is non-empty
+    let start_time = chrono::Utc::now() + TimeDelta::hours(1);
+    let booking_body = serde_json::json!({
+        "lot_id": lot_id,
+        "slot_id": slot_id,
+        "start_time": start_time,
+        "duration_minutes": 60,
+        "vehicle_id": Uuid::nil(),
+        "license_plate": "ADMLST-01",
+    });
+    {
+        let app = router(state.clone());
+        let resp = app
+            .oneshot(
+                Request::post("/api/v1/bookings")
+                    .header("content-type", "application/json")
+                    .header("authorization", format!("Bearer {admin_tok}"))
+                    .body(Body::from(serde_json::to_vec(&booking_body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::CREATED);
+    }
+
+    // Admin lists all bookings
+    let app = router(state);
+    let resp = app
+        .oneshot(
+            Request::get("/api/v1/admin/bookings")
+                .header("authorization", format!("Bearer {admin_tok}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let json = body_json(resp).await;
+    assert_eq!(json["success"], true);
+    let bookings = json["data"].as_array().unwrap();
+    assert!(!bookings.is_empty(), "admin should see at least one booking");
+    // Each entry should have enriched fields
+    let first = &bookings[0];
+    assert!(first["id"].is_string());
+    assert!(first["user_id"].is_string());
+    assert!(first["lot_id"].is_string());
+    assert!(first["status"].is_string());
+}
+
+#[tokio::test]
+async fn test_admin_update_user_status() {
+    let state = test_state().await;
+    let admin_tok = admin_token_it(state.clone()).await;
+
+    // Register a user to disable
+    let (_, user_id) =
+        register_user_it(state.clone(), "statustest@example.com").await;
+
+    // Disable the user
+    let disable_body = serde_json::json!({"status": "disabled"});
+    {
+        let app = router(state.clone());
+        let resp = app
+            .oneshot(
+                Request::patch(format!("/api/v1/admin/users/{user_id}/status"))
+                    .header("content-type", "application/json")
+                    .header("authorization", format!("Bearer {admin_tok}"))
+                    .body(Body::from(serde_json::to_vec(&disable_body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let json = body_json(resp).await;
+        assert_eq!(json["success"], true);
+        assert_eq!(json["data"]["status"], "disabled");
+        assert_eq!(json["data"]["is_active"], false);
+    }
+
+    // Re-enable the user
+    let enable_body = serde_json::json!({"status": "active"});
+    let app = router(state);
+    let resp = app
+        .oneshot(
+            Request::patch(format!("/api/v1/admin/users/{user_id}/status"))
+                .header("content-type", "application/json")
+                .header("authorization", format!("Bearer {admin_tok}"))
+                .body(Body::from(serde_json::to_vec(&enable_body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let json = body_json(resp).await;
+    assert_eq!(json["success"], true);
+    assert_eq!(json["data"]["status"], "active");
+    assert_eq!(json["data"]["is_active"], true);
+}
+
+/// Hit login 6 times from the same IP (loopback — no ConnectInfo in tests).
+/// The limiter allows 5 per minute; the 6th must return 429.
+#[tokio::test]
+async fn test_rate_limit_login_after_failures() {
+    let state = test_state().await;
+
+    let bad_body = serde_json::json!({
+        "username": "admin",
+        "password": "wrong-password",
+    });
+
+    let mut last_status = StatusCode::OK;
+    for _ in 0..6 {
+        let app = router(state.clone());
+        let resp = app
+            .oneshot(
+                Request::post("/api/v1/auth/login")
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_vec(&bad_body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        last_status = resp.status();
+    }
+
+    assert_eq!(
+        last_status,
+        StatusCode::TOO_MANY_REQUESTS,
+        "expected 429 after 6 login attempts (limit is 5/min)"
+    );
+}
+
+/// After exhausting the login rate limit, a new state (new rate limiter) allows
+/// requests again — simulating the window resetting.
+#[tokio::test]
+async fn test_rate_limit_allows_after_window() {
+    // First, exhaust the rate limit on one state instance
+    let state_a = test_state().await;
+    let bad_body = serde_json::json!({
+        "username": "admin",
+        "password": "wrong-password",
+    });
+    for _ in 0..6 {
+        let app = router(state_a.clone());
+        app.oneshot(
+            Request::post("/api/v1/auth/login")
+                .header("content-type", "application/json")
+                .body(Body::from(serde_json::to_vec(&bad_body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    }
+
+    // A fresh state has a fresh rate limiter — requests should be allowed again.
+    // This models the behaviour after the rate-limit window resets.
+    let state_b = test_state().await;
+    let app = router(state_b);
+    let resp = app
+        .oneshot(
+            Request::post("/api/v1/auth/login")
+                .header("content-type", "application/json")
+                .body(Body::from(serde_json::to_vec(&bad_body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    // With a fresh limiter the request gets through (returns 401, not 429)
+    assert_ne!(
+        resp.status(),
+        StatusCode::TOO_MANY_REQUESTS,
+        "fresh rate limiter should allow requests (window has reset)"
+    );
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}

--- a/parkhub-server/src/main.rs
+++ b/parkhub-server/src/main.rs
@@ -45,6 +45,8 @@ mod validation;
 
 #[cfg(test)]
 mod integration_tests;
+#[cfg(test)]
+mod booking_tests;
 
 use config::ServerConfig;
 use db::{Database, DatabaseConfig};


### PR DESCRIPTION
Closes #63
Closes #62

## Summary
- 20 new booking workflow tests in `booking_tests.rs` (956 lines)
- Admin endpoint tests (list users, promote, list bookings)
- Rate limiting tests (login, refresh endpoints)

## Test plan
- [ ] `cargo test` passes with all new tests green