### PR TITLE
ci: add --all-targets and doc tests to test job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,8 +88,13 @@ jobs:
 
       - name: Run tests (server + common)
         run: |
-          cargo test --package parkhub-common
-          cargo test --package parkhub-server --no-default-features --features headless
+          cargo test --package parkhub-common --all-targets
+          cargo test --package parkhub-server --no-default-features --features headless --all-targets
+
+      - name: Run doc tests
+        run: |
+          cargo test --package parkhub-common --doc
+          cargo test --package parkhub-server --no-default-features --features headless --doc
 
   frontend:
     name: Frontend Build & Test


### PR DESCRIPTION
## Summary

- Adds `--all-targets` flag to both `cargo test` commands so integration tests in `tests/` directories are executed (closes #68)
- Adds a dedicated doc-test step to run `--doc` tests for `parkhub-common` and `parkhub-server`

## Test plan
- [ ] CI passes with the updated test configuration
- [ ] All existing unit tests continue to pass
- [ ] Any integration tests in `tests/` directories are now included