### PR TITLE
ci: add --all-targets and --doc to test step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,8 +88,10 @@ jobs:
 
       - name: Run tests (server + common)
         run: |
-          cargo test --package parkhub-common
-          cargo test --package parkhub-server --no-default-features --features headless
+          cargo test --package parkhub-common --all-targets
+          cargo test --package parkhub-server --no-default-features --features headless --all-targets
+          cargo test --package parkhub-common --doc
+          cargo test --package parkhub-server --no-default-features --features headless --doc
 
   frontend:
     name: Frontend Build & Test


### PR DESCRIPTION
Closes #68

Adds `--all-targets` to both `cargo test` invocations so that tests in
benchmarks, examples, and integration-test targets are included. Also adds
separate `--doc` runs for doc-test execution (doc tests cannot be combined
with `--all-targets`).

Matches the flags already used by `cargo check` and `cargo clippy`.