### PR TITLE
feat(system, ical, webhooks): system endpoints, iCal import, webhook retry

### DIFF
--- a/parkhub-server/src/api/import.rs
+++ b/parkhub-server/src/api/import.rs
@@ -1,6 +1,7 @@
-//! CSV import endpoint for bulk user creation.
+//! Import endpoints: bulk CSV user creation and iCal absence import.
 //!
 //! - `POST /api/v1/admin/users/import` — import users from CSV (admin only)
+//! - `POST /api/v1/absences/import/ical` — import absences from iCal (user-scoped)
 
 use axum::{
     extract::State,
@@ -11,6 +12,7 @@ use chrono::Utc;
 use uuid::Uuid;
 
 use parkhub_common::{ApiResponse, User, UserPreferences, UserRole};
+use parkhub_common::models::{Absence, AbsenceType};
 
 use super::{check_admin, AuthUser, SharedState};
 use super::hash_password_simple;
@@ -323,6 +325,201 @@ pub async fn import_users_csv(
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
+// iCal absence import
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Result of an iCal absence import.
+#[derive(Debug, serde::Serialize, utoipa::ToSchema)]
+pub struct IcalImportResult {
+    /// Number of absences successfully imported.
+    pub imported: usize,
+    /// Number of events skipped (missing required fields).
+    pub skipped: usize,
+}
+
+/// Map an iCal SUMMARY or CATEGORIES string to an [`AbsenceType`].
+fn summary_to_absence_type(summary: &str) -> AbsenceType {
+    let lower = summary.to_lowercase();
+    if lower.contains("homeoffice") || lower.contains("home office") || lower.contains("remote") {
+        AbsenceType::Homeoffice
+    } else if lower.contains("vacation")
+        || lower.contains("urlaub")
+        || lower.contains("holiday")
+        || lower.contains("ferien")
+    {
+        AbsenceType::Vacation
+    } else if lower.contains("sick")
+        || lower.contains("krank")
+        || lower.contains("illness")
+        || lower.contains("krankenstand")
+    {
+        AbsenceType::Sick
+    } else if lower.contains("training")
+        || lower.contains("schulung")
+        || lower.contains("workshop")
+        || lower.contains("conference")
+        || lower.contains("konferenz")
+    {
+        AbsenceType::Training
+    } else {
+        AbsenceType::Other
+    }
+}
+
+/// Parse a date string from iCal (YYYYMMDD or YYYY-MM-DD) into "YYYY-MM-DD".
+fn parse_ical_date(value: &str) -> Option<String> {
+    let v = value.trim();
+    if v.len() == 8 && v.chars().all(|c| c.is_ascii_digit()) {
+        // YYYYMMDD
+        Some(format!("{}-{}-{}", &v[0..4], &v[4..6], &v[6..8]))
+    } else if v.len() == 10
+        && v.chars().enumerate().all(|(i, c)| {
+            if i == 4 || i == 7 {
+                c == '-'
+            } else {
+                c.is_ascii_digit()
+            }
+        })
+    {
+        Some(v.to_string())
+    } else {
+        None
+    }
+}
+
+/// Parse VEVENT blocks from an iCal string.
+/// Returns a list of `(dtstart, dtend, summary, description)` tuples.
+fn parse_vevents(ical: &str) -> Vec<(String, String, String, Option<String>)> {
+    let mut events = Vec::new();
+    let mut in_event = false;
+    let mut dtstart = String::new();
+    let mut dtend = String::new();
+    let mut summary = String::new();
+    let mut description: Option<String> = None;
+
+    for line in ical.lines() {
+        let line = line.trim_end_matches('\r');
+        match line {
+            "BEGIN:VEVENT" => {
+                in_event = true;
+                dtstart.clear();
+                dtend.clear();
+                summary.clear();
+                description = None;
+            }
+            "END:VEVENT" if in_event => {
+                in_event = false;
+                if !dtstart.is_empty() && !dtend.is_empty() {
+                    events.push((dtstart.clone(), dtend.clone(), summary.clone(), description.clone()));
+                }
+            }
+            _ if in_event => {
+                if let Some(rest) = line.strip_prefix("DTSTART") {
+                    // strip property params: DTSTART;VALUE=DATE:20240101 or DTSTART:20240101
+                    let val = rest.splitn(2, ':').nth(1).unwrap_or("").trim();
+                    if let Some(d) = parse_ical_date(val) {
+                        dtstart = d;
+                    }
+                } else if let Some(rest) = line.strip_prefix("DTEND") {
+                    let val = rest.splitn(2, ':').nth(1).unwrap_or("").trim();
+                    if let Some(d) = parse_ical_date(val) {
+                        dtend = d;
+                    }
+                } else if let Some(val) = line.strip_prefix("SUMMARY:") {
+                    summary = val.trim().to_string();
+                } else if let Some(val) = line.strip_prefix("DESCRIPTION:") {
+                    description = Some(val.trim().to_string());
+                }
+            }
+            _ => {}
+        }
+    }
+
+    events
+}
+
+/// `POST /api/v1/absences/import/ical` — import absences from an iCal body
+#[utoipa::path(
+    post,
+    path = "/api/v1/absences/import/ical",
+    tag = "Absences",
+    summary = "Import absences from iCal",
+    description = "Parse VEVENT blocks from an iCal (RFC 5545) body and create absences for the \
+        authenticated user. DTSTART and DTEND are required; SUMMARY is used to infer the absence type.",
+    request_body(
+        content = String,
+        content_type = "text/calendar",
+        description = "iCal data (VCALENDAR with VEVENT blocks)"
+    ),
+    security(("bearer_auth" = [])),
+    responses(
+        (status = 200, description = "Import completed", body = IcalImportResult),
+        (status = 400, description = "Empty or invalid iCal body"),
+    )
+)]
+pub async fn import_absences_ical(
+    State(state): State<SharedState>,
+    Extension(auth_user): Extension<AuthUser>,
+    body: String,
+) -> (StatusCode, Json<ApiResponse<IcalImportResult>>) {
+    if body.trim().is_empty() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(ApiResponse::error("EMPTY_ICAL", "iCal body is empty")),
+        );
+    }
+
+    let events = parse_vevents(&body);
+    if events.is_empty() {
+        return (
+            StatusCode::OK,
+            Json(ApiResponse::success(IcalImportResult { imported: 0, skipped: 0 })),
+        );
+    }
+
+    let state_guard = state.read().await;
+    let mut imported = 0usize;
+    let mut skipped = 0usize;
+    let now = Utc::now();
+
+    for (dtstart, dtend, summary, desc) in events {
+        if dtstart.is_empty() || dtend.is_empty() {
+            skipped += 1;
+            continue;
+        }
+
+        let absence_type = summary_to_absence_type(&summary);
+        let note = desc.or_else(|| if summary.is_empty() { None } else { Some(summary.clone()) });
+
+        let absence = Absence {
+            id: Uuid::new_v4(),
+            user_id: auth_user.user_id,
+            absence_type,
+            start_date: dtstart,
+            end_date: dtend,
+            note,
+            source: "ical".to_string(),
+            created_at: now,
+        };
+
+        match state_guard.db.save_absence(&absence).await {
+            Ok(_) => imported += 1,
+            Err(e) => {
+                tracing::error!("Failed to save iCal-imported absence: {e}");
+                skipped += 1;
+            }
+        }
+    }
+
+    drop(state_guard);
+
+    (
+        StatusCode::OK,
+        Json(ApiResponse::success(IcalImportResult { imported, skipped })),
+    )
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 // Tests
 // ─────────────────────────────────────────────────────────────────────────────
 
@@ -423,3 +620,4 @@ mod tests {
         assert_eq!(MAX_IMPORT_ROWS, 500);
     }
 }
+

--- a/parkhub-server/src/api/mod.rs
+++ b/parkhub-server/src/api/mod.rs
@@ -75,7 +75,6 @@ mod bookings;
 pub mod branding;
 pub mod credits;
 pub mod export;
-pub mod import;
 pub mod favorites;
 pub mod import;
 pub mod lots;
@@ -104,7 +103,7 @@ use vehicles::{
     upload_vehicle_photo, vehicle_city_codes,
 };
 use export::{admin_export_bookings_csv, admin_export_revenue_csv, admin_export_users_csv};
-use import::import_users_csv;
+use import::{import_absences_ical, import_users_csv};
 use favorites::{add_favorite, list_favorites, remove_favorite};
 use lots::{
     create_lot, create_slot, delete_lot, delete_slot, get_lot, get_lot_pricing, get_lot_slots,
@@ -232,6 +231,9 @@ pub fn create_router(state: SharedState) -> (Router, demo::SharedDemoState) {
         .route("/sw.js", get(pwa::service_worker))
         // Branding logo (public, cached)
         .route("/api/v1/branding/logo", get(branding::get_branding_logo))
+        // System info (public — no auth needed for version/maintenance checks)
+        .route("/api/v1/system/version", get(system_version))
+        .route("/api/v1/system/maintenance", get(system_maintenance))
         // WebSocket real-time events
         .route("/api/v1/ws", get(ws::ws_handler));
 
@@ -381,6 +383,11 @@ pub fn create_router(state: SharedState) -> (Router, demo::SharedDemoState) {
         .route(
             "/api/v1/admin/users/import",
             post(import::import_users_csv),
+        )
+        // Absence iCal import (user-scoped)
+        .route(
+            "/api/v1/absences/import/ical",
+            post(import::import_absences_ical),
         )
         // Absences (user-scoped)
         .route("/api/v1/absences", get(list_absences).post(create_absence))
@@ -966,6 +973,28 @@ pub async fn readiness_check(State(state): State<SharedState>) -> impl IntoRespo
             )
         }
     }
+}
+
+
+/// `GET /api/v1/system/version` — server version information
+pub async fn system_version() -> Json<serde_json::Value> {
+    Json(serde_json::json!({
+        "version": env!("CARGO_PKG_VERSION"),
+        "name": env!("CARGO_PKG_NAME"),
+    }))
+}
+
+/// `GET /api/v1/system/maintenance` — maintenance mode status
+pub async fn system_maintenance(State(state): State<SharedState>) -> Json<serde_json::Value> {
+    let state = state.read().await;
+    let maintenance = match state.db.get_setting("maintenance_mode").await {
+        Ok(Some(v)) => v == "true",
+        _ => false,
+    };
+    Json(serde_json::json!({
+        "maintenance_mode": maintenance,
+        "message": if maintenance { "System is under maintenance" } else { "" }
+    }))
 }
 
 #[utoipa::path(

--- a/parkhub-server/src/api/webhooks.rs
+++ b/parkhub-server/src/api/webhooks.rs
@@ -675,33 +675,49 @@ pub async fn dispatch_webhook_event(
                 .build()
                 .unwrap_or_default();
 
-            match client
-                .post(&url)
-                .header("Content-Type", "application/json")
-                .header("X-Webhook-Signature", &signature)
-                .body(body)
-                .send()
-                .await
-            {
-                Ok(resp) => {
-                    tracing::info!(
-                        "Webhook {} delivered event '{}' to {} — HTTP {}",
-                        webhook.id,
-                        event,
-                        url,
-                        resp.status()
-                    );
+            let max_attempts = 3u32;
+            let mut delay = std::time::Duration::from_secs(2);
+
+            for attempt in 1..=max_attempts {
+                match client
+                    .post(&url)
+                    .header("Content-Type", "application/json")
+                    .header("X-Webhook-Signature", &signature)
+                    .body(body.clone())
+                    .send()
+                    .await
+                {
+                    Ok(resp) if resp.status().is_success() => {
+                        tracing::info!(
+                            "Webhook {} delivered event '{}' to {} — HTTP {} (attempt {}/{})",
+                            webhook.id, event, url, resp.status(), attempt, max_attempts
+                        );
+                        return;
+                    }
+                    Ok(resp) => {
+                        tracing::warn!(
+                            "Webhook {} event '{}' to {} returned HTTP {} (attempt {}/{})",
+                            webhook.id, event, url, resp.status(), attempt, max_attempts
+                        );
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            "Webhook {} failed to deliver '{}' to {}: {} (attempt {}/{})",
+                            webhook.id, event, url, e, attempt, max_attempts
+                        );
+                    }
                 }
-                Err(e) => {
-                    tracing::warn!(
-                        "Webhook {} failed to deliver '{}' to {}: {}",
-                        webhook.id,
-                        event,
-                        url,
-                        e
-                    );
+
+                if attempt < max_attempts {
+                    tokio::time::sleep(delay).await;
+                    delay *= 4; // exponential backoff: 2s, 8s
                 }
             }
+
+            tracing::error!(
+                "Webhook {} delivery exhausted all {} attempts for event '{}' to {}",
+                webhook.id, max_attempts, event, url
+            );
         });
     }
 }


### PR DESCRIPTION
Closes #52
Closes #41
Closes #69

## Summary
- `GET /api/v1/system/version` — server version
- `GET /api/v1/system/maintenance` — maintenance mode status
- `POST /api/v1/absences/import/ical` — parse iCal VEVENT blocks into absences
- Webhook delivery: 3-attempt exponential backoff retry (2s, 8s delays)

## Test plan
- [ ] `cargo build` passes
- [ ] `cargo test` passes