### PR TITLE
fix+feat: system endpoints, iCal import, email retry, write-lock cleanup

### DIFF
--- a/parkhub-server/src/api/import.rs
+++ b/parkhub-server/src/api/import.rs
@@ -619,5 +619,57 @@ mod tests {
     fn test_max_rows_constant() {
         assert_eq!(MAX_IMPORT_ROWS, 500);
     }
+
+    #[test]
+    fn test_parse_ical_date_compact() {
+        assert_eq!(parse_ical_date("20240101"), Some("2024-01-01".to_string()));
+        assert_eq!(parse_ical_date("20241231"), Some("2024-12-31".to_string()));
+    }
+
+    #[test]
+    fn test_parse_ical_date_dashed() {
+        assert_eq!(parse_ical_date("2024-01-01"), Some("2024-01-01".to_string()));
+    }
+
+    #[test]
+    fn test_parse_ical_date_invalid() {
+        assert_eq!(parse_ical_date("not-a-date"), None);
+        assert_eq!(parse_ical_date("2024010"), None);
+    }
+
+    #[test]
+    fn test_summary_to_absence_type() {
+        use parkhub_common::models::AbsenceType;
+        assert!(matches!(summary_to_absence_type("Urlaub"), AbsenceType::Vacation));
+        assert!(matches!(summary_to_absence_type("Homeoffice"), AbsenceType::Homeoffice));
+        assert!(matches!(summary_to_absence_type("remote work"), AbsenceType::Homeoffice));
+        assert!(matches!(summary_to_absence_type("Krank"), AbsenceType::Sick));
+        assert!(matches!(summary_to_absence_type("Training Day"), AbsenceType::Training));
+        assert!(matches!(summary_to_absence_type("something else"), AbsenceType::Other));
+    }
+
+    #[test]
+    fn test_parse_vevents_basic() {
+        let ical = "BEGIN:VCALENDAR\r\nBEGIN:VEVENT\r\nDTSTART;VALUE=DATE:20240101\r\nDTEND;VALUE=DATE:20240115\r\nSUMMARY:Vacation\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n";
+        let events = parse_vevents(ical);
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].0, "2024-01-01");
+        assert_eq!(events[0].1, "2024-01-15");
+        assert_eq!(events[0].2, "Vacation");
+    }
+
+    #[test]
+    fn test_parse_vevents_missing_dates() {
+        let ical = "BEGIN:VEVENT\nSUMMARY:No dates\nEND:VEVENT\n";
+        let events = parse_vevents(ical);
+        assert_eq!(events.len(), 0);
+    }
+
+    #[test]
+    fn test_parse_vevents_multiple() {
+        let ical = "BEGIN:VEVENT\nDTSTART:20240101\nDTEND:20240107\nSUMMARY:First\nEND:VEVENT\nBEGIN:VEVENT\nDTSTART:20240201\nDTEND:20240210\nSUMMARY:Second\nEND:VEVENT\n";
+        let events = parse_vevents(ical);
+        assert_eq!(events.len(), 2);
+    }
 }
 

--- a/parkhub-server/src/api/mod.rs
+++ b/parkhub-server/src/api/mod.rs
@@ -976,7 +976,15 @@ pub async fn readiness_check(State(state): State<SharedState>) -> impl IntoRespo
 }
 
 
-/// `GET /api/v1/system/version` — server version information
+#[utoipa::path(
+    get,
+    path = "/api/v1/system/version",
+    tag = "Health",
+    summary = "Server version information",
+    responses(
+        (status = 200, description = "Version info", body = serde_json::Value),
+    )
+)]
 pub async fn system_version() -> Json<serde_json::Value> {
     Json(serde_json::json!({
         "version": env!("CARGO_PKG_VERSION"),
@@ -984,7 +992,15 @@ pub async fn system_version() -> Json<serde_json::Value> {
     }))
 }
 
-/// `GET /api/v1/system/maintenance` — maintenance mode status
+#[utoipa::path(
+    get,
+    path = "/api/v1/system/maintenance",
+    tag = "Health",
+    summary = "Maintenance mode status",
+    responses(
+        (status = 200, description = "Maintenance status", body = serde_json::Value),
+    )
+)]
 pub async fn system_maintenance(State(state): State<SharedState>) -> Json<serde_json::Value> {
     let state = state.read().await;
     let maintenance = match state.db.get_setting("maintenance_mode").await {
@@ -3846,7 +3862,7 @@ pub async fn admin_update_features(
     Extension(auth_user): Extension<AuthUser>,
     Json(body): Json<UpdateFeaturesRequest>,
 ) -> (StatusCode, Json<ApiResponse<serde_json::Value>>) {
-    let state_guard = state.write().await;
+    let state_guard = state.read().await;
     if let Err((status, msg)) = check_admin(&state_guard, &auth_user).await {
         return (status, Json(ApiResponse::error("FORBIDDEN", msg)));
     }
@@ -6653,7 +6669,7 @@ pub async fn booking_checkin(
     Extension(auth_user): Extension<AuthUser>,
     Path(id): Path<String>,
 ) -> (StatusCode, Json<ApiResponse<Booking>>) {
-    let state_guard = state.write().await;
+    let state_guard = state.read().await;
 
     let mut booking = match state_guard.db.get_booking(&id).await {
         Ok(Some(b)) => b,

--- a/parkhub-server/src/email.rs
+++ b/parkhub-server/src/email.rs
@@ -64,14 +64,6 @@ pub async fn send_email(to: &str, subject: &str, html_body: &str) -> Result<()> 
         return Ok(());
     };
 
-    let message = Message::builder()
-        .from(config.from.parse().context("Invalid SMTP_FROM address")?)
-        .to(to.parse().context("Invalid recipient email address")?)
-        .subject(subject)
-        .header(ContentType::TEXT_HTML)
-        .body(html_body.to_string())
-        .context("Failed to build email message")?;
-
     let mailer: AsyncSmtpTransport<Tokio1Executor> =
         AsyncSmtpTransport::<Tokio1Executor>::starttls_relay(&config.host)
             .context("Failed to create SMTP transport")?
@@ -82,10 +74,36 @@ pub async fn send_email(to: &str, subject: &str, html_body: &str) -> Result<()> 
             ))
             .build();
 
-    mailer.send(message).await.context("Failed to send email")?;
+    const MAX_ATTEMPTS: u32 = 3;
+    let mut delay = std::time::Duration::from_millis(200);
 
-    info!(to = %to, subject = %subject, "Email sent successfully");
-    Ok(())
+    for attempt in 1..=MAX_ATTEMPTS {
+        // Rebuild message each attempt — lettre Message is not Clone
+        let msg = Message::builder()
+            .from(config.from.parse().context("Invalid SMTP_FROM address")?)
+            .to(to.parse().context("Invalid recipient email address")?)
+            .subject(subject)
+            .header(ContentType::TEXT_HTML)
+            .body(html_body.to_string())
+            .context("Failed to build email message")?;
+
+        match mailer.send(msg).await {
+            Ok(_) => {
+                info!(to = %to, subject = %subject, attempt, "Email sent successfully");
+                return Ok(());
+            }
+            Err(e) if attempt < MAX_ATTEMPTS => {
+                warn!(to = %to, subject = %subject, attempt, error = %e, "Email delivery failed, retrying");
+                tokio::time::sleep(delay).await;
+                delay *= 2;
+            }
+            Err(e) => {
+                return Err(anyhow::anyhow!("Failed to send email after {MAX_ATTEMPTS} attempts: {e}"));
+            }
+        }
+    }
+
+    unreachable!()
 }
 
 /// Build a booking confirmation email body.

--- a/parkhub-server/src/main.rs
+++ b/parkhub-server/src/main.rs
@@ -63,7 +63,16 @@ use tray_icon::{
     Icon, TrayIconBuilder, TrayIconEvent,
 };
 
-/// Application state shared across handlers
+/// Application state shared across handlers via `Arc<RwLock<AppState>>`.
+///
+/// ## Locking strategy
+/// - **Read lock** (`state.read().await`): all handlers that only query or write through
+///   `Database`'s own internal locking (`Arc<RwLock<RedbDatabase>>`).
+/// - **Write lock** (`state.write().await`): only handlers that require an *atomic
+///   check-and-set* across multiple DB operations where no other booking can interleave:
+///   `create_booking`, `cancel_booking`, `quick_book`, `update_swap_request`, `admin_reset`.
+/// - All other mutations (features, checkin, credits, webhooks, etc.) use read locks
+///   because `Database` handles its own concurrency internally.
 pub struct AppState {
     pub config: ServerConfig,
     pub db: Database,

--- a/parkhub-server/src/openapi.rs
+++ b/parkhub-server/src/openapi.rs
@@ -106,6 +106,7 @@ use crate::{
             UpdateQuotaRequest,
             crate::api::import::ImportResult,
             crate::api::import::ImportError,
+            crate::api::import::IcalImportResult,
 
             // Credits
             AdminGrantCreditsRequest,
@@ -239,6 +240,7 @@ use crate::{
         crate::api::export::admin_export_revenue_csv,
         // Import
         crate::api::import::import_users_csv,
+        crate::api::import::import_absences_ical,
 
         // Health & Discovery (mod.rs)
         crate::api::health_check,
@@ -296,6 +298,10 @@ use crate::{
         crate::api::get_impressum_admin,
         crate::api::update_impressum,
         crate::api::admin_list_announcements,
+
+        // System (mod.rs)
+        crate::api::system_version,
+        crate::api::system_maintenance,
 
         // Public (mod.rs)
         crate::api::get_impressum,


### PR DESCRIPTION
## Summary

- **Fix: duplicate `pub mod import;`** in `api/mod.rs` — prevented compilation
- **feat(system)**: `GET /api/v1/system/version` and `GET /api/v1/system/maintenance` — public endpoints with utoipa docs (closes #52)
- **feat(ical)**: `POST /api/v1/absences/import/ical` — parse VEVENT blocks into absences, map SUMMARY to `AbsenceType`, unit tests for parser functions (closes #41)
- **fix(reliability)**: `send_email` now retries 3× with 200ms/400ms exponential backoff on SMTP failure (closes #69)
- **perf(locks)**: `admin_update_features` and `booking_checkin` downgraded from write to read lock — `Database` has its own internal `RwLock` (closes #64)
- **docs**: Document AppState locking strategy in `main.rs`
- **openapi**: Register all new endpoints in `ApiDoc`

## Test plan
- [ ] CI passes (cargo check + clippy + tests)
- [ ] `GET /api/v1/system/version` returns `{"version": "...", "name": "..."}`
- [ ] `GET /api/v1/system/maintenance` returns `{"maintenance_mode": false, "message": ""}`
- [ ] `POST /api/v1/absences/import/ical` with VEVENT body creates absences
- [ ] iCal unit tests pass (`cargo test -p parkhub-server import::tests`)