### PR TITLE
ci: add MSRV check (1.82) and Docker build test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,33 @@ jobs:
         run: |
           cargo test --package parkhub-common --doc
 
+  msrv:
+    name: MSRV Check (1.82)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust 1.82
+        uses: dtolnay/rust-toolchain@1.82
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+
+      - name: Create placeholder web dist
+        run: mkdir -p parkhub-web/dist && echo '<!doctype html><html><body></body></html>' > parkhub-web/dist/index.html
+
+      - name: Verify MSRV compiles
+        run: cargo check --package parkhub-server --no-default-features --features headless
+
+  docker:
+    name: Docker Build Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build Docker image
+        run: docker build --target builder -t parkhub-test .
+
   frontend:
     name: Frontend Build & Test
     runs-on: ubuntu-latest
@@ -125,7 +152,7 @@ jobs:
   ci:
     name: CI
     if: always()
-    needs: [check, fmt, clippy, test, frontend]
+    needs: [check, fmt, clippy, test, msrv, docker, frontend]
     runs-on: ubuntu-latest
     steps:
       - name: Check results
@@ -144,6 +171,14 @@ jobs:
           fi
           if [[ "${{ needs.test.result }}" != "success" ]]; then
             echo "test failed: ${{ needs.test.result }}"
+            exit 1
+          fi
+          if [[ "${{ needs.msrv.result }}" != "success" ]]; then
+            echo "msrv failed: ${{ needs.msrv.result }}"
+            exit 1
+          fi
+          if [[ "${{ needs.docker.result }}" != "success" ]]; then
+            echo "docker failed: ${{ needs.docker.result }}"
             exit 1
           fi
           if [[ "${{ needs.frontend.result }}" != "success" ]]; then

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ resolver = "2"
 [workspace.package]
 version = "1.9.0"
 edition = "2021"
+rust-version = "1.82"
 authors = ["nash87"]
 license = "MIT"
 repository = "https://github.com/nash87/parkhub-rust"


### PR DESCRIPTION
## Summary
- Set `rust-version = "1.82"` in workspace Cargo.toml as MSRV
- Add CI job to verify MSRV compiles using Rust 1.82
- Add CI job to test Docker image build (builder stage only for speed)
- Wire both into the CI gate job

## Test plan
- [x] CI workflow syntax validated
- [x] MSRV version chosen based on current dependency requirements

Closes #107, closes #110