### PR TITLE
fix(ci): bump MSRV from 1.82 to 1.85

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,13 +106,13 @@ jobs:
           cargo test --package parkhub-common --doc
 
   msrv:
-    name: MSRV Check (1.82)
+    name: MSRV Check (1.85)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Rust 1.82
-        uses: dtolnay/rust-toolchain@1.82
+      - name: Install Rust 1.85
+        uses: dtolnay/rust-toolchain@1.85
 
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ resolver = "2"
 [workspace.package]
 version = "1.9.0"
 edition = "2021"
-rust-version = "1.82"
+rust-version = "1.85"
 authors = ["nash87"]
 license = "MIT"
 repository = "https://github.com/nash87/parkhub-rust"


### PR DESCRIPTION
time-core 0.1.8 requires Rust >= 1.85. Fixes MSRV CI job failure.