### PR TITLE
fix(testing): un-ignore max_bookings_per_day enforcement test

### DIFF
--- a/parkhub-server/src/integration_tests.rs
+++ b/parkhub-server/src/integration_tests.rs
@@ -1312,7 +1312,6 @@ async fn test_get_booking_invoice_returns_correct_amounts() {
 }
 
 #[tokio::test]
-#[ignore = "max_bookings_per_day enforcement needs investigation — setting is applied but second booking still succeeds"]
 async fn test_booking_max_per_day_limit_enforced() {
     let state = test_state().await;
     let admin_tok = admin_token_it(state.clone()).await;


### PR DESCRIPTION
Fixes #103

The `test_booking_max_per_day_limit_enforced` test was marked `#[ignore]` because it was believed the enforcement logic was broken. Investigation shows the setting and handler logic work correctly — `list_bookings_by_user` returns the user's same-day bookings, and the handler properly rejects new bookings when `max_bookings_per_day` is reached.

Removed the `#[ignore]` annotation so the test runs in CI.