### PR TITLE
fix(security): invalidate sessions on password change

### DIFF
--- a/parkhub-server/src/api/mod.rs
+++ b/parkhub-server/src/api/mod.rs
@@ -4220,6 +4220,24 @@ pub async fn change_password(
         );
     }
 
+    // Invalidate all existing sessions for this user — a password change must
+    // force re-authentication on every device (issue #116).
+    if let Err(e) = state_guard
+        .db
+        .delete_sessions_by_user(auth_user.user_id)
+        .await
+    {
+        tracing::warn!(
+            user_id = %auth_user.user_id,
+            error = %e,
+            "Failed to invalidate sessions after password change"
+        );
+    }
+
+    crate::audit::AuditEntry::new(crate::audit::AuditEventType::PasswordChanged)
+        .user(auth_user.user_id, &updated_user.username)
+        .log();
+
     (StatusCode::OK, Json(ApiResponse::success(())))
 }
 


### PR DESCRIPTION
Fixes #116

When a user changes their password via `PATCH /api/v1/users/me/password`, all existing sessions are now invalidated via `delete_sessions_by_user`. This forces re-authentication on every device, matching the existing behavior in the `reset_password` handler and preventing session hijacking when a compromised password is changed.

Also adds an audit log entry for password changes.