### PR TITLE
fix(security): add input length limits on key endpoints

### DIFF
--- a/parkhub-server/src/api/auth.rs
+++ b/parkhub-server/src/api/auth.rs
@@ -66,6 +66,17 @@ pub async fn login(
     State(state): State<SharedState>,
     Json(request): Json<LoginRequest>,
 ) -> (StatusCode, Json<ApiResponse<LoginResponse>>) {
+    // ── Input length validation (issue #115) ────────────────────────────────
+    if request.username.len() > 254 {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(ApiResponse::error(
+                "INVALID_INPUT",
+                "Username/email must be at most 254 characters",
+            )),
+        );
+    }
+
     let state_guard = state.read().await;
 
     // Find user by username
@@ -198,6 +209,26 @@ pub async fn register(
     State(state): State<SharedState>,
     Json(request): Json<RegisterRequest>,
 ) -> (StatusCode, Json<ApiResponse<LoginResponse>>) {
+    // ── Input length validation (issue #115) ────────────────────────────────
+    if request.email.len() > 254 {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(ApiResponse::error(
+                "INVALID_INPUT",
+                "Email must be at most 254 characters",
+            )),
+        );
+    }
+    if request.name.len() > 100 {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(ApiResponse::error(
+                "INVALID_INPUT",
+                "Name must be at most 100 characters",
+            )),
+        );
+    }
+
     let state_guard = state.read().await;
 
     // Enforce allow_self_registration setting

--- a/parkhub-server/src/api/mod.rs
+++ b/parkhub-server/src/api/mod.rs
@@ -1461,6 +1461,30 @@ pub async fn update_current_user(
         }
     };
 
+    // ── Input length validation (issue #115) ────────────────────────────────
+    if let Some(ref name) = req.name {
+        if name.len() > 100 {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(ApiResponse::error(
+                    "INVALID_INPUT",
+                    "Name must be at most 100 characters",
+                )),
+            );
+        }
+    }
+    if let Some(ref phone) = req.phone {
+        if phone.len() > 20 {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(ApiResponse::error(
+                    "INVALID_INPUT",
+                    "Phone number must be at most 20 characters",
+                )),
+            );
+        }
+    }
+
     // Apply only the fields provided in the request
     if let Some(name) = req.name {
         user.name = name;
@@ -1620,6 +1644,27 @@ pub async fn create_booking(
     Extension(auth_user): Extension<AuthUser>,
     Json(req): Json<CreateBookingRequest>,
 ) -> (StatusCode, Json<ApiResponse<Booking>>) {
+    // ── Input length validation (issue #115) ────────────────────────────────
+    if req.license_plate.len() > 20 {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(ApiResponse::error(
+                "INVALID_INPUT",
+                "License plate must be at most 20 characters",
+            )),
+        );
+    }
+    if let Some(ref notes) = req.notes {
+        if notes.len() > 500 {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(ApiResponse::error(
+                    "INVALID_INPUT",
+                    "Notes must be at most 500 characters",
+                )),
+            );
+        }
+    }
     // ── Phase 1: reads under a read lock ──────────────────────────────────────
     // Collect all data needed to validate and price the booking.  A read lock
     // allows concurrent readers; we release it before any mutation.


### PR DESCRIPTION
Fixes #115

Adds max-length validation to string inputs on several endpoints:
- `POST /auth/login` — username/email capped at 254 chars
- `POST /auth/register` — email at 254, name at 100
- `PUT /users/me` — name at 100, phone at 20
- `POST /bookings` — license_plate at 20, notes at 500

Returns 400 with clear error messages when limits are exceeded.