### PR TITLE
fix(security): remove unused rustls-pemfile dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,6 @@ reqwest = { version = "0.12", features = ["json", "rustls-tls"] }  # 0.13 exists
 # Security
 rcgen = "0.14"  # updated from 0.13
 rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12"] }
-rustls-pemfile = "2"
 argon2 = { version = "0.5", features = ["std", "rand"] }  # 0.6 is RC only
 
 # Network discovery

--- a/deny.toml
+++ b/deny.toml
@@ -5,7 +5,6 @@
 # Ignore unmaintained/vulnerable transitive dependencies from Slint GUI framework
 # These come from GTK3 bindings and are only used in the optional GUI feature
 ignore = [
-    "RUSTSEC-2025-0134", # rustls-pemfile unmaintained
     "RUSTSEC-2024-0412", # gtk-rs GTK3 unmaintained (atk)
     "RUSTSEC-2024-0413", # gtk-rs GTK3 unmaintained (gdk)
     "RUSTSEC-2024-0415", # gtk-rs GTK3 unmaintained (gdk-pixbuf)

--- a/parkhub-client/Cargo.toml
+++ b/parkhub-client/Cargo.toml
@@ -52,7 +52,6 @@ mdns-sd.workspace = true
 
 # TLS certificate handling
 rustls.workspace = true
-rustls-pemfile.workspace = true
 
 # Random for mock data (temporary)
 rand = "0.9"  # updated from 0.8

--- a/parkhub-server/Cargo.toml
+++ b/parkhub-server/Cargo.toml
@@ -44,7 +44,6 @@ uuid.workspace = true
 # Security - TLS certificates
 rcgen.workspace = true
 rustls.workspace = true
-rustls-pemfile.workspace = true
 argon2 = { version = "0.5", features = ["std", "rand"] }
 rand_core = { version = "0.9", features = ["os_rng"] }  # updated from 0.6; getrandom renamed to os_rng in 0.9
 axum-server = { version = "0.8", features = ["tls-rustls"] }  # updated from 0.7 (matches axum 0.8)


### PR DESCRIPTION
Fixes #102

Removed `rustls-pemfile` from workspace, server, and client Cargo.toml since it was never used in source code (TLS PEM loading is handled internally by axum-server). Also removed the RUSTSEC-2025-0134 advisory ignore from deny.toml.