### PR TITLE
fix(security): use constant-time comparison for metrics token

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4928,7 +4928,6 @@ dependencies = [
  "raw-window-handle",
  "reqwest",
  "rustls",
- "rustls-pemfile",
  "serde",
  "serde_json",
  "slint",
@@ -4994,12 +4993,12 @@ dependencies = [
  "ring",
  "rust-embed",
  "rustls",
- "rustls-pemfile",
  "serde",
  "serde_json",
  "sha2",
  "slint",
  "slint-build",
+ "subtle",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -6131,15 +6130,6 @@ dependencies = [
  "rustls-pki-types",
  "schannel",
  "security-framework",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
 ]
 
 [[package]]

--- a/parkhub-server/Cargo.toml
+++ b/parkhub-server/Cargo.toml
@@ -116,6 +116,7 @@ mime_guess = "2.0.5"
 # QR code generation
 qrcode = "0.14"
 image = { version = "0.25", default-features = false, features = ["png"] }
+subtle = "2.6.1"
 
 [build-dependencies]
 slint-build = { version = "1.15", optional = true }  # updated from 1.14

--- a/parkhub-server/src/api/mod.rs
+++ b/parkhub-server/src/api/mod.rs
@@ -946,7 +946,11 @@ pub fn create_router(state: SharedState) -> (Router, demo::SharedDemoState) {
                             .get(header::AUTHORIZATION)
                             .and_then(|v| v.to_str().ok())
                             .and_then(|v| v.strip_prefix("Bearer "))
-                            .is_some_and(|token| token == expected);
+                            .is_some_and(|token| {
+                                // Constant-time comparison to prevent timing attacks (issue #114)
+                                use subtle::ConstantTimeEq;
+                                token.as_bytes().ct_eq(expected.as_bytes()).into()
+                            });
                         if !authorized {
                             return (
                                 StatusCode::UNAUTHORIZED,


### PR DESCRIPTION
Fixes #114

Replaced `token == expected` with `subtle::ConstantTimeEq` for the METRICS_TOKEN comparison to prevent timing side-channel attacks.