### PR TITLE
chore: GitOps polish — docs, security, templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/security_vulnerability.yml
+++ b/.github/ISSUE_TEMPLATE/security_vulnerability.yml
@@ -1,0 +1,46 @@
+name: Security Vulnerability
+description: Report a security vulnerability (use GitHub Security Advisories for private disclosure)
+labels: ["security"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        **STOP** — If this is a security vulnerability that could be exploited, please use
+        [GitHub Security Advisories](https://github.com/nash87/parkhub-rust/security/advisories/new)
+        instead. This form creates a **public** issue.
+
+        Use this form only for security-related improvements that are not exploitable vulnerabilities
+        (e.g., suggesting a stronger default, adding a missing security header, improving documentation).
+  - type: textarea
+    id: description
+    attributes:
+      label: Security concern
+      placeholder: |
+        Describe the security improvement or concern.
+        What is the current behavior? What should it be?
+    validations:
+      required: true
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity assessment
+      options:
+        - Low (hardening improvement)
+        - Medium (defense-in-depth gap)
+        - High (potential for exploitation)
+    validations:
+      required: true
+  - type: textarea
+    id: mitigation
+    attributes:
+      label: Suggested mitigation
+      placeholder: "How would you fix or improve this?"
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Confirmation
+      options:
+        - label: This is NOT an exploitable vulnerability (those should use Security Advisories)
+          required: true
+        - label: I checked existing issues and this has not been reported before
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,13 +11,20 @@
 
 ## Testing
 - [ ] I tested locally with Docker Compose (`docker compose up -d`)
-- [ ] I ran the test suite (`cargo test`)
-- [ ] I ran Clippy (`cargo clippy -- -D warnings`)
+- [ ] I ran the test suite (`cargo test --workspace`)
+- [ ] I ran Clippy (`cargo clippy --workspace -- -D warnings`)
+- [ ] I ran frontend tests (`cd parkhub-web && npx vitest run`)
 - [ ] I checked GDPR compliance impact (does this change affect data handling, storage, or erasure?)
 
+## Security checklist
+- [ ] No secrets, credentials, or API keys committed
+- [ ] New endpoints have appropriate auth guards and rate limiting
+- [ ] User input is validated before use
+- [ ] No new `unsafe` blocks without justification
+
 ## Checklist
-- [ ] Code follows project style (Rust fmt, no Clippy warnings)
-- [ ] No secrets or credentials committed
+- [ ] Code follows project style (Rust fmt, no Clippy warnings, pedantic + nursery)
 - [ ] Documentation updated if needed (docs/, README.md)
 - [ ] CHANGELOG.md entry added
 - [ ] New endpoints are covered by OpenAPI annotations (`#[utoipa::path]`)
+- [ ] Feature-gated behind appropriate `mod-*` feature flag (if applicable)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,56 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [2.2.0] - 2026-03-22
+
+### Added
+- **Glass morphism UI**: Bento grid dashboard with frosted-glass cards, animated counters, and modern gradients
+- **2FA/TOTP authentication**: QR code enrollment via `totp-rs`, backup codes, per-account enable/disable
+- **Accessibility score 100**: Full ARIA compliance, contrast fixes, confirm dialogs replacing `window.confirm`
+- **CI badges and GitOps polish**: README overhaul, SECURITY.md, issue/PR templates, CHANGELOG in Keep a Changelog format
+
+### Changed
+- Bumped version to 2.2.0
+- README badges switched from for-the-badge to flat-square style with CI status badge
+- Added Security link to README navigation
+
+---
+
+## [2.1.0] - 2026-03-22
+
+### Added
+- **28 Cargo feature flags**: Full modularity system — build only the modules you need (`mod-bookings`, `mod-vehicles`, `mod-absences`, etc.)
+- **Headless mode**: `--no-default-features --features headless` for pure MIT server builds without GUI dependencies
+- **Module documentation**: Feature flag table in README with build examples
+
+### Changed
+- Workspace Rust version updated to 1.85
+- Axum upgraded from 0.7 to 0.8
+- `rand` upgraded from 0.8 to 0.9
+
+---
+
+## [2.0.0] - 2026-03-22
+
+### Added
+- **Full modularity system**: 28 feature-gated modules for compile-time customization
+- **Smart slot recommendations**: Heuristic scoring engine (slot frequency, lot frequency, features, proximity) — top 5 returned
+- **Community translation management**: Proposal submission, up/down voting, admin review with comments
+- **Runtime translation overrides**: Approved translations hot-loaded into i18n at app startup
+- **Favorites UI**: Full view for managing pinned parking slots with live availability status
+- **Dashboard analytics**: 7-day booking activity bar chart with real booking data
+- **DataTable CSV export**: Download any data table as CSV with proper cell escaping
+- **Demo reset tracking**: `last_reset_at`, `next_scheduled_reset`, `reset_in_progress` in status API
+
+### Changed
+- Major version bump to reflect the modularity system and feature flag architecture
+- Clippy pedantic and nursery lints enforced with zero warnings
+
+### Tests
+- **505 Rust + 401 Frontend + 484 PHP** = 1,390 total tests
+
+---
+
 ## [1.9.0] - 2026-03-21
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.9.0"
+version = "2.2.0"
 edition = "2021"
 rust-version = "1.85"
 authors = ["nash87"]

--- a/README.md
+++ b/README.md
@@ -5,14 +5,15 @@
 <h1 align="center">ParkHub — Self-Hosted Parking Management</h1>
 
 <p align="center">
-  <a href="https://www.rust-lang.org/"><img src="https://img.shields.io/badge/Rust-1.84%2B-orange.svg?style=for-the-badge&logo=rust&logoColor=white" alt="Rust 1.84+"></a>
-  <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-blue.svg?style=for-the-badge" alt="MIT License"></a>
-  <a href="CHANGELOG.md"><img src="https://img.shields.io/badge/Release-v1.9.0-brightgreen.svg?style=for-the-badge" alt="v1.9.0"></a>
-  <a href="https://react.dev/"><img src="https://img.shields.io/badge/React-19-61DAFB.svg?style=for-the-badge&logo=react&logoColor=black" alt="React 19"></a>
-  <a href="docs/GDPR.md"><img src="https://img.shields.io/badge/DSGVO-konform-green.svg?style=for-the-badge" alt="GDPR Compliant"></a>
-  <a href="COMPLIANCE-REPORT.md"><img src="https://img.shields.io/badge/Compliance-Audited-brightgreen.svg?style=for-the-badge" alt="Compliance Audited"></a>
-  <a href="docs/SECURITY.md"><img src="https://img.shields.io/badge/OWASP-Audited-green.svg?style=for-the-badge" alt="OWASP Audited"></a>
-  <a href="docker-compose.yml"><img src="https://img.shields.io/badge/Docker-ready-2496ED.svg?style=for-the-badge&logo=docker&logoColor=white" alt="Docker Ready"></a>
+  <a href="https://github.com/nash87/parkhub-rust/actions/workflows/ci.yml"><img src="https://github.com/nash87/parkhub-rust/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
+  <a href="CHANGELOG.md"><img src="https://img.shields.io/badge/Release-v2.2.0-brightgreen.svg?style=flat-square" alt="v2.2.0"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square" alt="MIT License"></a>
+  <a href="https://www.rust-lang.org/"><img src="https://img.shields.io/badge/Rust-1.85%2B-orange.svg?style=flat-square&logo=rust&logoColor=white" alt="Rust 1.85+"></a>
+  <a href="https://react.dev/"><img src="https://img.shields.io/badge/React-19-61DAFB.svg?style=flat-square&logo=react&logoColor=black" alt="React 19"></a>
+  <img src="https://img.shields.io/badge/Tests-1390%2B-success.svg?style=flat-square" alt="1390+ tests">
+  <a href="docs/GDPR.md"><img src="https://img.shields.io/badge/DSGVO-konform-green.svg?style=flat-square" alt="GDPR Compliant"></a>
+  <a href="COMPLIANCE-REPORT.md"><img src="https://img.shields.io/badge/Compliance-Audited-brightgreen.svg?style=flat-square" alt="Compliance Audited"></a>
+  <a href="docker-compose.yml"><img src="https://img.shields.io/badge/Docker-ready-2496ED.svg?style=flat-square&logo=docker&logoColor=white" alt="Docker Ready"></a>
 </p>
 
 <p align="center">
@@ -27,20 +28,23 @@
   <a href="docs/INSTALLATION.md">Installation</a> &nbsp;·&nbsp;
   <a href="docs/API.md">API Docs</a> &nbsp;·&nbsp;
   <a href="docs/GDPR.md">GDPR Guide</a> &nbsp;·&nbsp;
-  <a href="CHANGELOG.md">Changelog</a>
+  <a href="CHANGELOG.md">Changelog</a> &nbsp;·&nbsp;
+  <a href="SECURITY.md">Security</a>
 </p>
 
 ---
 
 ## Why Self-Hosted?
 
-Most parking management SaaS costs €200–2,000/month, stores your data on US cloud infrastructure, and requires a data processing agreement just to get started.
+Most parking management SaaS costs 200--2,000 EUR/month, stores your data on US cloud infrastructure, and requires a data processing agreement just to get started.
 
-ParkHub is different. It runs on your server — a Raspberry Pi, a VPS, or your company network. Your data never leaves your premises, which means **no GDPR processor agreement needed**, no CLOUD Act exposure, and no monthly fees. The entire source code is MIT-licensed and auditable.
+ParkHub is different. It runs on your server -- a Raspberry Pi, a VPS, or your company network. Your data never leaves your premises, which means **no GDPR processor agreement needed**, no CLOUD Act exposure, and no monthly fees. The entire source code is MIT-licensed and auditable.
 
 ---
 
 ## Quick Start
+
+### Docker (recommended)
 
 ```bash
 git clone https://github.com/nash87/parkhub-rust.git && cd parkhub-rust
@@ -48,38 +52,50 @@ docker compose up -d
 # Open http://localhost:8080 — admin password is in the logs
 ```
 
-The first build takes 5–10 minutes (compiles Rust + React from source). After that, starts are instant.
+The first build takes 5--10 minutes (compiles Rust + React from source). After that, starts are instant.
 
-For a **single binary** without Docker:
+### Native binary
 
 ```bash
 cargo build --release --package parkhub-server --no-default-features --features headless
 ./target/release/parkhub-server --headless --unattended --port 8080
 ```
 
-**[Live Demo →](https://parkhub-rust-demo.onrender.com)** &nbsp; Login: `admin@parkhub.test` / `demo` &nbsp; (auto-resets every 6 hours)
+**[Live Demo](https://parkhub-rust-demo.onrender.com)** | Login: `admin@parkhub.test` / `demo` | (auto-resets every 6 hours)
 
 ---
 
-## What You Get
+## Features
 
-**Booking System** — Full booking lifecycle from lot selection to QR code parking pass. One-tap quick booking, recurring reservations, guest bookings without accounts, swap requests between users, waitlists for full lots, and automatic no-show release. Every booking sends email confirmations and cancellation notices via SMTP.
+### v2.2.0 Highlights
 
-**Smart Recommendations** — A heuristic scoring engine learns from usage patterns (slot frequency, lot proximity, feature preferences) and suggests the best available slots. Users can pin favorites for one-tap access.
+- **Glass morphism UI** -- Bento grid dashboard with animated counters and frosted-glass cards
+- **2FA/TOTP authentication** -- QR code enrollment, backup codes, per-account enable/disable
+- **28 Cargo feature flags** -- Build only the modules you need (see [Module System](#module-system))
+- **Smart recommendations** -- Heuristic scoring engine that learns from usage patterns
+- **Community translations** -- 10 languages with proposal voting and admin review
 
-**Parking Lot Management** — Create multiple lots with per-floor visual slot layouts. The interactive grid editor lets admins design layouts with drag-and-drop, while users see real-time occupancy with color-coded availability.
+### Core
 
-**User & Access Control** — Four-tier RBAC (user, premium, admin, superadmin) with JWT session auth, token refresh, and self-service password reset. A credits system supports monthly quotas with per-booking deduction. Absence tracking covers homeoffice, vacation, sick leave, and team overview.
+- **Full booking lifecycle** -- One-tap quick booking, recurring reservations, guest bookings, swap requests, waitlists, automatic no-show release
+- **Visual lot editor** -- Per-floor interactive grid layouts with drag-and-drop, real-time occupancy, color-coded availability
+- **4-tier RBAC** -- User, premium, admin, superadmin with JWT session auth and token refresh
+- **Credits system** -- Monthly quotas with per-booking deduction
+- **Absence tracking** -- Homeoffice, vacation, sick leave with team overview and iCal import
+- **Admin dashboard** -- Occupancy stats, 7-day booking charts, weekday/hour heatmaps, CSV export, announcements
+- **10 languages** -- EN, DE, FR, ES, IT, PT, TR, PL, JA, ZH with runtime hot-loading
+- **GDPR & German legal compliance** -- Art. 15/17, DDG SS5, 7 legal templates, audited for DSGVO/TTDSG/UK GDPR/CCPA/nDSG
+- **Observability** -- Prometheus metrics, OpenAPI 3.0 with 125+ endpoints at `/swagger-ui`, K8s health probes, structured tracing
 
-**Admin Dashboard** — Occupancy statistics, 7-day booking activity charts, heatmaps by weekday and hour, CSV export for bookings/users/revenue, announcements, and a full settings panel for branding, booking rules, and use-case theming (company, residential, shared parking, rental).
+### Security
 
-**Internationalization** — Ships with 10 languages (EN, DE, FR, ES, IT, PT, TR, PL, JA, ZH). Community translation proposals with up/down voting and admin review. Approved translations are hot-loaded at runtime without restarts.
-
-**GDPR & German Legal Compliance** — Art. 15 data export, Art. 17 erasure (PII anonymized, bookings retained per §147 AO), DDG §5 Impressum, and 7 ready-to-use legal templates (Impressum, Datenschutzerklärung, AGB, AVV, Widerrufsbelehrung, Cookie-Policy, VVt). Audited for DSGVO, TTDSG, UK GDPR, CCPA, and nDSG. [Full Compliance Report →](COMPLIANCE-REPORT.md)
-
-**Security** — Argon2id password hashing, optional AES-256-GCM database encryption at rest, auto-generated TLS 1.3 certificates, IP-based rate limiting (5 login/min, 100 req/s global), CSP + security headers, 4 MiB request size limit, and a complete audit log. [Security Audit →](SECURITY-AUDIT.md)
-
-**Observability** — Prometheus metrics at `/metrics`, OpenAPI 3.0 docs at `/swagger-ui` with 125+ annotated endpoints, Kubernetes health probes (`/health/live`, `/health/ready`), and structured logging via `tracing`.
+- Argon2id password hashing
+- Optional AES-256-GCM database encryption at rest
+- Auto-generated TLS 1.3 certificates (rustls, no OpenSSL)
+- IP-based rate limiting (5 login/min, 100 req/s global)
+- CSP + HSTS + security headers
+- 4 MiB request body limit
+- Complete audit log
 
 ---
 
@@ -113,23 +129,66 @@ cargo build --release --package parkhub-server --no-default-features --features 
                           Single Rust binary (~15 MB)
 ```
 
-The entire stack — API server, database, and frontend — compiles into a **single binary**. No PostgreSQL, no Redis, no nginx. Just download and run. The React frontend is embedded via `rust-embed` and served as static files.
+The entire stack -- API server, database, and frontend -- compiles into a **single binary**. No PostgreSQL, no Redis, no nginx. Just download and run. The React frontend is embedded via `rust-embed` and served as static files.
 
 For LAN deployments, mDNS autodiscovery lets clients find the server without any DNS configuration. A desktop client (Slint UI) with system tray integration is available for Windows and macOS.
 
 ---
 
+## Module System
+
+ParkHub uses Cargo feature flags to let you build only the modules you need. The `full` feature enables everything. Use `--no-default-features --features headless` for a minimal server build, then add individual modules as needed.
+
+| Flag | Description |
+|------|-------------|
+| `mod-bookings` | Core booking lifecycle (create, cancel, check-in) |
+| `mod-vehicles` | Vehicle registry with licence plate management |
+| `mod-absences` | Homeoffice, vacation, sick leave tracking |
+| `mod-branding` | Custom logo, colors, company name |
+| `mod-import` | Bulk user import (CSV, up to 500 users) |
+| `mod-qr` | QR code generation for bookings and slots |
+| `mod-pwa` | Progressive Web App (service worker, manifest) |
+| `mod-payments` | Credits and payment processing |
+| `mod-webhooks` | Outbound webhooks with HMAC signing |
+| `mod-notifications` | In-app notification system |
+| `mod-announcements` | Admin announcements with expiry |
+| `mod-recurring` | Recurring booking patterns |
+| `mod-guest` | Guest bookings without user accounts |
+| `mod-calendar` | Calendar view and iCal export |
+| `mod-team` | Team overview and today's status |
+| `mod-settings` | Application settings management |
+| `mod-jobs` | Background job processing |
+| `mod-swap` | Booking swap requests between users |
+| `mod-waitlist` | Waitlist for fully occupied lots |
+| `mod-zones` | Per-lot zone management |
+| `mod-credits` | Monthly credit quotas |
+| `mod-email` | SMTP email notifications |
+| `mod-export` | CSV data export |
+| `mod-favorites` | Favourite slot pinning |
+| `mod-push` | Web Push notifications (VAPID) |
+| `mod-recommendations` | Smart slot recommendation engine |
+| `mod-translations` | Community translation management |
+| `mod-social` | Social features |
+| `gui` | Slint desktop GUI with system tray |
+| `headless` | Server-only mode (no GUI dependencies) |
+
+Example: build a minimal server with just bookings and email:
+
+```bash
+cargo build --release -p parkhub-server --no-default-features \
+  --features "headless,mod-bookings,mod-email"
+```
+
+---
+
 ## Deployment
 
-ParkHub runs anywhere — from a Raspberry Pi to Kubernetes.
+ParkHub runs anywhere -- from a Raspberry Pi to Kubernetes.
 
-**Docker Compose** (recommended) — `docker compose up -d` and you're done. Works on any Linux, macOS, or Windows machine with Docker installed.
-
-**Kubernetes** — Health probes, Prometheus metrics, and a Helm-ready manifest. Designed for GitOps with Flux CD.
-
-**Bare Metal** — Download the single binary, run it. No runtime dependencies. Works on x86_64 and ARM64.
-
-**Windows** — GUI installer with system tray icon and setup wizard.
+- **Docker Compose** (recommended) -- `docker compose up -d` and you're done
+- **Kubernetes** -- Health probes, Prometheus metrics, Helm-ready manifests, designed for GitOps with Flux CD
+- **Bare Metal** -- Download the single binary, run it. No runtime dependencies. x86_64 and ARM64
+- **Windows** -- GUI installer with system tray icon and setup wizard
 
 See [docs/INSTALLATION.md](docs/INSTALLATION.md) for detailed guides.
 
@@ -137,7 +196,7 @@ See [docs/INSTALLATION.md](docs/INSTALLATION.md) for detailed guides.
 
 ## Testing
 
-**1,390 tests** across Rust backend (505), React frontend (401), and PHP sibling edition (484), plus Playwright E2E and Maestro mobile flows. Clippy runs in pedantic + nursery mode with zero warnings.
+**1,390+ tests** across Rust backend (505), React frontend (401), and PHP sibling edition (484), plus Playwright E2E and Maestro mobile flows. Clippy runs in pedantic + nursery mode with zero warnings.
 
 ```bash
 cargo test --workspace           # Rust backend
@@ -151,13 +210,23 @@ npx playwright test              # E2E
 
 All configuration via environment variables or `config.toml`. Key settings:
 
-- `PARKHUB_DB_PASSPHRASE` — Enable AES-256-GCM database encryption
-- `SMTP_HOST` / `SMTP_USER` / `SMTP_PASS` — Email notifications
-- `PARKHUB_ADMIN_PASSWORD` — Set admin password (auto-generated if omitted)
-- `DEMO_MODE=true` — Enable demo overlay with 6-hour auto-reset
-- `RUST_LOG=info` — Log level
+| Variable | Purpose |
+|----------|---------|
+| `PARKHUB_DB_PASSPHRASE` | Enable AES-256-GCM database encryption |
+| `SMTP_HOST` / `SMTP_USER` / `SMTP_PASS` | Email notifications |
+| `PARKHUB_ADMIN_PASSWORD` | Set admin password (auto-generated if omitted) |
+| `DEMO_MODE=true` | Enable demo overlay with 6-hour auto-reset |
+| `RUST_LOG=info` | Log level |
 
 Full reference: [docs/CONFIGURATION.md](docs/CONFIGURATION.md)
+
+---
+
+## API Documentation
+
+Interactive API docs are available at `/swagger-ui` when the server is running. The OpenAPI 3.0 spec covers 125+ annotated endpoints across auth, bookings, lots, vehicles, admin, GDPR, and more.
+
+**[Live API Docs](https://parkhub-rust-demo.onrender.com/swagger-ui)**
 
 ---
 
@@ -165,20 +234,20 @@ Full reference: [docs/CONFIGURATION.md](docs/CONFIGURATION.md)
 
 A feature-equivalent **PHP edition** (Laravel 12 + MySQL/SQLite/PostgreSQL) exists for environments where shared hosting compatibility matters. Both editions share the same React frontend and REST API surface, so they're fully interchangeable.
 
-**[nash87/parkhub-php →](https://github.com/nash87/parkhub-php)**
-
----
-
-## License
-
-MIT — see [LICENSE](LICENSE).
-
-The default build includes [Slint](https://slint.dev/) for the desktop GUI (GPL-3.0 community edition). Server/Docker builds use `--features headless` and are purely MIT. See [LICENSES.md](LICENSES.md) for the full dependency license inventory.
+**[nash87/parkhub-php](https://github.com/nash87/parkhub-php)**
 
 ---
 
 ## Contributing
 
-Contributions welcome — see [docs/CONTRIBUTING.md](docs/CONTRIBUTING.md) for setup and PR process.
+Contributions welcome -- see [docs/CONTRIBUTING.md](docs/CONTRIBUTING.md) for setup and PR process.
 
 Bug reports and feature requests: [GitHub Issues](https://github.com/nash87/parkhub-rust/issues)
+
+---
+
+## License
+
+MIT -- see [LICENSE](LICENSE).
+
+The default build includes [Slint](https://slint.dev/) for the desktop GUI (GPL-3.0 community edition). Server/Docker builds use `--features headless` and are purely MIT. See [LICENSES.md](LICENSES.md) for the full dependency license inventory.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,87 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported          |
+|---------|--------------------|
+| 2.2.x   | Yes                |
+| 2.1.x   | Yes                |
+| 2.0.x   | Security fixes only |
+| < 2.0   | No                 |
+
+## Reporting a Vulnerability
+
+**Do not open a public GitHub issue for security vulnerabilities.**
+
+Instead, use one of these channels:
+
+1. **GitHub Security Advisory** (preferred):
+   [Create a private advisory](https://github.com/nash87/parkhub-rust/security/advisories/new)
+
+2. **Email**: Open a private security advisory on GitHub (see above)
+
+Please include:
+- Description of the vulnerability
+- Steps to reproduce
+- Potential impact assessment
+- Suggested fix (if available)
+
+### Response Times
+
+| Severity | Acknowledgement | Fix Timeline |
+|----------|----------------|--------------|
+| Critical | Within 24 hours | Within 7 days |
+| High     | Within 48 hours | Within 14 days |
+| Medium   | Within 72 hours | Within 30 days |
+| Low      | Within 1 week   | Next release |
+
+Researchers are credited in release notes unless anonymity is requested.
+
+## Security Features
+
+### Authentication
+- **2FA/TOTP** -- QR code enrollment, backup codes, per-account toggle
+- **Argon2id** password hashing with cryptographically random salts (OsRng)
+- **Constant-time token comparison** via opaque UUID Bearer tokens
+- **4-tier RBAC** (user, premium, admin, superadmin) enforced at handler level
+
+### Encryption
+- **AES-256-GCM** database encryption at rest (optional, via `PARKHUB_DB_PASSPHRASE`)
+- **PBKDF2-SHA256** key derivation from passphrase
+- **zeroize** crate zeroes key material in memory on drop
+- **TLS 1.3** via rustls (pure Rust, no OpenSSL dependency)
+
+### Transport Security
+- **CSP headers** -- `default-src 'self'`, frame-ancestors none
+- **HSTS** -- `max-age=31536000; includeSubDomains`
+- **X-Frame-Options** DENY, X-Content-Type-Options nosniff
+- **Referrer-Policy** strict-origin-when-cross-origin
+- **Permissions-Policy** disables geolocation, camera, microphone
+
+### Rate Limiting
+- Login: 5 requests/minute per IP
+- Registration: 3 requests/minute per IP
+- Global: 100 req/s with burst 200
+
+### Input Validation
+- 4 MiB request body size limit
+- Strict JSON deserialization (unknown fields rejected)
+- UUID validation at the type level
+- Positive duration validation before arithmetic
+
+### Concurrency
+- Async RwLock on booking creation prevents double-booking race conditions
+- No SQL injection surface (redb is a key-value store, not SQL)
+
+### Supply Chain
+- Static musl binary -- no shared library vulnerabilities
+- All cryptography via audited Rust crates (argon2, aes-gcm, rustls, rand)
+- No third-party JavaScript loaded at runtime
+
+## Full Security Documentation
+
+See [docs/SECURITY.md](docs/SECURITY.md) for the complete security model, architecture details, and audit log reference.
+
+## CVE History
+
+No CVEs have been reported against ParkHub.


### PR DESCRIPTION
## Summary
- README overhaul: CI badge, v2.2.0 features, module system table (28 flags), API docs link
- CHANGELOG: added v2.2.0, v2.1.0, v2.0.0 entries in Keep a Changelog format
- SECURITY.md at repo root: supported versions, disclosure process, response SLAs
- New issue template: security_vulnerability.yml
- Enhanced PR template: security checklist, feature-flag check
- Version bump to 2.2.0