### PR TITLE
feat: design theme switcher with 6 visual themes

### DIFF
--- a/parkhub-server/Cargo.toml
+++ b/parkhub-server/Cargo.toml
@@ -143,6 +143,7 @@ full = [
     "mod-jobs", "mod-swap", "mod-waitlist", "mod-zones", "mod-credits",
     "mod-email", "mod-export", "mod-favorites", "mod-push",
     "mod-recommendations", "mod-translations", "mod-social",
+    "mod-themes",
 ]
 gui = ["slint", "slint-build", "tray-icon"]
 headless = []
@@ -174,6 +175,7 @@ mod-push = []
 mod-recommendations = []
 mod-translations = []
 mod-social = []
+mod-themes = []
 
 [dev-dependencies]
 tempfile = "3"

--- a/parkhub-server/src/api/admin_ext.rs
+++ b/parkhub-server/src/api/admin_ext.rs
@@ -619,6 +619,92 @@ pub async fn load_notification_preferences(
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════
+// DESIGN THEME PREFERENCES
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/// Available design theme IDs.
+const VALID_DESIGN_THEMES: &[&str] = &[
+    "classic", "glass", "bento", "brutalist", "neon", "warm",
+];
+
+/// Design theme preference.
+#[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
+pub struct DesignThemePreference {
+    pub design_theme: String,
+}
+
+/// `GET /api/v1/preferences/theme` — Get the user's design theme preference.
+#[utoipa::path(
+    get,
+    path = "/api/v1/preferences/theme",
+    tag = "Users",
+    summary = "Get design theme preference",
+    security(("bearer_auth" = [])),
+    responses((status = 200, description = "Design theme preference")),
+)]
+pub async fn get_design_theme_preference(
+    State(state): State<SharedState>,
+    Extension(auth_user): Extension<AuthUser>,
+) -> (StatusCode, Json<ApiResponse<DesignThemePreference>>) {
+    let state_guard = state.read().await;
+    let key = format!("design_theme:{}", auth_user.user_id);
+    let theme = match state_guard.db.get_setting(&key).await {
+        Ok(Some(val)) if VALID_DESIGN_THEMES.contains(&val.as_str()) => val,
+        _ => "classic".to_string(),
+    };
+    (
+        StatusCode::OK,
+        Json(ApiResponse::success(DesignThemePreference {
+            design_theme: theme,
+        })),
+    )
+}
+
+/// `PUT /api/v1/preferences/theme` — Update the user's design theme preference.
+#[utoipa::path(
+    put,
+    path = "/api/v1/preferences/theme",
+    tag = "Users",
+    summary = "Update design theme preference",
+    security(("bearer_auth" = [])),
+    request_body = DesignThemePreference,
+    responses((status = 200, description = "Design theme updated")),
+)]
+pub async fn update_design_theme_preference(
+    State(state): State<SharedState>,
+    Extension(auth_user): Extension<AuthUser>,
+    Json(body): Json<DesignThemePreference>,
+) -> (StatusCode, Json<ApiResponse<DesignThemePreference>>) {
+    if !VALID_DESIGN_THEMES.contains(&body.design_theme.as_str()) {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(ApiResponse::error(
+                "INVALID_THEME",
+                "Invalid design theme. Valid: classic, glass, bento, brutalist, neon, warm",
+            )),
+        );
+    }
+
+    let state_guard = state.read().await;
+    let key = format!("design_theme:{}", auth_user.user_id);
+    if let Err(e) = state_guard
+        .db
+        .set_setting(&key, &body.design_theme)
+        .await
+    {
+        tracing::error!("Failed to save design theme: {}", e);
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ApiResponse::error(
+                "SERVER_ERROR",
+                "Failed to save design theme",
+            )),
+        );
+    }
+    (StatusCode::OK, Json(ApiResponse::success(body)))
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
 // BOOKING POLICIES
 // ═══════════════════════════════════════════════════════════════════════════════
 

--- a/parkhub-server/src/api/mod.rs
+++ b/parkhub-server/src/api/mod.rs
@@ -313,6 +313,7 @@ async fn list_module_features() -> impl IntoResponse {
         cfg!(feature = "mod-translations").into(),
     );
     modules.insert("social".into(), cfg!(feature = "mod-social").into());
+    modules.insert("themes".into(), cfg!(feature = "mod-themes").into());
 
     Json(serde_json::json!({
         "modules": modules,
@@ -516,6 +517,12 @@ pub fn create_router(state: SharedState) -> (Router, demo::SharedDemoState) {
             "/api/v1/preferences/notifications",
             get(admin_ext::get_notification_preferences)
                 .put(admin_ext::update_notification_preferences),
+        )
+        // ── Design theme preferences ──
+        .route(
+            "/api/v1/preferences/theme",
+            get(admin_ext::get_design_theme_preference)
+                .put(admin_ext::update_design_theme_preference),
         );
 
     // ── Admin routes (guarded by admin_middleware) ────────────────────────

--- a/parkhub-server/src/api/settings.rs
+++ b/parkhub-server/src/api/settings.rs
@@ -322,6 +322,7 @@ const FEATURE_MODULES: &[&str] = &[
     "fab_quick_actions",
     "rich_empty_states",
     "onboarding_hints",
+    "themes",
 ];
 
 /// Default enabled features (business use case).
@@ -338,6 +339,7 @@ const DEFAULT_FEATURES: &[&str] = &[
     "fab_quick_actions",
     "rich_empty_states",
     "onboarding_hints",
+    "themes",
 ];
 
 const SETTINGS_FEATURES_KEY: &str = "features_enabled";

--- a/parkhub-server/src/coverage_tests.rs
+++ b/parkhub-server/src/coverage_tests.rs
@@ -1321,6 +1321,122 @@ async fn test_update_notification_preferences() {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════
+// 8b. DESIGN THEME PREFERENCES
+// ═══════════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn test_get_design_theme_default() {
+    let state = test_state().await;
+    let admin_tok = admin_token(state.clone()).await;
+    let app = router(state);
+
+    let resp = app
+        .oneshot(
+            Request::get("/api/v1/preferences/theme")
+                .header("authorization", format!("Bearer {admin_tok}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let json = body_json(resp).await;
+    assert_eq!(json["data"]["design_theme"], "classic");
+}
+
+#[tokio::test]
+async fn test_update_design_theme() {
+    let state = test_state().await;
+    let admin_tok = admin_token(state.clone()).await;
+
+    let body = serde_json::json!({ "design_theme": "neon" });
+
+    let app = router(state.clone());
+    let resp = app
+        .oneshot(
+            Request::put("/api/v1/preferences/theme")
+                .header("content-type", "application/json")
+                .header("authorization", format!("Bearer {admin_tok}"))
+                .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let json = body_json(resp).await;
+    assert_eq!(json["data"]["design_theme"], "neon");
+
+    // Verify persistence
+    let app = router(state);
+    let resp = app
+        .oneshot(
+            Request::get("/api/v1/preferences/theme")
+                .header("authorization", format!("Bearer {admin_tok}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    let json = body_json(resp).await;
+    assert_eq!(json["data"]["design_theme"], "neon");
+}
+
+#[tokio::test]
+async fn test_update_design_theme_invalid() {
+    let state = test_state().await;
+    let admin_tok = admin_token(state.clone()).await;
+
+    let body = serde_json::json!({ "design_theme": "nonexistent_theme" });
+
+    let app = router(state);
+    let resp = app
+        .oneshot(
+            Request::put("/api/v1/preferences/theme")
+                .header("content-type", "application/json")
+                .header("authorization", format!("Bearer {admin_tok}"))
+                .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    let json = body_json(resp).await;
+    assert_eq!(json["error"]["code"], "INVALID_THEME");
+}
+
+#[tokio::test]
+async fn test_update_design_theme_all_valid_themes() {
+    let valid_themes = ["classic", "glass", "bento", "brutalist", "neon", "warm"];
+
+    for theme_name in valid_themes {
+        let state = test_state().await;
+        let admin_tok = admin_token(state.clone()).await;
+
+        let body = serde_json::json!({ "design_theme": theme_name });
+
+        let app = router(state);
+        let resp = app
+            .oneshot(
+                Request::put("/api/v1/preferences/theme")
+                    .header("content-type", "application/json")
+                    .header("authorization", format!("Bearer {admin_tok}"))
+                    .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK, "Theme '{}' should be valid", theme_name);
+        let json = body_json(resp).await;
+        assert_eq!(json["data"]["design_theme"], theme_name);
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
 // 9. ADMIN EXTENSIONS — BOOKING POLICIES
 // ═══════════════════════════════════════════════════════════════════════════════
 

--- a/parkhub-server/src/openapi.rs
+++ b/parkhub-server/src/openapi.rs
@@ -257,6 +257,8 @@ use crate::{
         crate::api::update_user_preferences,
         crate::api::gdpr_export_data,
         crate::api::gdpr_delete_account,
+        crate::api::admin_ext::get_design_theme_preference,
+        crate::api::admin_ext::update_design_theme_preference,
 
         // Bookings (mod.rs)
         crate::api::list_bookings,

--- a/parkhub-web/src/api/client.ts
+++ b/parkhub-web/src/api/client.ts
@@ -230,6 +230,11 @@ export const api = {
   updateNotificationPreferences: (prefs: NotificationPreferences) =>
     request<NotificationPreferences>('/api/v1/preferences/notifications', { method: 'PUT', body: JSON.stringify(prefs) }),
 
+  // ── Design Theme Preferences ──
+  getDesignThemePreference: () => request<{ design_theme: string }>('/api/v1/preferences/theme'),
+  updateDesignThemePreference: (design_theme: string) =>
+    request<{ design_theme: string }>('/api/v1/preferences/theme', { method: 'PUT', body: JSON.stringify({ design_theme }) }),
+
   // ── Bulk Admin ──
   adminBulkUpdate: (user_ids: string[], action: string, role?: string) =>
     request<BulkResult>('/api/v1/admin/users/bulk-update', { method: 'POST', body: JSON.stringify({ user_ids, action, role }) }),

--- a/parkhub-web/src/components/Layout.tsx
+++ b/parkhub-web/src/components/Layout.tsx
@@ -10,6 +10,7 @@ import { useAuth } from '../context/AuthContext';
 import { useTheme } from '../context/ThemeContext';
 import { useKeyboardShortcuts } from '../hooks/useKeyboardShortcuts';
 import { CommandPalette } from './CommandPalette';
+import { ThemeSwitcher, ThemeSwitcherFab } from './ThemeSwitcher';
 import { Breadcrumb } from './ui/Breadcrumb';
 import { NotificationBadge } from './ui/NotificationBadge';
 
@@ -35,6 +36,7 @@ export function Layout() {
   const { resolved, setTheme } = useTheme();
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const [commandPaletteOpen, setCommandPaletteOpen] = useState(false);
+  const [themeSwitcherOpen, setThemeSwitcherOpen] = useState(false);
   const [unreadCount, setUnreadCount] = useState(0);
 
   const toggleCommandPalette = useCallback(
@@ -268,6 +270,8 @@ export function Layout() {
       </div>
 
       <CommandPalette open={commandPaletteOpen} onClose={() => setCommandPaletteOpen(false)} />
+      <ThemeSwitcherFab onClick={() => setThemeSwitcherOpen(true)} />
+      <ThemeSwitcher open={themeSwitcherOpen} onClose={() => setThemeSwitcherOpen(false)} />
     </div>
   );
 }

--- a/parkhub-web/src/components/ProfileThemeSection.tsx
+++ b/parkhub-web/src/components/ProfileThemeSection.tsx
@@ -1,0 +1,88 @@
+import { Check, Palette } from '@phosphor-icons/react';
+import { useTranslation } from 'react-i18next';
+import { useTheme, type DesignThemeId, type DesignThemeInfo } from '../context/ThemeContext';
+
+function MiniThemeCard({ theme, isActive, onApply, resolved }: {
+  theme: DesignThemeInfo;
+  isActive: boolean;
+  onApply: (id: DesignThemeId) => void;
+  resolved: 'light' | 'dark';
+}) {
+  const { t } = useTranslation();
+  const colors = resolved === 'dark' ? theme.previewColors.dark : theme.previewColors.light;
+  const [bg, card, accent, text, border] = colors;
+
+  return (
+    <button
+      onClick={() => onApply(theme.id)}
+      className={`relative text-left rounded-lg border-2 p-3 transition-all hover:shadow-sm ${
+        isActive
+          ? 'border-primary-500 ring-1 ring-primary-500/20'
+          : 'border-surface-200 dark:border-surface-700 hover:border-surface-300 dark:hover:border-surface-600'
+      }`}
+      aria-pressed={isActive}
+      aria-label={t('themes.applyTheme', { name: theme.name })}
+    >
+      {isActive && (
+        <div className="absolute top-1.5 right-1.5 w-5 h-5 rounded-full bg-primary-500 flex items-center justify-center">
+          <Check weight="bold" className="w-3 h-3 text-white" />
+        </div>
+      )}
+
+      {/* Mini preview */}
+      <div
+        className="w-full aspect-[3/2] rounded overflow-hidden mb-2 border"
+        style={{ backgroundColor: bg, borderColor: border }}
+      >
+        <div className="flex h-full">
+          <div className="w-1/4 h-full p-1" style={{ borderRight: `1px solid ${border}` }}>
+            <div className="w-full h-1 rounded-full mb-0.5" style={{ backgroundColor: accent }} />
+            <div className="w-3/4 h-0.5 rounded-full opacity-30" style={{ backgroundColor: text }} />
+            <div className="w-3/4 h-0.5 rounded-full opacity-30 mt-0.5" style={{ backgroundColor: text }} />
+          </div>
+          <div className="flex-1 p-1.5 flex flex-col gap-1">
+            <div className="w-1/2 h-1 rounded-full" style={{ backgroundColor: text }} />
+            <div className="flex gap-1 flex-1">
+              <div className="flex-1 rounded-sm" style={{ backgroundColor: card, border: `1px solid ${border}` }} />
+              <div className="flex-1 rounded-sm" style={{ backgroundColor: card, border: `1px solid ${border}` }} />
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <p className="text-xs font-semibold text-surface-900 dark:text-white">
+        {t(`themes.names.${theme.id}`, theme.name)}
+      </p>
+    </button>
+  );
+}
+
+export function ProfileThemeSection() {
+  const { t } = useTranslation();
+  const { designTheme, setDesignTheme, designThemes, resolved } = useTheme();
+
+  return (
+    <div>
+      <div className="flex items-center gap-2 mb-4">
+        <Palette weight="fill" className="w-5 h-5 text-primary-500" />
+        <h3 className="text-base font-semibold text-surface-900 dark:text-white">
+          {t('themes.title', 'Design Themes')}
+        </h3>
+      </div>
+      <p className="text-sm text-surface-500 dark:text-surface-400 mb-4">
+        {t('themes.subtitle', 'Choose a visual design for your ParkHub experience.')}
+      </p>
+      <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
+        {designThemes.map(theme => (
+          <MiniThemeCard
+            key={theme.id}
+            theme={theme}
+            isActive={designTheme === theme.id}
+            onApply={setDesignTheme}
+            resolved={resolved}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/parkhub-web/src/components/ThemeSwitcher.test.tsx
+++ b/parkhub-web/src/components/ThemeSwitcher.test.tsx
@@ -1,0 +1,179 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import React from 'react';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+// ── Hoisted mocks ──
+const { localStorageMock, matchMediaState } = vi.hoisted(() => {
+  let store: Record<string, string> = {};
+  const localStorageMock = {
+    getItem: vi.fn((key: string) => store[key] ?? null),
+    setItem: vi.fn((key: string, val: string) => { store[key] = val; }),
+    removeItem: vi.fn((key: string) => { delete store[key]; }),
+    clear: vi.fn(() => { store = {}; }),
+  };
+
+  const matchMediaState = { dark: false, listeners: [] as Array<() => void> };
+
+  const persistentMql = {
+    get matches() { return matchMediaState.dark; },
+    media: '(prefers-color-scheme: dark)',
+    addEventListener: vi.fn((_event: string, handler: () => void) => {
+      matchMediaState.listeners.push(handler);
+    }),
+    removeEventListener: vi.fn(),
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  };
+
+  Object.defineProperty(globalThis.window ?? globalThis, 'localStorage', {
+    value: localStorageMock, writable: true, configurable: true,
+  });
+  Object.defineProperty(globalThis.window ?? globalThis, 'matchMedia', {
+    writable: true, configurable: true,
+    value: vi.fn((_query: string) => persistentMql),
+  });
+
+  return { localStorageMock, matchMediaState };
+});
+
+// Mock i18next
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, fallback?: string | Record<string, string>) => {
+      if (typeof fallback === 'string') return fallback;
+      return key;
+    },
+  }),
+}));
+
+// Mock framer-motion to avoid animation complexity in tests
+vi.mock('framer-motion', () => ({
+  motion: {
+    div: React.forwardRef(({ children, ...props }: any, ref: any) => <div ref={ref} {...props}>{children}</div>),
+    button: React.forwardRef(({ children, ...props }: any, ref: any) => <button ref={ref} {...props}>{children}</button>),
+    aside: React.forwardRef(({ children, ...props }: any, ref: any) => <aside ref={ref} {...props}>{children}</aside>),
+  },
+  AnimatePresence: ({ children }: any) => <>{children}</>,
+}));
+
+import { ThemeProvider } from '../context/ThemeContext';
+import { ThemeSwitcher, ThemeSwitcherFab } from './ThemeSwitcher';
+
+describe('ThemeSwitcher', () => {
+  beforeEach(() => {
+    localStorageMock.clear();
+    matchMediaState.dark = false;
+    vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve({}) })));
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders all 6 theme cards when open', () => {
+    render(
+      <ThemeProvider>
+        <ThemeSwitcher open={true} onClose={() => {}} />
+      </ThemeProvider>,
+    );
+
+    // Each theme card has an aria-label with theme name
+    expect(screen.getByRole('dialog')).toBeTruthy();
+    const buttons = screen.getAllByRole('button', { pressed: undefined });
+    // 6 theme cards + close button = 7 buttons
+    const themeButtons = buttons.filter(b => b.getAttribute('aria-pressed') !== null);
+    expect(themeButtons).toHaveLength(6);
+  });
+
+  it('does not render when closed', () => {
+    const { container } = render(
+      <ThemeProvider>
+        <ThemeSwitcher open={false} onClose={() => {}} />
+      </ThemeProvider>,
+    );
+
+    expect(container.querySelector('[role="dialog"]')).toBeNull();
+  });
+
+  it('marks the active theme with aria-pressed=true', () => {
+    render(
+      <ThemeProvider>
+        <ThemeSwitcher open={true} onClose={() => {}} />
+      </ThemeProvider>,
+    );
+
+    const activeButtons = screen.getAllByRole('button').filter(
+      b => b.getAttribute('aria-pressed') === 'true'
+    );
+    expect(activeButtons).toHaveLength(1);
+  });
+
+  it('calls onClose when close button is clicked', async () => {
+    const onClose = vi.fn();
+    const user = userEvent.setup();
+
+    render(
+      <ThemeProvider>
+        <ThemeSwitcher open={true} onClose={onClose} />
+      </ThemeProvider>,
+    );
+
+    const closeBtn = screen.getByLabelText('Close');
+    await user.click(closeBtn);
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('changes theme when a card is clicked', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <ThemeProvider>
+        <ThemeSwitcher open={true} onClose={() => {}} />
+      </ThemeProvider>,
+    );
+
+    // Find the Neon theme card — it's a button with aria-pressed that contains "Neon" text
+    const themeButtons = screen.getAllByRole('button').filter(
+      b => b.getAttribute('aria-pressed') !== null
+    );
+    // Neon is the 5th theme (index 4)
+    const neonCard = themeButtons[4];
+    await user.click(neonCard);
+
+    expect(localStorageMock.setItem).toHaveBeenCalledWith('parkhub_design_theme', 'neon');
+  });
+});
+
+describe('ThemeSwitcherFab', () => {
+  beforeEach(() => {
+    localStorageMock.clear();
+    matchMediaState.dark = false;
+  });
+
+  it('renders the FAB button', () => {
+    render(
+      <ThemeProvider>
+        <ThemeSwitcherFab onClick={() => {}} />
+      </ThemeProvider>,
+    );
+
+    expect(screen.getByLabelText('Change theme')).toBeTruthy();
+  });
+
+  it('calls onClick when clicked', async () => {
+    const onClick = vi.fn();
+    const user = userEvent.setup();
+
+    render(
+      <ThemeProvider>
+        <ThemeSwitcherFab onClick={onClick} />
+      </ThemeProvider>,
+    );
+
+    await user.click(screen.getByLabelText('Change theme'));
+    expect(onClick).toHaveBeenCalled();
+  });
+});

--- a/parkhub-web/src/components/ThemeSwitcher.tsx
+++ b/parkhub-web/src/components/ThemeSwitcher.tsx
@@ -1,0 +1,182 @@
+import { motion, AnimatePresence } from 'framer-motion';
+import { Check, X, Palette } from '@phosphor-icons/react';
+import { useTranslation } from 'react-i18next';
+import { useTheme, type DesignThemeId, type DesignThemeInfo } from '../context/ThemeContext';
+
+// ── Theme Preview Card ──
+
+function ThemePreviewCard({ theme, isActive, onApply }: {
+  theme: DesignThemeInfo;
+  isActive: boolean;
+  onApply: (id: DesignThemeId) => void;
+}) {
+  const { t } = useTranslation();
+  const { resolved } = useTheme();
+  const colors = resolved === 'dark' ? theme.previewColors.dark : theme.previewColors.light;
+  const [bg, card, accent, text, border] = colors;
+
+  return (
+    <motion.button
+      onClick={() => onApply(theme.id)}
+      whileHover={{ scale: 1.02 }}
+      whileTap={{ scale: 0.98 }}
+      transition={{ type: 'spring', stiffness: 400, damping: 25 }}
+      className={`relative group text-left rounded-xl border-2 p-4 transition-colors ${
+        isActive
+          ? 'border-primary-500 ring-2 ring-primary-500/20'
+          : 'border-surface-200 dark:border-surface-700 hover:border-surface-300 dark:hover:border-surface-600'
+      }`}
+      aria-pressed={isActive}
+      aria-label={t('themes.applyTheme', { name: theme.name })}
+    >
+      {/* Active indicator */}
+      {isActive && (
+        <motion.div
+          initial={{ scale: 0 }}
+          animate={{ scale: 1 }}
+          className="absolute top-2 right-2 w-6 h-6 rounded-full bg-primary-500 flex items-center justify-center"
+        >
+          <Check weight="bold" className="w-3.5 h-3.5 text-white" />
+        </motion.div>
+      )}
+
+      {/* Mini layout preview */}
+      <div
+        className="w-full aspect-[16/10] rounded-lg overflow-hidden mb-3 border"
+        style={{ backgroundColor: bg, borderColor: border }}
+      >
+        <div className="flex h-full">
+          {/* Mini sidebar */}
+          <div
+            className="w-1/4 h-full p-1.5 flex flex-col gap-1"
+            style={{ borderRight: `1px solid ${border}` }}
+          >
+            <div className="w-full h-1.5 rounded-full" style={{ backgroundColor: accent }} />
+            <div className="w-3/4 h-1 rounded-full opacity-40" style={{ backgroundColor: text }} />
+            <div className="w-3/4 h-1 rounded-full opacity-40" style={{ backgroundColor: text }} />
+            <div className="w-3/4 h-1 rounded-full opacity-40" style={{ backgroundColor: text }} />
+          </div>
+          {/* Mini content */}
+          <div className="flex-1 p-2 flex flex-col gap-1.5">
+            <div className="w-2/3 h-1.5 rounded-full" style={{ backgroundColor: text }} />
+            <div className="flex gap-1.5 flex-1">
+              <div className="flex-1 rounded" style={{ backgroundColor: card, border: `1px solid ${border}` }} />
+              <div className="flex-1 rounded" style={{ backgroundColor: card, border: `1px solid ${border}` }} />
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Theme info */}
+      <h3 className="font-semibold text-sm text-surface-900 dark:text-white">
+        {t(`themes.names.${theme.id}`, theme.name)}
+      </h3>
+      <p className="text-xs text-surface-500 dark:text-surface-400 mt-0.5 line-clamp-2">
+        {t(`themes.descriptions.${theme.id}`, theme.description)}
+      </p>
+
+      {/* Color swatches */}
+      <div className="flex gap-1 mt-2">
+        {colors.map((color, i) => (
+          <div
+            key={i}
+            className="w-4 h-4 rounded-full border border-surface-200 dark:border-surface-600"
+            style={{ backgroundColor: color }}
+            aria-hidden="true"
+          />
+        ))}
+      </div>
+    </motion.button>
+  );
+}
+
+// ── Theme Switcher Panel ──
+
+export function ThemeSwitcher({ open, onClose }: { open: boolean; onClose: () => void }) {
+  const { t } = useTranslation();
+  const { designTheme, setDesignTheme, designThemes } = useTheme();
+
+  return (
+    <AnimatePresence>
+      {open && (
+        <>
+          {/* Backdrop */}
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            className="fixed inset-0 bg-black/30 backdrop-blur-sm z-50"
+            onClick={onClose}
+            aria-hidden="true"
+          />
+          {/* Panel */}
+          <motion.div
+            initial={{ opacity: 0, y: 20, scale: 0.96 }}
+            animate={{ opacity: 1, y: 0, scale: 1 }}
+            exit={{ opacity: 0, y: 20, scale: 0.96 }}
+            transition={{ type: 'spring', stiffness: 400, damping: 30 }}
+            className="fixed inset-x-4 bottom-4 sm:inset-auto sm:right-4 sm:bottom-4 sm:w-[480px] z-50
+              bg-white dark:bg-surface-900 rounded-2xl border border-surface-200 dark:border-surface-700
+              shadow-2xl max-h-[80vh] overflow-hidden flex flex-col"
+            role="dialog"
+            aria-label={t('themes.title', 'Design Themes')}
+          >
+            {/* Header */}
+            <div className="flex items-center justify-between p-4 border-b border-surface-200 dark:border-surface-800">
+              <div className="flex items-center gap-2">
+                <Palette weight="fill" className="w-5 h-5 text-primary-500" />
+                <h2 className="text-lg font-bold text-surface-900 dark:text-white">
+                  {t('themes.title', 'Design Themes')}
+                </h2>
+              </div>
+              <button
+                onClick={onClose}
+                className="btn btn-ghost btn-icon"
+                aria-label={t('common.close', 'Close')}
+              >
+                <X weight="bold" className="w-4 h-4" />
+              </button>
+            </div>
+
+            {/* Theme grid */}
+            <div className="p-4 overflow-y-auto flex-1">
+              <p className="text-sm text-surface-500 dark:text-surface-400 mb-4">
+                {t('themes.subtitle', 'Choose a visual design for your ParkHub experience.')}
+              </p>
+              <div className="grid grid-cols-2 gap-3">
+                {designThemes.map(theme => (
+                  <ThemePreviewCard
+                    key={theme.id}
+                    theme={theme}
+                    isActive={designTheme === theme.id}
+                    onApply={setDesignTheme}
+                  />
+                ))}
+              </div>
+            </div>
+          </motion.div>
+        </>
+      )}
+    </AnimatePresence>
+  );
+}
+
+// ── Floating Theme Button ──
+
+export function ThemeSwitcherFab({ onClick }: { onClick: () => void }) {
+  const { t } = useTranslation();
+
+  return (
+    <motion.button
+      onClick={onClick}
+      whileHover={{ scale: 1.05 }}
+      whileTap={{ scale: 0.95 }}
+      className="fixed bottom-4 left-4 z-40 w-10 h-10 rounded-full bg-surface-100 dark:bg-surface-800
+        border border-surface-200 dark:border-surface-700 shadow-lg
+        flex items-center justify-center hover:bg-surface-200 dark:hover:bg-surface-700 transition-colors"
+      aria-label={t('themes.openSwitcher', 'Change theme')}
+    >
+      <Palette weight="fill" className="w-5 h-5 text-surface-600 dark:text-surface-300" />
+    </motion.button>
+  );
+}

--- a/parkhub-web/src/context/FeaturesContext.tsx
+++ b/parkhub-web/src/context/FeaturesContext.tsx
@@ -16,7 +16,8 @@ export type FeatureModule =
   | 'micro_animations'
   | 'fab_quick_actions'
   | 'rich_empty_states'
-  | 'onboarding_hints';
+  | 'onboarding_hints'
+  | 'themes';
 
 export type FeatureCategory = 'core' | 'collaboration' | 'billing' | 'admin' | 'experience';
 
@@ -46,13 +47,14 @@ export const FEATURE_REGISTRY: FeatureInfo[] = [
   { id: 'fab_quick_actions', category: 'experience',    defaultEnabled: true },
   { id: 'rich_empty_states', category: 'experience',    defaultEnabled: true },
   { id: 'onboarding_hints',  category: 'experience',    defaultEnabled: false },
+  { id: 'themes',            category: 'experience',    defaultEnabled: true },
 ];
 
 /** Use-case presets — which features are enabled by default per use case */
 export const USE_CASE_PRESETS: Record<UseCase, FeatureModule[]> = {
-  business: ['credits', 'absences', 'vehicles', 'analytics', 'team_view', 'booking_types', 'invoices', 'generative_bg', 'micro_animations', 'fab_quick_actions', 'rich_empty_states', 'onboarding_hints'],
-  residential: ['vehicles', 'booking_types', 'self_registration', 'generative_bg', 'micro_animations', 'rich_empty_states'],
-  personal: ['vehicles', 'booking_types', 'generative_bg', 'micro_animations', 'fab_quick_actions'],
+  business: ['credits', 'absences', 'vehicles', 'analytics', 'team_view', 'booking_types', 'invoices', 'generative_bg', 'micro_animations', 'fab_quick_actions', 'rich_empty_states', 'onboarding_hints', 'themes'],
+  residential: ['vehicles', 'booking_types', 'self_registration', 'generative_bg', 'micro_animations', 'rich_empty_states', 'themes'],
+  personal: ['vehicles', 'booking_types', 'generative_bg', 'micro_animations', 'fab_quick_actions', 'themes'],
 };
 
 const STORAGE_KEY = 'parkhub_features';

--- a/parkhub-web/src/context/ThemeContext.test.tsx
+++ b/parkhub-web/src/context/ThemeContext.test.tsx
@@ -42,18 +42,27 @@ const { localStorageMock, matchMediaState, persistentMql } = vi.hoisted(() => {
   return { localStorageMock, matchMediaState, persistentMql };
 });
 
-import { ThemeProvider, useTheme } from './ThemeContext';
+import { ThemeProvider, useTheme, DESIGN_THEMES, type DesignThemeId } from './ThemeContext';
 
 // Helper component to consume the context
 function ThemeConsumer() {
-  const { theme, resolved, setTheme } = useTheme();
+  const { theme, resolved, setTheme, designTheme, setDesignTheme, designThemes, currentDesignTheme } = useTheme();
   return (
     <div>
       <span data-testid="theme">{theme}</span>
       <span data-testid="resolved">{resolved}</span>
+      <span data-testid="design-theme">{designTheme}</span>
+      <span data-testid="design-theme-name">{currentDesignTheme.name}</span>
+      <span data-testid="design-themes-count">{designThemes.length}</span>
       <button data-testid="set-dark" onClick={() => setTheme('dark')}>Dark</button>
       <button data-testid="set-light" onClick={() => setTheme('light')}>Light</button>
       <button data-testid="set-system" onClick={() => setTheme('system')}>System</button>
+      <button data-testid="set-glass" onClick={() => setDesignTheme('glass')}>Glass</button>
+      <button data-testid="set-neon" onClick={() => setDesignTheme('neon')}>Neon</button>
+      <button data-testid="set-brutalist" onClick={() => setDesignTheme('brutalist')}>Brutalist</button>
+      <button data-testid="set-warm" onClick={() => setDesignTheme('warm')}>Warm</button>
+      <button data-testid="set-bento" onClick={() => setDesignTheme('bento')}>Bento</button>
+      <button data-testid="set-classic" onClick={() => setDesignTheme('classic')}>Classic</button>
     </div>
   );
 }
@@ -64,6 +73,9 @@ describe('ThemeContext', () => {
     matchMediaState.dark = false;
     matchMediaState.listeners.length = 0;
     document.documentElement.classList.remove('dark');
+    delete document.documentElement.dataset.designTheme;
+    // Mock fetch for design theme sync
+    vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve({}) })));
   });
 
   afterEach(() => {
@@ -197,5 +209,131 @@ describe('ThemeContext', () => {
     await user.click(screen.getByTestId('set-system'));
     expect(screen.getByTestId('theme').textContent).toBe('system');
     expect(screen.getByTestId('resolved').textContent).toBe('dark');
+  });
+
+  // ── Design Theme Tests ──
+
+  it('defaults design theme to classic', () => {
+    render(
+      <ThemeProvider>
+        <ThemeConsumer />
+      </ThemeProvider>,
+    );
+
+    expect(screen.getByTestId('design-theme').textContent).toBe('classic');
+    expect(screen.getByTestId('design-theme-name').textContent).toBe('Classic');
+  });
+
+  it('exposes all 6 design themes', () => {
+    render(
+      <ThemeProvider>
+        <ThemeConsumer />
+      </ThemeProvider>,
+    );
+
+    expect(screen.getByTestId('design-themes-count').textContent).toBe('6');
+  });
+
+  it('setDesignTheme changes the active design theme', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <ThemeProvider>
+        <ThemeConsumer />
+      </ThemeProvider>,
+    );
+
+    await user.click(screen.getByTestId('set-glass'));
+    expect(screen.getByTestId('design-theme').textContent).toBe('glass');
+
+    await user.click(screen.getByTestId('set-neon'));
+    expect(screen.getByTestId('design-theme').textContent).toBe('neon');
+
+    await user.click(screen.getByTestId('set-brutalist'));
+    expect(screen.getByTestId('design-theme').textContent).toBe('brutalist');
+
+    await user.click(screen.getByTestId('set-warm'));
+    expect(screen.getByTestId('design-theme').textContent).toBe('warm');
+
+    await user.click(screen.getByTestId('set-bento'));
+    expect(screen.getByTestId('design-theme').textContent).toBe('bento');
+
+    await user.click(screen.getByTestId('set-classic'));
+    expect(screen.getByTestId('design-theme').textContent).toBe('classic');
+  });
+
+  it('persists design theme to localStorage', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <ThemeProvider>
+        <ThemeConsumer />
+      </ThemeProvider>,
+    );
+
+    await user.click(screen.getByTestId('set-glass'));
+    expect(localStorageMock.setItem).toHaveBeenCalledWith('parkhub_design_theme', 'glass');
+  });
+
+  it('reads initial design theme from localStorage', () => {
+    localStorageMock.setItem('parkhub_design_theme', 'neon');
+
+    render(
+      <ThemeProvider>
+        <ThemeConsumer />
+      </ThemeProvider>,
+    );
+
+    expect(screen.getByTestId('design-theme').textContent).toBe('neon');
+  });
+
+  it('sets data-design-theme attribute on document element', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <ThemeProvider>
+        <ThemeConsumer />
+      </ThemeProvider>,
+    );
+
+    // Initial
+    expect(document.documentElement.dataset.designTheme).toBe('classic');
+
+    await user.click(screen.getByTestId('set-brutalist'));
+    expect(document.documentElement.dataset.designTheme).toBe('brutalist');
+  });
+
+  it('falls back to classic for invalid localStorage design theme', () => {
+    localStorageMock.setItem('parkhub_design_theme', 'invalid_theme');
+
+    render(
+      <ThemeProvider>
+        <ThemeConsumer />
+      </ThemeProvider>,
+    );
+
+    expect(screen.getByTestId('design-theme').textContent).toBe('classic');
+  });
+
+  it('each DESIGN_THEMES entry has required fields', () => {
+    for (const theme of DESIGN_THEMES) {
+      expect(theme.id).toBeTruthy();
+      expect(theme.name).toBeTruthy();
+      expect(theme.description).toBeTruthy();
+      expect(theme.previewColors.light).toHaveLength(5);
+      expect(theme.previewColors.dark).toHaveLength(5);
+      expect(theme.tags.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('DESIGN_THEMES contains all 6 themes', () => {
+    const ids = DESIGN_THEMES.map(t => t.id);
+    expect(ids).toContain('classic');
+    expect(ids).toContain('glass');
+    expect(ids).toContain('bento');
+    expect(ids).toContain('brutalist');
+    expect(ids).toContain('neon');
+    expect(ids).toContain('warm');
+    expect(ids).toHaveLength(6);
   });
 });

--- a/parkhub-web/src/context/ThemeContext.tsx
+++ b/parkhub-web/src/context/ThemeContext.tsx
@@ -1,11 +1,107 @@
-import { createContext, useContext, useEffect, useState, useSyncExternalStore, type ReactNode } from 'react';
+import { createContext, useContext, useEffect, useState, useCallback, useSyncExternalStore, type ReactNode } from 'react';
 
-type Theme = 'light' | 'dark' | 'system';
+// ── Light/Dark Mode ──
+
+type ColorMode = 'light' | 'dark' | 'system';
+
+// ── Design Themes ──
+
+export type DesignThemeId = 'classic' | 'glass' | 'bento' | 'brutalist' | 'neon' | 'warm';
+
+export interface DesignThemeInfo {
+  id: DesignThemeId;
+  name: string;
+  description: string;
+  /** Preview palette colors [bg, card, accent, text, border] */
+  previewColors: {
+    light: [string, string, string, string, string];
+    dark: [string, string, string, string, string];
+  };
+  tags: string[];
+}
+
+export const DESIGN_THEMES: DesignThemeInfo[] = [
+  {
+    id: 'classic',
+    name: 'Classic',
+    description: 'Clean, professional. The original ParkHub look.',
+    previewColors: {
+      light: ['#fafaf9', '#ffffff', '#0d9488', '#1e293b', '#e2e8f0'],
+      dark: ['#0f172a', '#1e293b', '#14b8a6', '#f1f5f9', '#334155'],
+    },
+    tags: ['clean', 'professional', 'default'],
+  },
+  {
+    id: 'glass',
+    name: 'Glass',
+    description: 'Frosted glassmorphism with blur and translucency.',
+    previewColors: {
+      light: ['#f8fafc', 'rgba(255,255,255,0.6)', '#14b8a6', '#0f172a', 'rgba(255,255,255,0.3)'],
+      dark: ['#0c0a1a', 'rgba(255,255,255,0.05)', '#6366f1', '#e2e8f0', 'rgba(255,255,255,0.06)'],
+    },
+    tags: ['modern', 'glassmorphism', 'blur'],
+  },
+  {
+    id: 'bento',
+    name: 'Bento',
+    description: 'Grid-focused, minimal. Japanese-inspired clean lines.',
+    previewColors: {
+      light: ['#fafaf9', '#ffffff', '#0d9488', '#1c1917', '#e7e5e4'],
+      dark: ['#0c0a09', '#1c1917', '#14b8a6', '#fafaf9', '#292524'],
+    },
+    tags: ['minimal', 'grid', 'japanese'],
+  },
+  {
+    id: 'brutalist',
+    name: 'Brutalist',
+    description: 'Raw, bold, high-contrast. No rounded corners.',
+    previewColors: {
+      light: ['#ffffff', '#ffffff', '#000000', '#000000', '#000000'],
+      dark: ['#0a0a0a', '#171717', '#ffffff', '#ffffff', '#ffffff'],
+    },
+    tags: ['bold', 'raw', 'high-contrast'],
+  },
+  {
+    id: 'neon',
+    name: 'Neon',
+    description: 'Vibrant accents with cyberpunk-inspired glow.',
+    previewColors: {
+      light: ['#f8fafc', '#ffffff', '#6366f1', '#0f172a', '#e2e8f0'],
+      dark: ['#050510', '#0a0a1a', '#6366f1', '#e2e8f0', 'rgba(99,102,241,0.2)'],
+    },
+    tags: ['vibrant', 'cyberpunk', 'glow'],
+  },
+  {
+    id: 'warm',
+    name: 'Warm',
+    description: 'Earth tones, soft gradients, cozy feel.',
+    previewColors: {
+      light: ['#fef7ee', '#fffbf5', '#ea580c', '#431407', '#fed7aa'],
+      dark: ['#1a0e04', '#271505', '#ea580c', '#fed7aa', '#7c2d12'],
+    },
+    tags: ['cozy', 'earth', 'soft'],
+  },
+];
+
+const DEFAULT_DESIGN_THEME: DesignThemeId = 'classic';
+
+// ── Context ──
 
 interface ThemeState {
-  theme: Theme;
+  /** Light/dark/system selection */
+  theme: ColorMode;
+  /** Resolved light or dark */
   resolved: 'light' | 'dark';
-  setTheme: (t: Theme) => void;
+  /** Set light/dark mode */
+  setTheme: (t: ColorMode) => void;
+  /** Current design theme ID */
+  designTheme: DesignThemeId;
+  /** Set design theme */
+  setDesignTheme: (id: DesignThemeId) => void;
+  /** All available design themes */
+  designThemes: DesignThemeInfo[];
+  /** Get current design theme metadata */
+  currentDesignTheme: DesignThemeInfo;
 }
 
 const ThemeContext = createContext<ThemeState | null>(null);
@@ -30,9 +126,17 @@ function getServerSnapshot(): 'light' | 'dark' {
 }
 
 export function ThemeProvider({ children }: { children: ReactNode }) {
-  const [theme, setThemeState] = useState<Theme>(() =>
-    (localStorage.getItem('parkhub_theme') as Theme) || 'system'
+  const [theme, setThemeState] = useState<ColorMode>(() =>
+    (localStorage.getItem('parkhub_theme') as ColorMode) || 'system'
   );
+
+  const [designTheme, setDesignThemeState] = useState<DesignThemeId>(() => {
+    const stored = localStorage.getItem('parkhub_design_theme');
+    if (stored && DESIGN_THEMES.some(t => t.id === stored)) {
+      return stored as DesignThemeId;
+    }
+    return DEFAULT_DESIGN_THEME;
+  });
 
   // Reactively track OS preference so `resolved` updates on system change
   const systemTheme = useSyncExternalStore(
@@ -43,6 +147,7 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
 
   const resolved = theme === 'system' ? systemTheme : theme;
 
+  // Apply light/dark class
   useEffect(() => {
     const root = document.documentElement;
     root.classList.toggle('dark', resolved === 'dark');
@@ -58,13 +163,46 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
     }
   }, [resolved]);
 
-  function setTheme(t: Theme) {
+  // Apply design theme data attribute
+  useEffect(() => {
+    document.documentElement.dataset.designTheme = designTheme;
+  }, [designTheme]);
+
+  const setTheme = useCallback((t: ColorMode) => {
     setThemeState(t);
     localStorage.setItem('parkhub_theme', t);
-  }
+  }, []);
+
+  const setDesignTheme = useCallback((id: DesignThemeId) => {
+    if (!DESIGN_THEMES.some(t => t.id === id)) return;
+    setDesignThemeState(id);
+    localStorage.setItem('parkhub_design_theme', id);
+    // Sync to server if user is logged in
+    const token = localStorage.getItem('parkhub_token');
+    if (token) {
+      fetch('/api/v1/preferences/theme', {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ design_theme: id }),
+      }).catch(() => {});
+    }
+  }, []);
+
+  const currentDesignTheme = DESIGN_THEMES.find(t => t.id === designTheme) || DESIGN_THEMES[0];
 
   return (
-    <ThemeContext.Provider value={{ theme, resolved, setTheme }}>
+    <ThemeContext.Provider value={{
+      theme,
+      resolved,
+      setTheme,
+      designTheme,
+      setDesignTheme,
+      designThemes: DESIGN_THEMES,
+      currentDesignTheme,
+    }}>
       {children}
     </ThemeContext.Provider>
   );

--- a/parkhub-web/src/i18n/locales/de.ts
+++ b/parkhub-web/src/i18n/locales/de.ts
@@ -489,6 +489,7 @@ export default {
         fab_quick_actions: { name: 'Schnellaktionen', desc: 'Schwebende Aktionsschaltflache fur schnellen Zugriff', help: 'Befehlspalette (Strg+K) und schwebende Schaltflache.' },
         rich_empty_states: { name: 'Illustrierte Leerzustande', desc: 'Illustrierte Leerzustande mit hilfreichen Vorschlagen', help: 'Hilfreiche Illustrationen wenn Listen leer sind.' },
         onboarding_hints: { name: 'Onboarding-Hinweise', desc: 'Kontextbezogene Tipps fur neue Benutzer', help: 'Gefuhrte Tooltips fur Erstbenutzer.' },
+        themes: { name: 'Design-Themen', desc: 'Zwischen visuellen Design-Themen wechseln', help: 'Wahlen Sie zwischen Klassisch, Glas, Bento, Brutalistisch, Neon oder Warm.' },
       },
       compliance: {
         title: 'Integrierte Compliance',
@@ -766,6 +767,29 @@ export default {
         fri: 'Fr',
         sat: 'Sa',
         sun: 'So',
+      },
+    },
+    themes: {
+      title: 'Design-Themen',
+      subtitle: 'Wahlen Sie ein visuelles Design fur Ihre ParkHub-Oberflache.',
+      openSwitcher: 'Design andern',
+      applyTheme: '{{name}}-Design anwenden',
+      currentTheme: 'Aktuelles Design',
+      names: {
+        classic: 'Klassisch',
+        glass: 'Glas',
+        bento: 'Bento',
+        brutalist: 'Brutalistisch',
+        neon: 'Neon',
+        warm: 'Warm',
+      },
+      descriptions: {
+        classic: 'Sauber, professionell. Der originale ParkHub-Look.',
+        glass: 'Milchglas-Optik mit Unschärfe und Transparenz.',
+        bento: 'Rasterbasiert, minimalistisch. Japanisch inspiriert.',
+        brutalist: 'Roh, fett, kontraststark. Keine Rundungen.',
+        neon: 'Leuchtende Akzente mit Cyberpunk-Glühen.',
+        warm: 'Erdtöne, sanfte Verläufe, gemütliches Gefühl.',
       },
     },
     payment: {

--- a/parkhub-web/src/i18n/locales/en.ts
+++ b/parkhub-web/src/i18n/locales/en.ts
@@ -489,6 +489,7 @@ export default {
         fab_quick_actions: { name: 'Quick Actions', desc: 'Floating action button for fast access to common tasks', help: 'Shows a command palette (Ctrl+K) and floating button for quick navigation.' },
         rich_empty_states: { name: 'Rich Empty States', desc: 'Illustrated empty states with helpful suggestions', help: 'Shows helpful illustrations and action buttons when lists are empty.' },
         onboarding_hints: { name: 'Onboarding Hints', desc: 'Contextual tips for new users', help: 'Displays guided tooltips and hints for first-time users.' },
+        themes: { name: 'Design Themes', desc: 'Switch between visual design themes', help: 'Choose from Classic, Glass, Bento, Brutalist, Neon, or Warm design themes.' },
       },
       compliance: {
         title: 'Built-in Compliance',
@@ -766,6 +767,29 @@ export default {
         fri: 'Fri',
         sat: 'Sat',
         sun: 'Sun',
+      },
+    },
+    themes: {
+      title: 'Design Themes',
+      subtitle: 'Choose a visual design for your ParkHub experience.',
+      openSwitcher: 'Change theme',
+      applyTheme: 'Apply {{name}} theme',
+      currentTheme: 'Current theme',
+      names: {
+        classic: 'Classic',
+        glass: 'Glass',
+        bento: 'Bento',
+        brutalist: 'Brutalist',
+        neon: 'Neon',
+        warm: 'Warm',
+      },
+      descriptions: {
+        classic: 'Clean, professional. The original ParkHub look.',
+        glass: 'Frosted glassmorphism with blur and translucency.',
+        bento: 'Grid-focused, minimal. Japanese-inspired clean lines.',
+        brutalist: 'Raw, bold, high-contrast. No rounded corners.',
+        neon: 'Vibrant accents with cyberpunk-inspired glow.',
+        warm: 'Earth tones, soft gradients, cozy feel.',
       },
     },
     payment: {

--- a/parkhub-web/src/styles/global.css
+++ b/parkhub-web/src/styles/global.css
@@ -1,4 +1,5 @@
 @import "tailwindcss";
+@import "./themes.css";
 
 /* Enable class-based dark mode (Tailwind CSS 4 defaults to media query) */
 @custom-variant dark (&:where(.dark, .dark *));

--- a/parkhub-web/src/styles/themes.css
+++ b/parkhub-web/src/styles/themes.css
@@ -1,0 +1,290 @@
+/* ═══════════════════════════════════════════════════════════════════════════════
+   ParkHub Design Theme System
+   Each theme defines a complete visual identity via CSS custom properties.
+   Themes support both light and dark mode variants.
+   ═══════════════════════════════════════════════════════════════════════════════ */
+
+/* ── Theme: Classic ──────────────────────────────────────────────────────────
+   Clean, professional. The original ParkHub look.
+   ──────────────────────────────────────────────────────────────────────────── */
+[data-design-theme="classic"] {
+  --dt-bg-primary: var(--color-surface-50);
+  --dt-bg-secondary: white;
+  --dt-bg-card: white;
+  --dt-text-primary: var(--color-surface-900);
+  --dt-text-secondary: var(--color-surface-500);
+  --dt-border: var(--color-surface-200);
+  --dt-border-subtle: var(--color-surface-100);
+  --dt-card-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
+  --dt-card-radius: var(--radius-lg);
+  --dt-sidebar-bg: rgba(255, 255, 255, 0.9);
+  --dt-sidebar-blur: 12px;
+  --dt-sidebar-border: var(--color-surface-200);
+  --dt-accent-gradient: linear-gradient(135deg, var(--color-primary-600), var(--color-primary-500));
+  --dt-input-bg: white;
+  --dt-input-border: var(--color-surface-300);
+  --dt-badge-radius: var(--radius-md);
+  --dt-nav-active-bg: var(--color-primary-50);
+  --dt-nav-hover-bg: var(--color-surface-100);
+  --dt-header-bg: rgba(255, 255, 255, 0.9);
+}
+
+[data-design-theme="classic"].dark,
+.dark [data-design-theme="classic"] {
+  --dt-bg-primary: var(--color-surface-950);
+  --dt-bg-secondary: var(--color-surface-900);
+  --dt-bg-card: var(--color-surface-900);
+  --dt-text-primary: var(--color-surface-100);
+  --dt-text-secondary: var(--color-surface-400);
+  --dt-border: var(--color-surface-800);
+  --dt-border-subtle: var(--color-surface-800);
+  --dt-card-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+  --dt-sidebar-bg: rgba(15, 23, 42, 0.9);
+  --dt-sidebar-border: var(--color-surface-800);
+  --dt-input-bg: var(--color-surface-800);
+  --dt-input-border: var(--color-surface-600);
+  --dt-nav-active-bg: rgba(20, 184, 166, 0.1);
+  --dt-nav-hover-bg: var(--color-surface-800);
+  --dt-header-bg: rgba(15, 23, 42, 0.9);
+}
+
+/* ── Theme: Glass ────────────────────────────────────────────────────────────
+   Frosted glassmorphism with blur, translucency, and depth.
+   ──────────────────────────────────────────────────────────────────────────── */
+[data-design-theme="glass"] {
+  --dt-bg-primary: var(--color-surface-50);
+  --dt-bg-secondary: rgba(255, 255, 255, 0.7);
+  --dt-bg-card: rgba(255, 255, 255, 0.6);
+  --dt-text-primary: var(--color-surface-900);
+  --dt-text-secondary: var(--color-surface-500);
+  --dt-border: rgba(255, 255, 255, 0.3);
+  --dt-border-subtle: rgba(255, 255, 255, 0.15);
+  --dt-card-shadow: 0 8px 32px rgba(0, 0, 0, 0.08);
+  --dt-card-radius: var(--radius-2xl);
+  --dt-sidebar-bg: rgba(255, 255, 255, 0.7);
+  --dt-sidebar-blur: 40px;
+  --dt-sidebar-border: rgba(255, 255, 255, 0.2);
+  --dt-accent-gradient: linear-gradient(135deg, var(--color-primary-500), var(--color-accent-400));
+  --dt-input-bg: rgba(255, 255, 255, 0.5);
+  --dt-input-border: rgba(255, 255, 255, 0.3);
+  --dt-badge-radius: var(--radius-full);
+  --dt-nav-active-bg: rgba(20, 184, 166, 0.12);
+  --dt-nav-hover-bg: rgba(255, 255, 255, 0.4);
+  --dt-header-bg: rgba(255, 255, 255, 0.7);
+}
+
+[data-design-theme="glass"].dark,
+.dark [data-design-theme="glass"] {
+  --dt-bg-primary: oklch(0.12 0.02 260);
+  --dt-bg-secondary: rgba(15, 23, 42, 0.7);
+  --dt-bg-card: rgba(255, 255, 255, 0.05);
+  --dt-text-primary: var(--color-surface-100);
+  --dt-text-secondary: var(--color-surface-400);
+  --dt-border: rgba(255, 255, 255, 0.06);
+  --dt-border-subtle: rgba(255, 255, 255, 0.03);
+  --dt-card-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
+  --dt-sidebar-bg: rgba(15, 23, 42, 0.7);
+  --dt-sidebar-border: rgba(255, 255, 255, 0.06);
+  --dt-input-bg: rgba(255, 255, 255, 0.05);
+  --dt-input-border: rgba(255, 255, 255, 0.1);
+  --dt-nav-active-bg: rgba(20, 184, 166, 0.15);
+  --dt-nav-hover-bg: rgba(255, 255, 255, 0.05);
+  --dt-header-bg: rgba(15, 23, 42, 0.7);
+}
+
+/* ── Theme: Bento ────────────────────────────────────────────────────────────
+   Grid-focused, minimal, Japanese-inspired. Clean borders, generous spacing.
+   ──────────────────────────────────────────────────────────────────────────── */
+[data-design-theme="bento"] {
+  --dt-bg-primary: #fafaf9;
+  --dt-bg-secondary: #ffffff;
+  --dt-bg-card: #ffffff;
+  --dt-text-primary: #1c1917;
+  --dt-text-secondary: #78716c;
+  --dt-border: #e7e5e4;
+  --dt-border-subtle: #f5f5f4;
+  --dt-card-shadow: none;
+  --dt-card-radius: var(--radius-xl);
+  --dt-sidebar-bg: #ffffff;
+  --dt-sidebar-blur: none;
+  --dt-sidebar-border: #e7e5e4;
+  --dt-accent-gradient: linear-gradient(135deg, #0d9488, #14b8a6);
+  --dt-input-bg: #fafaf9;
+  --dt-input-border: #d6d3d1;
+  --dt-badge-radius: var(--radius-sm);
+  --dt-nav-active-bg: #f5f5f4;
+  --dt-nav-hover-bg: #fafaf9;
+  --dt-header-bg: #ffffff;
+}
+
+[data-design-theme="bento"].dark,
+.dark [data-design-theme="bento"] {
+  --dt-bg-primary: #0c0a09;
+  --dt-bg-secondary: #1c1917;
+  --dt-bg-card: #1c1917;
+  --dt-text-primary: #fafaf9;
+  --dt-text-secondary: #a8a29e;
+  --dt-border: #292524;
+  --dt-border-subtle: #1c1917;
+  --dt-card-shadow: none;
+  --dt-sidebar-bg: #1c1917;
+  --dt-sidebar-border: #292524;
+  --dt-input-bg: #292524;
+  --dt-input-border: #44403c;
+  --dt-nav-active-bg: #292524;
+  --dt-nav-hover-bg: #1c1917;
+  --dt-header-bg: #1c1917;
+}
+
+/* ── Theme: Brutalist ────────────────────────────────────────────────────────
+   Raw, bold, high-contrast. Thick borders, monospace accents, no rounded corners.
+   ──────────────────────────────────────────────────────────────────────────── */
+[data-design-theme="brutalist"] {
+  --dt-bg-primary: #ffffff;
+  --dt-bg-secondary: #ffffff;
+  --dt-bg-card: #ffffff;
+  --dt-text-primary: #000000;
+  --dt-text-secondary: #525252;
+  --dt-border: #000000;
+  --dt-border-subtle: #d4d4d4;
+  --dt-card-shadow: 4px 4px 0px #000000;
+  --dt-card-radius: 0px;
+  --dt-sidebar-bg: #ffffff;
+  --dt-sidebar-blur: none;
+  --dt-sidebar-border: #000000;
+  --dt-accent-gradient: linear-gradient(135deg, #000000, #404040);
+  --dt-input-bg: #ffffff;
+  --dt-input-border: #000000;
+  --dt-badge-radius: 0px;
+  --dt-nav-active-bg: #000000;
+  --dt-nav-hover-bg: #f5f5f5;
+  --dt-header-bg: #ffffff;
+}
+
+[data-design-theme="brutalist"].dark,
+.dark [data-design-theme="brutalist"] {
+  --dt-bg-primary: #0a0a0a;
+  --dt-bg-secondary: #0a0a0a;
+  --dt-bg-card: #171717;
+  --dt-text-primary: #ffffff;
+  --dt-text-secondary: #a3a3a3;
+  --dt-border: #ffffff;
+  --dt-border-subtle: #404040;
+  --dt-card-shadow: 4px 4px 0px #ffffff;
+  --dt-sidebar-bg: #0a0a0a;
+  --dt-sidebar-border: #ffffff;
+  --dt-input-bg: #171717;
+  --dt-input-border: #ffffff;
+  --dt-nav-active-bg: #ffffff;
+  --dt-nav-hover-bg: #171717;
+  --dt-header-bg: #0a0a0a;
+}
+
+/* ── Theme: Neon ─────────────────────────────────────────────────────────────
+   Dark-first with vibrant neon accents, cyberpunk-inspired glow effects.
+   ──────────────────────────────────────────────────────────────────────────── */
+[data-design-theme="neon"] {
+  --dt-bg-primary: #f8fafc;
+  --dt-bg-secondary: #ffffff;
+  --dt-bg-card: #ffffff;
+  --dt-text-primary: #0f172a;
+  --dt-text-secondary: #64748b;
+  --dt-border: #e2e8f0;
+  --dt-border-subtle: #f1f5f9;
+  --dt-card-shadow: 0 2px 8px rgba(99, 102, 241, 0.08);
+  --dt-card-radius: var(--radius-lg);
+  --dt-sidebar-bg: #ffffff;
+  --dt-sidebar-blur: none;
+  --dt-sidebar-border: #e2e8f0;
+  --dt-accent-gradient: linear-gradient(135deg, #6366f1, #a855f7);
+  --dt-input-bg: #ffffff;
+  --dt-input-border: #cbd5e1;
+  --dt-badge-radius: var(--radius-md);
+  --dt-nav-active-bg: rgba(99, 102, 241, 0.08);
+  --dt-nav-hover-bg: #f1f5f9;
+  --dt-header-bg: #ffffff;
+}
+
+[data-design-theme="neon"].dark,
+.dark [data-design-theme="neon"] {
+  --dt-bg-primary: #050510;
+  --dt-bg-secondary: #0a0a1a;
+  --dt-bg-card: rgba(99, 102, 241, 0.06);
+  --dt-text-primary: #e2e8f0;
+  --dt-text-secondary: #94a3b8;
+  --dt-border: rgba(99, 102, 241, 0.2);
+  --dt-border-subtle: rgba(99, 102, 241, 0.08);
+  --dt-card-shadow: 0 0 20px rgba(99, 102, 241, 0.12), 0 0 40px rgba(168, 85, 247, 0.06);
+  --dt-sidebar-bg: rgba(5, 5, 16, 0.95);
+  --dt-sidebar-border: rgba(99, 102, 241, 0.2);
+  --dt-input-bg: rgba(99, 102, 241, 0.06);
+  --dt-input-border: rgba(99, 102, 241, 0.25);
+  --dt-nav-active-bg: rgba(99, 102, 241, 0.15);
+  --dt-nav-hover-bg: rgba(99, 102, 241, 0.08);
+  --dt-header-bg: rgba(5, 5, 16, 0.95);
+}
+
+/* ── Theme: Warm ─────────────────────────────────────────────────────────────
+   Earth tones, soft gradients, cozy feel. Inspired by natural materials.
+   ──────────────────────────────────────────────────────────────────────────── */
+[data-design-theme="warm"] {
+  --dt-bg-primary: #fef7ee;
+  --dt-bg-secondary: #fffbf5;
+  --dt-bg-card: #fffbf5;
+  --dt-text-primary: #431407;
+  --dt-text-secondary: #9a3412;
+  --dt-border: #fed7aa;
+  --dt-border-subtle: #fff1e0;
+  --dt-card-shadow: 0 2px 8px rgba(194, 65, 12, 0.06);
+  --dt-card-radius: var(--radius-xl);
+  --dt-sidebar-bg: #fffbf5;
+  --dt-sidebar-blur: none;
+  --dt-sidebar-border: #fed7aa;
+  --dt-accent-gradient: linear-gradient(135deg, #ea580c, #f59e0b);
+  --dt-input-bg: #fffbf5;
+  --dt-input-border: #fdba74;
+  --dt-badge-radius: var(--radius-lg);
+  --dt-nav-active-bg: rgba(234, 88, 12, 0.08);
+  --dt-nav-hover-bg: #fff1e0;
+  --dt-header-bg: #fffbf5;
+}
+
+[data-design-theme="warm"].dark,
+.dark [data-design-theme="warm"] {
+  --dt-bg-primary: #1a0e04;
+  --dt-bg-secondary: #271505;
+  --dt-bg-card: #271505;
+  --dt-text-primary: #fed7aa;
+  --dt-text-secondary: #fb923c;
+  --dt-border: #7c2d12;
+  --dt-border-subtle: #431407;
+  --dt-card-shadow: 0 2px 8px rgba(194, 65, 12, 0.12);
+  --dt-sidebar-bg: #271505;
+  --dt-sidebar-border: #7c2d12;
+  --dt-input-bg: #431407;
+  --dt-input-border: #9a3412;
+  --dt-nav-active-bg: rgba(234, 88, 12, 0.15);
+  --dt-nav-hover-bg: #431407;
+  --dt-header-bg: #271505;
+}
+
+/* ═══════════════════════════════════════════════════════════════════════════════
+   Theme Application Layer
+   Maps design-theme tokens onto existing semantic tokens so all existing
+   components automatically pick up the active theme.
+   ═══════════════════════════════════════════════════════════════════════════════ */
+
+[data-design-theme] {
+  --theme-bg: var(--dt-bg-primary);
+  --theme-bg-subtle: var(--dt-bg-secondary);
+  --theme-bg-muted: var(--dt-bg-secondary);
+  --theme-text: var(--dt-text-primary);
+  --theme-text-muted: var(--dt-text-secondary);
+  --theme-border: var(--dt-border);
+  --theme-border-subtle: var(--dt-border-subtle);
+  --theme-card-bg: var(--dt-bg-card);
+  --theme-card-border: var(--dt-border);
+  --glass-bg: var(--dt-sidebar-bg);
+  --glass-border: var(--dt-border-subtle);
+  --glass-shadow: var(--dt-card-shadow);
+}

--- a/parkhub-web/src/views/Profile.tsx
+++ b/parkhub-web/src/views/Profile.tsx
@@ -14,6 +14,7 @@ import { ConfirmDialog } from '../components/ui/ConfirmDialog';
 import { TwoFactorSetupComponent } from '../components/TwoFactorSetup';
 import { NotificationPreferencesComponent } from '../components/NotificationPreferences';
 import { LoginHistoryComponent } from '../components/LoginHistory';
+import { ProfileThemeSection } from '../components/ProfileThemeSection';
 
 export function ProfilePage() {
   const { t } = useTranslation();
@@ -250,6 +251,11 @@ export function ProfilePage() {
           </button>
         </div>
       </motion.div>
+      {/* Design Theme */}
+      <motion.div variants={fadeUp} className="card p-6">
+        <ProfileThemeSection />
+      </motion.div>
+
       {/* Security: 2FA */}
       <motion.div variants={fadeUp} className="card p-6">
         <TwoFactorSetupComponent />


### PR DESCRIPTION
## Summary
- **6 selectable design themes**: Classic, Glass, Bento, Brutalist, Neon, Warm — each with full light/dark mode support
- **CSS architecture**: `themes.css` defines custom properties per theme, mapped onto existing semantic tokens so all components automatically adapt
- **ThemeContext upgraded**: `designTheme` state with localStorage persistence + server sync
- **ThemeSwitcher UI**: floating FAB button + slide-up panel with mini layout previews and color swatches
- **Profile integration**: theme selection section added to Profile page
- **Backend API**: `GET/PUT /api/v1/preferences/theme` with validation against 6 valid theme IDs
- **Feature module**: `mod-themes` feature flag, registered in FEATURE_MODULES/DEFAULT_FEATURES
- **i18n**: English + German translations for all theme names and descriptions

## Test plan
- [x] 25 frontend tests pass (18 ThemeContext + 7 ThemeSwitcher)
- [x] 4 backend Rust tests pass (default, update, invalid, all-valid-themes)
- [x] 0 clippy warnings
- [x] Rust `cargo check` compiles clean
- [ ] Manual: open theme switcher FAB, switch between themes, verify visual changes
- [ ] Manual: verify theme persists across page reload (localStorage)
- [ ] Manual: verify theme syncs to server for logged-in users