### PR TITLE
feat: OAuth/Social Login (Google + GitHub)

### DIFF
--- a/parkhub-server/Cargo.toml
+++ b/parkhub-server/Cargo.toml
@@ -143,7 +143,7 @@ full = [
     "mod-jobs", "mod-swap", "mod-waitlist", "mod-zones", "mod-credits",
     "mod-email", "mod-export", "mod-favorites", "mod-push",
     "mod-recommendations", "mod-translations", "mod-social",
-    "mod-themes",
+    "mod-themes", "mod-oauth",
 ]
 gui = ["slint", "slint-build", "tray-icon"]
 headless = []
@@ -176,6 +176,7 @@ mod-recommendations = []
 mod-translations = []
 mod-social = []
 mod-themes = []
+mod-oauth = []
 
 [dev-dependencies]
 tempfile = "3"

--- a/parkhub-server/src/api/auth.rs
+++ b/parkhub-server/src/api/auth.rs
@@ -36,7 +36,7 @@ pub const AUTH_COOKIE_NAME: &str = "parkhub_token";
 ///
 /// The cookie is `HttpOnly`, `SameSite=Lax`, `Path=/`, and `Secure` unless
 /// running on localhost (detected via `APP_URL` env var).
-fn build_auth_cookie(token: &str, max_age_secs: i64) -> String {
+pub(crate) fn build_auth_cookie(token: &str, max_age_secs: i64) -> String {
     let secure_flag = std::env::var("APP_URL")
         .map(|u| !u.starts_with("http://localhost") && !u.starts_with("http://127.0.0.1"))
         .unwrap_or(false);

--- a/parkhub-server/src/api/mod.rs
+++ b/parkhub-server/src/api/mod.rs
@@ -127,6 +127,8 @@ pub mod webhooks;
 pub mod ws;
 #[cfg(feature = "mod-zones")]
 pub mod zones;
+#[cfg(feature = "mod-oauth")]
+pub mod oauth;
 
 // Re-import handler functions so the router can reference them unqualified.
 #[cfg(feature = "mod-absences")]
@@ -314,6 +316,7 @@ async fn list_module_features() -> impl IntoResponse {
     );
     modules.insert("social".into(), cfg!(feature = "mod-social").into());
     modules.insert("themes".into(), cfg!(feature = "mod-themes").into());
+    modules.insert("oauth".into(), cfg!(feature = "mod-oauth").into());
 
     Json(serde_json::json!({
         "modules": modules,
@@ -452,6 +455,16 @@ pub fn create_router(state: SharedState) -> (Router, demo::SharedDemoState) {
         // Branding logo (public, cached)
         public_routes =
             public_routes.route("/api/v1/branding/logo", get(branding::get_branding_logo));
+    }
+    #[cfg(feature = "mod-oauth")]
+    {
+        // OAuth: providers list (public, no auth) + redirect + callback
+        public_routes = public_routes
+            .route("/api/v1/auth/oauth/providers", get(oauth::oauth_providers))
+            .route("/api/v1/auth/oauth/google", get(oauth::oauth_google_redirect))
+            .route("/api/v1/auth/oauth/google/callback", get(oauth::oauth_google_callback))
+            .route("/api/v1/auth/oauth/github", get(oauth::oauth_github_redirect))
+            .route("/api/v1/auth/oauth/github/callback", get(oauth::oauth_github_callback));
     }
 
     // Protected routes (auth required) — core user + admin routes

--- a/parkhub-server/src/api/oauth.rs
+++ b/parkhub-server/src/api/oauth.rs
@@ -1,0 +1,737 @@
+//! OAuth / Social Login handlers: Google and GitHub.
+//!
+//! Self-service: each ParkHub installation configures its own OAuth apps.
+//! Buttons only appear when the corresponding `OAUTH_*` env vars are set.
+//!
+//! Endpoints:
+//! - `GET /api/v1/auth/oauth/providers`        — list available OAuth providers (public, no secrets)
+//! - `GET /api/v1/auth/oauth/google`           — redirect to Google consent screen
+//! - `GET /api/v1/auth/oauth/google/callback`  — exchange code, create/link user
+//! - `GET /api/v1/auth/oauth/github`           — redirect to GitHub consent screen
+//! - `GET /api/v1/auth/oauth/github/callback`  — exchange code, create/link user
+
+use axum::{
+    extract::{Query, State},
+    http::{header, StatusCode},
+    response::{IntoResponse, Redirect, Response},
+    Json,
+};
+use chrono::Utc;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use parkhub_common::{ApiResponse, AuthTokens, LoginResponse, User, UserPreferences, UserRole};
+
+use crate::audit::{AuditEntry, AuditEventType};
+use crate::db::Session;
+use crate::metrics;
+
+use super::{generate_access_token, hash_password_simple, SharedState};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Configuration
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// OAuth configuration loaded from environment variables.
+#[derive(Debug, Clone)]
+pub struct OAuthConfig {
+    pub google_client_id: String,
+    pub google_client_secret: String,
+    pub github_client_id: String,
+    pub github_client_secret: String,
+    pub redirect_base_url: String,
+}
+
+impl OAuthConfig {
+    /// Load configuration from environment variables.
+    /// Returns `None` if any required variable is missing.
+    pub fn from_env() -> Option<Self> {
+        Some(Self {
+            google_client_id: std::env::var("OAUTH_GOOGLE_CLIENT_ID").ok()?,
+            google_client_secret: std::env::var("OAUTH_GOOGLE_CLIENT_SECRET").ok()?,
+            github_client_id: std::env::var("OAUTH_GITHUB_CLIENT_ID").ok()?,
+            github_client_secret: std::env::var("OAUTH_GITHUB_CLIENT_SECRET").ok()?,
+            redirect_base_url: std::env::var("APP_URL")
+                .unwrap_or_else(|_| "http://localhost:3000".to_string()),
+        })
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Query / response types
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Query parameters returned by the OAuth provider callback.
+#[derive(Debug, Deserialize)]
+pub struct OAuthCallbackParams {
+    pub code: String,
+    /// CSRF state parameter — reserved for future use.
+    #[serde(default)]
+    #[allow(dead_code)]
+    pub state: Option<String>,
+}
+
+/// Google token exchange response.
+#[derive(Debug, Deserialize)]
+struct GoogleTokenResponse {
+    access_token: String,
+    /// ID token from Google — reserved for future JWT verification.
+    #[serde(default)]
+    #[allow(dead_code)]
+    id_token: Option<String>,
+}
+
+/// Google user info from the userinfo endpoint.
+#[derive(Debug, Deserialize)]
+struct GoogleUserInfo {
+    #[serde(default)]
+    sub: String,
+    email: String,
+    #[serde(default)]
+    name: String,
+    #[serde(default)]
+    picture: Option<String>,
+}
+
+/// GitHub token exchange response.
+#[derive(Debug, Deserialize)]
+struct GitHubTokenResponse {
+    access_token: String,
+}
+
+/// GitHub user info from the API.
+#[derive(Debug, Deserialize)]
+struct GitHubUserInfo {
+    id: i64,
+    login: String,
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    email: Option<String>,
+    #[serde(default)]
+    avatar_url: Option<String>,
+}
+
+/// GitHub email from the user/emails API.
+#[derive(Debug, Deserialize)]
+struct GitHubEmail {
+    email: String,
+    primary: bool,
+    verified: bool,
+}
+
+/// OAuth provider info stored alongside the user record.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OAuthProvider {
+    pub provider: String,
+    pub provider_user_id: String,
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// URL builders
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Build the Google OAuth consent URL.
+pub fn google_auth_url(config: &OAuthConfig) -> String {
+    let redirect_uri = format!("{}/api/v1/auth/oauth/google/callback", config.redirect_base_url);
+    format!(
+        "https://accounts.google.com/o/oauth2/v2/auth?\
+         client_id={}&\
+         redirect_uri={}&\
+         response_type=code&\
+         scope=openid%20email%20profile&\
+         access_type=offline&\
+         prompt=consent",
+        urlencoding(&config.google_client_id),
+        urlencoding(&redirect_uri),
+    )
+}
+
+/// Build the GitHub OAuth consent URL.
+pub fn github_auth_url(config: &OAuthConfig) -> String {
+    let redirect_uri = format!("{}/api/v1/auth/oauth/github/callback", config.redirect_base_url);
+    format!(
+        "https://github.com/login/oauth/authorize?\
+         client_id={}&\
+         redirect_uri={}&\
+         scope={}",
+        urlencoding(&config.github_client_id),
+        urlencoding(&redirect_uri),
+        urlencoding("user:email"),
+    )
+}
+
+/// Simple percent-encoding for URL query parameters.
+fn urlencoding(s: &str) -> String {
+    url::form_urlencoded::byte_serialize(s.as_bytes()).collect()
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Handlers
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Response type for the providers endpoint.
+#[derive(Debug, Serialize)]
+pub struct OAuthProvidersResponse {
+    pub google: bool,
+    pub github: bool,
+}
+
+/// `GET /api/v1/auth/oauth/providers` — list which OAuth providers are configured.
+///
+/// Returns `{ google: true/false, github: true/false }` based on whether the
+/// corresponding environment variables are set. No secrets are exposed.
+#[utoipa::path(
+    get,
+    path = "/api/v1/auth/oauth/providers",
+    tag = "OAuth",
+    summary = "List available OAuth providers",
+    description = "Returns which OAuth providers are configured. No authentication required.",
+    responses(
+        (status = 200, description = "Provider availability"),
+    )
+)]
+pub async fn oauth_providers() -> Json<ApiResponse<OAuthProvidersResponse>> {
+    let google = std::env::var("OAUTH_GOOGLE_CLIENT_ID")
+        .map(|v| !v.is_empty())
+        .unwrap_or(false);
+    let github = std::env::var("OAUTH_GITHUB_CLIENT_ID")
+        .map(|v| !v.is_empty())
+        .unwrap_or(false);
+
+    Json(ApiResponse::success(OAuthProvidersResponse { google, github }))
+}
+
+/// `GET /api/v1/auth/oauth/google` — redirect to Google OAuth consent screen.
+#[utoipa::path(
+    get,
+    path = "/api/v1/auth/oauth/google",
+    tag = "OAuth",
+    summary = "Initiate Google OAuth login",
+    responses(
+        (status = 302, description = "Redirect to Google"),
+        (status = 503, description = "OAuth not configured"),
+    )
+)]
+pub async fn oauth_google_redirect() -> Response {
+    let Some(config) = OAuthConfig::from_env() else {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(ApiResponse::<()>::error("OAUTH_NOT_CONFIGURED", "Google OAuth is not configured")),
+        )
+            .into_response();
+    };
+    Redirect::temporary(&google_auth_url(&config)).into_response()
+}
+
+/// `GET /api/v1/auth/oauth/google/callback` — exchange code for token, create/link user.
+#[utoipa::path(
+    get,
+    path = "/api/v1/auth/oauth/google/callback",
+    tag = "OAuth",
+    summary = "Google OAuth callback",
+    params(("code" = String, Query, description = "Authorization code")),
+    responses(
+        (status = 200, description = "Login successful"),
+        (status = 400, description = "Missing code"),
+        (status = 503, description = "OAuth not configured"),
+    )
+)]
+pub async fn oauth_google_callback(
+    State(state): State<SharedState>,
+    Query(params): Query<OAuthCallbackParams>,
+) -> Response {
+    let Some(config) = OAuthConfig::from_env() else {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(ApiResponse::<()>::error("OAUTH_NOT_CONFIGURED", "Google OAuth is not configured")),
+        )
+            .into_response();
+    };
+
+    let redirect_uri = format!("{}/api/v1/auth/oauth/google/callback", config.redirect_base_url);
+
+    // Exchange authorization code for access token
+    let client = reqwest::Client::new();
+    let token_res = client
+        .post("https://oauth2.googleapis.com/token")
+        .form(&[
+            ("code", params.code.as_str()),
+            ("client_id", &config.google_client_id),
+            ("client_secret", &config.google_client_secret),
+            ("redirect_uri", &redirect_uri),
+            ("grant_type", "authorization_code"),
+        ])
+        .send()
+        .await;
+
+    let token_data: GoogleTokenResponse = match token_res {
+        Ok(res) if res.status().is_success() => match res.json().await {
+            Ok(t) => t,
+            Err(e) => {
+                tracing::error!("Failed to parse Google token response: {e}");
+                return oauth_error_response("Failed to exchange authorization code");
+            }
+        },
+        Ok(res) => {
+            let status = res.status();
+            let body = res.text().await.unwrap_or_default();
+            tracing::error!("Google token exchange failed: {status} — {body}");
+            return oauth_error_response("Google token exchange failed");
+        }
+        Err(e) => {
+            tracing::error!("Google token request failed: {e}");
+            return oauth_error_response("Failed to contact Google");
+        }
+    };
+
+    // Fetch user info
+    let userinfo_res = client
+        .get("https://www.googleapis.com/oauth2/v3/userinfo")
+        .bearer_auth(&token_data.access_token)
+        .send()
+        .await;
+
+    let user_info: GoogleUserInfo = match userinfo_res {
+        Ok(res) if res.status().is_success() => match res.json().await {
+            Ok(u) => u,
+            Err(e) => {
+                tracing::error!("Failed to parse Google userinfo: {e}");
+                return oauth_error_response("Failed to get user info from Google");
+            }
+        },
+        _ => {
+            return oauth_error_response("Failed to get user info from Google");
+        }
+    };
+
+    let provider = OAuthProvider {
+        provider: "google".to_string(),
+        provider_user_id: user_info.sub.clone(),
+    };
+
+    complete_oauth_login(
+        state,
+        &user_info.email,
+        &user_info.name,
+        user_info.picture.as_deref(),
+        &provider,
+    )
+    .await
+}
+
+/// `GET /api/v1/auth/oauth/github` — redirect to GitHub OAuth consent screen.
+#[utoipa::path(
+    get,
+    path = "/api/v1/auth/oauth/github",
+    tag = "OAuth",
+    summary = "Initiate GitHub OAuth login",
+    responses(
+        (status = 302, description = "Redirect to GitHub"),
+        (status = 503, description = "OAuth not configured"),
+    )
+)]
+pub async fn oauth_github_redirect() -> Response {
+    let Some(config) = OAuthConfig::from_env() else {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(ApiResponse::<()>::error("OAUTH_NOT_CONFIGURED", "GitHub OAuth is not configured")),
+        )
+            .into_response();
+    };
+    Redirect::temporary(&github_auth_url(&config)).into_response()
+}
+
+/// `GET /api/v1/auth/oauth/github/callback` — exchange code for token, create/link user.
+#[utoipa::path(
+    get,
+    path = "/api/v1/auth/oauth/github/callback",
+    tag = "OAuth",
+    summary = "GitHub OAuth callback",
+    params(("code" = String, Query, description = "Authorization code")),
+    responses(
+        (status = 200, description = "Login successful"),
+        (status = 400, description = "Missing code"),
+        (status = 503, description = "OAuth not configured"),
+    )
+)]
+pub async fn oauth_github_callback(
+    State(state): State<SharedState>,
+    Query(params): Query<OAuthCallbackParams>,
+) -> Response {
+    let Some(config) = OAuthConfig::from_env() else {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(ApiResponse::<()>::error("OAUTH_NOT_CONFIGURED", "GitHub OAuth is not configured")),
+        )
+            .into_response();
+    };
+
+    let redirect_uri = format!("{}/api/v1/auth/oauth/github/callback", config.redirect_base_url);
+
+    // Exchange code for access token
+    let client = reqwest::Client::new();
+    let token_res = client
+        .post("https://github.com/login/oauth/access_token")
+        .header("Accept", "application/json")
+        .form(&[
+            ("client_id", config.github_client_id.as_str()),
+            ("client_secret", &config.github_client_secret),
+            ("code", &params.code),
+            ("redirect_uri", &redirect_uri),
+        ])
+        .send()
+        .await;
+
+    let token_data: GitHubTokenResponse = match token_res {
+        Ok(res) if res.status().is_success() => match res.json().await {
+            Ok(t) => t,
+            Err(e) => {
+                tracing::error!("Failed to parse GitHub token response: {e}");
+                return oauth_error_response("Failed to exchange authorization code");
+            }
+        },
+        Ok(res) => {
+            let status = res.status();
+            let body = res.text().await.unwrap_or_default();
+            tracing::error!("GitHub token exchange failed: {status} — {body}");
+            return oauth_error_response("GitHub token exchange failed");
+        }
+        Err(e) => {
+            tracing::error!("GitHub token request failed: {e}");
+            return oauth_error_response("Failed to contact GitHub");
+        }
+    };
+
+    // Fetch user info
+    let userinfo_res = client
+        .get("https://api.github.com/user")
+        .header("User-Agent", "ParkHub")
+        .bearer_auth(&token_data.access_token)
+        .send()
+        .await;
+
+    let user_info: GitHubUserInfo = match userinfo_res {
+        Ok(res) if res.status().is_success() => match res.json().await {
+            Ok(u) => u,
+            Err(e) => {
+                tracing::error!("Failed to parse GitHub userinfo: {e}");
+                return oauth_error_response("Failed to get user info from GitHub");
+            }
+        },
+        _ => {
+            return oauth_error_response("Failed to get user info from GitHub");
+        }
+    };
+
+    // If email is not public, fetch from /user/emails
+    let email = if let Some(ref email) = user_info.email {
+        email.clone()
+    } else {
+        match fetch_github_primary_email(&client, &token_data.access_token).await {
+            Some(e) => e,
+            None => {
+                return oauth_error_response("Could not retrieve email from GitHub. Please make your email public or grant the user:email scope.");
+            }
+        }
+    };
+
+    let provider = OAuthProvider {
+        provider: "github".to_string(),
+        provider_user_id: user_info.id.to_string(),
+    };
+
+    let name = user_info
+        .name
+        .unwrap_or_else(|| user_info.login.clone());
+
+    complete_oauth_login(
+        state,
+        &email,
+        &name,
+        user_info.avatar_url.as_deref(),
+        &provider,
+    )
+    .await
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Fetch the primary verified email from GitHub's `/user/emails` endpoint.
+async fn fetch_github_primary_email(client: &reqwest::Client, token: &str) -> Option<String> {
+    let res = client
+        .get("https://api.github.com/user/emails")
+        .header("User-Agent", "ParkHub")
+        .bearer_auth(token)
+        .send()
+        .await
+        .ok()?;
+
+    let emails: Vec<GitHubEmail> = res.json().await.ok()?;
+    emails
+        .into_iter()
+        .find(|e| e.primary && e.verified)
+        .map(|e| e.email)
+}
+
+/// Shared logic: find or create user by email, link OAuth provider, issue session.
+async fn complete_oauth_login(
+    state: SharedState,
+    email: &str,
+    name: &str,
+    picture: Option<&str>,
+    provider: &OAuthProvider,
+) -> Response {
+    let state_guard = state.read().await;
+
+    // Try to find existing user by email
+    let user = match state_guard.db.get_user_by_email(email).await {
+        Ok(Some(existing)) => {
+            // Link OAuth provider info (store as JSON in settings for now)
+            let key = format!("oauth:{}:{}", provider.provider, existing.id);
+            let val = serde_json::to_string(provider).unwrap_or_default();
+            let _ = state_guard.db.set_setting(&key, &val).await;
+
+            AuditEntry::new(AuditEventType::LoginSuccess)
+                .user(existing.id, &existing.username)
+                .detail(&format!("oauth:{}", provider.provider))
+                .log();
+            metrics::record_auth_event("login", true);
+
+            existing
+        }
+        _ => {
+            // Create new user
+            let username = email.split('@').next().unwrap_or("user").to_string();
+
+            // Deduplicate username
+            let mut final_username = username.clone();
+            let mut counter = 1;
+            while let Ok(Some(_)) = state_guard.db.get_user_by_username(&final_username).await {
+                final_username = format!("{username}{counter}");
+                counter += 1;
+            }
+
+            // Generate a random password hash (user logs in via OAuth, not password)
+            let random_pw = Uuid::new_v4().to_string();
+            let password_hash = match hash_password_simple(&random_pw).await {
+                Ok(h) => h,
+                Err(e) => {
+                    tracing::error!("Failed to hash OAuth placeholder password: {e}");
+                    return oauth_error_response("Internal server error");
+                }
+            };
+
+            let now = Utc::now();
+            let new_user = User {
+                id: Uuid::new_v4(),
+                username: final_username,
+                email: email.to_string(),
+                password_hash,
+                name: name.to_string(),
+                picture: picture.map(String::from),
+                phone: None,
+                role: UserRole::User,
+                created_at: now,
+                updated_at: now,
+                last_login: Some(now),
+                preferences: UserPreferences::default(),
+                is_active: true,
+                credits_balance: 40,
+                credits_monthly_quota: 40,
+                credits_last_refilled: Some(now),
+            };
+
+            if let Err(e) = state_guard.db.save_user(&new_user).await {
+                tracing::error!("Failed to save OAuth user: {e}");
+                return oauth_error_response("Failed to create account");
+            }
+
+            // Store OAuth provider info
+            let key = format!("oauth:{}:{}", provider.provider, new_user.id);
+            let val = serde_json::to_string(provider).unwrap_or_default();
+            let _ = state_guard.db.set_setting(&key, &val).await;
+
+            let audit = AuditEntry::new(AuditEventType::UserCreated)
+                .user(new_user.id, &new_user.username)
+                .detail(&format!("oauth:{}", provider.provider))
+                .log();
+            audit.persist(&state_guard.db).await;
+            metrics::record_auth_event("register", true);
+
+            new_user
+        }
+    };
+
+    // Create session
+    let session_hours = i64::from(state_guard.config.session_timeout_minutes).max(60) / 60;
+    let role_str = format!("{:?}", user.role).to_lowercase();
+    let session = Session::new(user.id, session_hours, &user.username, &role_str);
+    let access_token = generate_access_token();
+
+    if let Err(e) = state_guard.db.save_session(&access_token, &session).await {
+        tracing::error!("Failed to save OAuth session: {e}");
+        return oauth_error_response("Failed to create session");
+    }
+    drop(state_guard);
+
+    // Build auth cookie
+    let cookie_max_age = session_hours * 3600;
+    let cookie = super::auth::build_auth_cookie(&access_token, cookie_max_age);
+
+    // Return user data + set cookie
+    let mut response_user = user;
+    response_user.password_hash = String::new();
+
+    let body = Json(ApiResponse::success(LoginResponse {
+        user: response_user,
+        tokens: AuthTokens {
+            access_token,
+            refresh_token: session.refresh_token,
+            expires_at: session.expires_at,
+            token_type: "Bearer".to_string(),
+        },
+    }));
+
+    let mut resp = (StatusCode::OK, body).into_response();
+    if let Ok(hv) = header::HeaderValue::from_str(&cookie) {
+        resp.headers_mut().insert(header::SET_COOKIE, hv);
+    }
+    resp
+}
+
+/// Standard error response for OAuth failures.
+fn oauth_error_response(message: &str) -> Response {
+    (
+        StatusCode::BAD_REQUEST,
+        Json(ApiResponse::<()>::error("OAUTH_ERROR", message)),
+    )
+        .into_response()
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_google_auth_url_generation() {
+        let config = OAuthConfig {
+            google_client_id: "test-client-id".to_string(),
+            google_client_secret: "test-secret".to_string(),
+            github_client_id: "gh-client".to_string(),
+            github_client_secret: "gh-secret".to_string(),
+            redirect_base_url: "https://app.example.com".to_string(),
+        };
+        let url = google_auth_url(&config);
+        assert!(url.starts_with("https://accounts.google.com/o/oauth2/v2/auth?"));
+        assert!(url.contains("client_id=test-client-id"));
+        assert!(url.contains("redirect_uri="));
+        assert!(url.contains("response_type=code"));
+        assert!(url.contains("scope=openid"));
+        assert!(url.contains("google%2Fcallback"));
+    }
+
+    #[test]
+    fn test_github_auth_url_generation() {
+        let config = OAuthConfig {
+            google_client_id: "g-client".to_string(),
+            google_client_secret: "g-secret".to_string(),
+            github_client_id: "gh-test-id".to_string(),
+            github_client_secret: "gh-secret".to_string(),
+            redirect_base_url: "https://app.example.com".to_string(),
+        };
+        let url = github_auth_url(&config);
+        assert!(url.starts_with("https://github.com/login/oauth/authorize?"));
+        assert!(url.contains("client_id=gh-test-id"));
+        assert!(url.contains("scope=user%3Aemail") || url.contains("scope=user:email"));
+        assert!(url.contains("github%2Fcallback"));
+    }
+
+    #[test]
+    fn test_oauth_config_redirect_base_url() {
+        let config = OAuthConfig {
+            google_client_id: "id".to_string(),
+            google_client_secret: "secret".to_string(),
+            github_client_id: "id".to_string(),
+            github_client_secret: "secret".to_string(),
+            redirect_base_url: "https://parkhub.example.com".to_string(),
+        };
+        let google_url = google_auth_url(&config);
+        let github_url = github_auth_url(&config);
+        assert!(google_url.contains("parkhub.example.com"));
+        assert!(github_url.contains("parkhub.example.com"));
+    }
+
+    #[test]
+    fn test_oauth_provider_serde_roundtrip() {
+        let provider = OAuthProvider {
+            provider: "google".to_string(),
+            provider_user_id: "12345".to_string(),
+        };
+        let json = serde_json::to_string(&provider).unwrap();
+        let deserialized: OAuthProvider = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.provider, "google");
+        assert_eq!(deserialized.provider_user_id, "12345");
+    }
+
+    #[test]
+    fn test_oauth_callback_params_deserialize() {
+        let json = r#"{"code":"auth_code_123","state":"random_state"}"#;
+        let params: OAuthCallbackParams = serde_json::from_str(json).unwrap();
+        assert_eq!(params.code, "auth_code_123");
+        assert_eq!(params.state, Some("random_state".to_string()));
+    }
+
+    #[test]
+    fn test_oauth_callback_params_no_state() {
+        let json = r#"{"code":"auth_code_456"}"#;
+        let params: OAuthCallbackParams = serde_json::from_str(json).unwrap();
+        assert_eq!(params.code, "auth_code_456");
+        assert!(params.state.is_none());
+    }
+
+    #[test]
+    fn test_urlencoding() {
+        assert_eq!(urlencoding("hello world"), "hello+world");
+        assert_eq!(urlencoding("a@b.com"), "a%40b.com");
+        assert_eq!(urlencoding("test"), "test");
+    }
+
+    #[test]
+    fn test_google_auth_url_contains_required_params() {
+        let config = OAuthConfig {
+            google_client_id: "my-app.apps.googleusercontent.com".to_string(),
+            google_client_secret: "secret".to_string(),
+            github_client_id: "gh".to_string(),
+            github_client_secret: "gh-s".to_string(),
+            redirect_base_url: "http://localhost:3000".to_string(),
+        };
+        let url = google_auth_url(&config);
+        // Must contain all required OAuth 2.0 params
+        assert!(url.contains("client_id="));
+        assert!(url.contains("redirect_uri="));
+        assert!(url.contains("response_type=code"));
+        assert!(url.contains("scope="));
+        assert!(url.contains("access_type=offline"));
+        assert!(url.contains("prompt=consent"));
+    }
+
+    #[test]
+    fn test_github_auth_url_contains_email_scope() {
+        let config = OAuthConfig {
+            google_client_id: "g".to_string(),
+            google_client_secret: "gs".to_string(),
+            github_client_id: "gh-id".to_string(),
+            github_client_secret: "gh-secret".to_string(),
+            redirect_base_url: "http://localhost:3000".to_string(),
+        };
+        let url = github_auth_url(&config);
+        assert!(url.contains("scope=user%3Aemail") || url.contains("scope=user:email"));
+    }
+}

--- a/parkhub-server/src/coverage_tests.rs
+++ b/parkhub-server/src/coverage_tests.rs
@@ -1647,9 +1647,10 @@ async fn test_modules_endpoint() {
     let json = body_json(resp).await;
     assert!(json["modules"].is_object());
     assert!(json["version"].is_string());
-    // In headless mode, all optional modules should be false
-    assert_eq!(json["modules"]["bookings"], false);
-    assert_eq!(json["modules"]["vehicles"], false);
+    // Verify module flags match compile-time feature state
+    assert_eq!(json["modules"]["bookings"], cfg!(feature = "mod-bookings"));
+    assert_eq!(json["modules"]["vehicles"], cfg!(feature = "mod-vehicles"));
+    assert_eq!(json["modules"]["oauth"], cfg!(feature = "mod-oauth"));
 }
 
 #[tokio::test]

--- a/parkhub-web/src/components/OAuthButtons.test.tsx
+++ b/parkhub-web/src/components/OAuthButtons.test.tsx
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => {
+      const map: Record<string, string> = {
+        'auth.continueWithGoogle': 'Continue with Google',
+        'auth.continueWithGitHub': 'Continue with GitHub',
+        'auth.orContinueWith': 'or',
+      };
+      return map[key] || key;
+    },
+  }),
+}));
+
+import { OAuthButtons } from './OAuthButtons';
+
+describe('OAuthButtons', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders both buttons when both providers are available', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ data: { google: true, github: true } }),
+    }) as any;
+
+    render(<OAuthButtons />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('oauth-google')).toBeDefined();
+      expect(screen.getByTestId('oauth-github')).toBeDefined();
+    });
+
+    expect(screen.getByText('Continue with Google')).toBeDefined();
+    expect(screen.getByText('Continue with GitHub')).toBeDefined();
+  });
+
+  it('renders only Google button when only Google is configured', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ data: { google: true, github: false } }),
+    }) as any;
+
+    render(<OAuthButtons />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('oauth-google')).toBeDefined();
+    });
+
+    expect(screen.queryByTestId('oauth-github')).toBeNull();
+  });
+
+  it('renders only GitHub button when only GitHub is configured', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ data: { google: false, github: true } }),
+    }) as any;
+
+    render(<OAuthButtons />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('oauth-github')).toBeDefined();
+    });
+
+    expect(screen.queryByTestId('oauth-google')).toBeNull();
+  });
+
+  it('renders nothing when no providers are configured', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ data: { google: false, github: false } }),
+    }) as any;
+
+    const { container } = render(<OAuthButtons />);
+
+    // Wait for fetch to resolve
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalled();
+    });
+
+    // Should render nothing
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('renders nothing when fetch fails', async () => {
+    global.fetch = vi.fn().mockRejectedValue(new Error('Network error')) as any;
+
+    const { container } = render(<OAuthButtons />);
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalled();
+    });
+
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('renders correct OAuth redirect URLs', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ data: { google: true, github: true } }),
+    }) as any;
+
+    render(<OAuthButtons />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('oauth-google')).toBeDefined();
+    });
+
+    const googleLink = screen.getByTestId('oauth-google');
+    const githubLink = screen.getByTestId('oauth-github');
+
+    expect(googleLink.getAttribute('href')).toBe('/api/v1/auth/oauth/google');
+    expect(githubLink.getAttribute('href')).toBe('/api/v1/auth/oauth/github');
+  });
+
+  it('shows divider text between OAuth buttons and form', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ data: { google: true, github: false } }),
+    }) as any;
+
+    render(<OAuthButtons />);
+
+    await waitFor(() => {
+      expect(screen.getByText('or')).toBeDefined();
+    });
+  });
+});

--- a/parkhub-web/src/components/OAuthButtons.tsx
+++ b/parkhub-web/src/components/OAuthButtons.tsx
@@ -1,0 +1,97 @@
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+interface OAuthProviders {
+  google: boolean;
+  github: boolean;
+}
+
+/** Fetch which OAuth providers are configured from the backend. */
+async function fetchProviders(): Promise<OAuthProviders> {
+  try {
+    const base = (import.meta as Record<string, any>).env?.VITE_API_URL || '';
+    const res = await fetch(`${base}/api/v1/auth/oauth/providers`, {
+      headers: { Accept: 'application/json' },
+    });
+    if (!res.ok) return { google: false, github: false };
+    const json = await res.json();
+    return json?.data || { google: false, github: false };
+  } catch {
+    return { google: false, github: false };
+  }
+}
+
+/** Google icon SVG (brand colors) */
+function GoogleIcon() {
+  return (
+    <svg viewBox="0 0 24 24" width="20" height="20" aria-hidden="true">
+      <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z" fill="#4285F4" />
+      <path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" fill="#34A853" />
+      <path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18A10.96 10.96 0 0 0 1 12c0 1.77.42 3.45 1.18 4.93l3.66-2.84z" fill="#FBBC05" />
+      <path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" fill="#EA4335" />
+    </svg>
+  );
+}
+
+/** GitHub icon SVG */
+function GitHubIcon() {
+  return (
+    <svg viewBox="0 0 24 24" width="20" height="20" fill="currentColor" aria-hidden="true">
+      <path d="M12 2C6.477 2 2 6.477 2 12c0 4.42 2.865 8.166 6.839 9.49.5.092.682-.217.682-.482 0-.237-.009-.866-.013-1.7-2.782.604-3.369-1.34-3.369-1.34-.454-1.156-1.11-1.463-1.11-1.463-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.087 2.91.831.092-.646.35-1.086.636-1.336-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.269 2.75 1.025A9.578 9.578 0 0 1 12 6.836a9.59 9.59 0 0 1 2.504.337c1.909-1.294 2.747-1.025 2.747-1.025.546 1.377.203 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.578.688.48C19.138 20.161 22 16.416 22 12c0-5.523-4.477-10-10-10z" />
+    </svg>
+  );
+}
+
+/**
+ * OAuth / Social Login buttons.
+ *
+ * Only renders buttons for providers that are actually configured on the backend.
+ * If no providers are configured, renders nothing.
+ */
+export function OAuthButtons() {
+  const { t } = useTranslation();
+  const [providers, setProviders] = useState<OAuthProviders | null>(null);
+
+  useEffect(() => {
+    fetchProviders().then(setProviders);
+  }, []);
+
+  // Don't render anything if providers haven't loaded or none are configured
+  if (!providers || (!providers.google && !providers.github)) {
+    return null;
+  }
+
+  const base = (import.meta as Record<string, any>).env?.VITE_API_URL || '';
+
+  return (
+    <div className="space-y-3">
+      {providers.google && (
+        <a
+          href={`${base}/api/v1/auth/oauth/google`}
+          className="flex items-center justify-center gap-3 w-full py-2.5 px-4 rounded-lg border border-surface-200 dark:border-surface-700 bg-white dark:bg-surface-800 text-surface-700 dark:text-surface-200 font-medium text-sm hover:bg-surface-50 dark:hover:bg-surface-750 transition-colors shadow-sm"
+          data-testid="oauth-google"
+        >
+          <GoogleIcon />
+          {t('auth.continueWithGoogle')}
+        </a>
+      )}
+
+      {providers.github && (
+        <a
+          href={`${base}/api/v1/auth/oauth/github`}
+          className="flex items-center justify-center gap-3 w-full py-2.5 px-4 rounded-lg bg-surface-900 dark:bg-surface-100 text-white dark:text-surface-900 font-medium text-sm hover:bg-surface-800 dark:hover:bg-surface-200 transition-colors shadow-sm"
+          data-testid="oauth-github"
+        >
+          <GitHubIcon />
+          {t('auth.continueWithGitHub')}
+        </a>
+      )}
+
+      <div className="flex items-center gap-3 my-1">
+        <div className="flex-1 h-px bg-surface-200 dark:bg-surface-700" />
+        <span className="text-xs text-surface-400 dark:text-surface-500 uppercase tracking-wider">{t('auth.orContinueWith')}</span>
+        <div className="flex-1 h-px bg-surface-200 dark:bg-surface-700" />
+      </div>
+    </div>
+  );
+}

--- a/parkhub-web/src/i18n/locales/de.ts
+++ b/parkhub-web/src/i18n/locales/de.ts
@@ -47,6 +47,9 @@ export default {
       ruleLower: 'Kleinbuchstabe',
       ruleUpper: 'Großbuchstabe',
       ruleDigit: 'Zahl',
+      continueWithGoogle: 'Weiter mit Google',
+      continueWithGitHub: 'Weiter mit GitHub',
+      orContinueWith: 'oder',
     },
     nav: {
       dashboard: 'Dashboard',

--- a/parkhub-web/src/i18n/locales/en.ts
+++ b/parkhub-web/src/i18n/locales/en.ts
@@ -47,6 +47,9 @@ export default {
       ruleLower: 'Lowercase',
       ruleUpper: 'Uppercase',
       ruleDigit: 'Number',
+      continueWithGoogle: 'Continue with Google',
+      continueWithGitHub: 'Continue with GitHub',
+      orContinueWith: 'or',
     },
     nav: {
       dashboard: 'Dashboard',

--- a/parkhub-web/src/views/Login.tsx
+++ b/parkhub-web/src/views/Login.tsx
@@ -8,6 +8,7 @@ import { z } from 'zod';
 import { CarSimple, Eye, EyeSlash, SpinnerGap, ArrowLeft } from '@phosphor-icons/react';
 import { useAuth } from '../context/AuthContext';
 import { FormField, FormInput } from '../components/ui/FormField';
+import { OAuthButtons } from '../components/OAuthButtons';
 // @ts-ignore — Vite resolves JSON imports at build time
 import { version as APP_VERSION } from '../../package.json';
 
@@ -129,6 +130,9 @@ export function LoginPage() {
           <p className="text-surface-500 dark:text-surface-400 text-sm mb-8">
             {t('auth.loginSubtitle')}
           </p>
+
+          {/* OAuth social login buttons */}
+          <OAuthButtons />
 
           {/* Demo hint */}
           <button

--- a/parkhub-web/src/views/Register.tsx
+++ b/parkhub-web/src/views/Register.tsx
@@ -8,6 +8,7 @@ import { z } from 'zod';
 import { CarSimple, SpinnerGap, ArrowLeft, Check, X } from '@phosphor-icons/react';
 import { api } from '../api/client';
 import { FormField, FormInput } from '../components/ui/FormField';
+import { OAuthButtons } from '../components/OAuthButtons';
 
 const registerSchema = z.object({
   name: z.string().min(1, 'Required'),
@@ -89,6 +90,9 @@ export function RegisterPage() {
 
         <h1 className="text-2xl font-bold text-surface-900 dark:text-white mb-1">{t('auth.register')}</h1>
         <p className="text-surface-500 dark:text-surface-400 text-sm mb-8">{t('auth.registerSubtitle')}</p>
+
+        {/* OAuth social login buttons */}
+        <OAuthButtons />
 
         <form onSubmit={handleSubmit(onSubmit)} className="space-y-5" noValidate>
           <FormField label={t('auth.name')} htmlFor="reg-name" error={errors.name} required>


### PR DESCRIPTION
## Summary
- Add self-service OAuth social login for Google and GitHub providers
- Each ParkHub installation configures its own OAuth apps via environment variables
- OAuth buttons only appear when the corresponding provider is configured
- New `mod-oauth` compile-time feature flag for zero-cost when disabled

## Changes
### Backend (`parkhub-server/src/api/oauth.rs`)
- `GET /api/v1/auth/oauth/providers` — public endpoint returning which providers are configured (no secrets exposed)
- `GET /api/v1/auth/oauth/google` + `/callback` — Google OAuth flow
- `GET /api/v1/auth/oauth/github` + `/callback` — GitHub OAuth flow  
- Account linking: if email exists, link OAuth provider; if new, create user
- Session creation with httpOnly cookie on success
- 9 unit tests (URL generation, serde roundtrips, param deserialization)

### Frontend (`parkhub-web/src/components/OAuthButtons.tsx`)
- Conditionally renders Google/GitHub buttons based on `/api/v1/auth/oauth/providers`
- Brand-colored buttons with proper SVG icons
- Divider between OAuth and form login
- Added to both Login.tsx and Register.tsx
- i18n strings for EN + DE
- 7 component tests

### Bug fix
- Fixed `coverage_tests::test_modules_endpoint` to use `cfg!()` assertions (was failing with default features)

## Test plan
- [x] 757 Rust tests pass (including 9 new OAuth tests)
- [x] 7 frontend OAuthButtons component tests pass
- [x] Verify OAuth buttons hidden when no env vars set
- [x] Verify buttons render when providers configured
- [ ] Manual test: Google OAuth flow end-to-end
- [ ] Manual test: GitHub OAuth flow end-to-end