### PR TITLE
feat: Synthwave + Zen themes (12 total)

### DIFF
--- a/parkhub-server/src/api/admin_ext.rs
+++ b/parkhub-server/src/api/admin_ext.rs
@@ -634,6 +634,8 @@ const VALID_DESIGN_THEMES: &[&str] = &[
     "mono",
     "ocean",
     "forest",
+    "synthwave",
+    "zen",
 ];
 
 /// Design theme preference.

--- a/parkhub-web/src/context/ThemeContext.tsx
+++ b/parkhub-web/src/context/ThemeContext.tsx
@@ -7,7 +7,7 @@ type ColorMode = 'light' | 'dark' | 'system';
 
 // ── Design Themes ──
 
-export type DesignThemeId = 'classic' | 'glass' | 'bento' | 'brutalist' | 'neon' | 'warm' | 'liquid' | 'mono' | 'ocean' | 'forest';
+export type DesignThemeId = 'classic' | 'glass' | 'bento' | 'brutalist' | 'neon' | 'warm' | 'liquid' | 'mono' | 'ocean' | 'forest' | 'synthwave' | 'zen';
 
 export interface DesignThemeInfo {
   id: DesignThemeId;
@@ -121,6 +121,26 @@ export const DESIGN_THEMES: DesignThemeInfo[] = [
       dark: ['#0d1a0d', '#142814', '#22c55e', '#c8dcc0', '#1e3a1e'],
     },
     tags: ['nature', 'green', 'organic', 'sustainable'],
+  },
+  {
+    id: 'synthwave',
+    name: 'Synthwave',
+    description: '80s retro-futurism with neon purple-pink glow.',
+    previewColors: {
+      light: ['#f5f0ff', '#ffffff', '#a855f7', '#2e1065', '#ddd6fe'],
+      dark: ['#0f0019', 'rgba(168,85,247,0.06)', '#a855f7', '#e9d5ff', 'rgba(168,85,247,0.2)'],
+    },
+    tags: ['retro', '80s', 'cyberpunk', 'purple', 'glow'],
+  },
+  {
+    id: 'zen',
+    name: 'Zen',
+    description: 'Wabi-sabi Japanese minimalism. Paper textures, ink-wash subtlety.',
+    previewColors: {
+      light: ['#faf8f5', '#fdfcfa', '#87a68f', '#3d3731', '#e8e4df'],
+      dark: ['#1a1815', '#221f1b', '#87a68f', '#d4cfc8', '#33302b'],
+    },
+    tags: ['japanese', 'wabi-sabi', 'minimal', 'paper', 'zen'],
   },
 ];
 

--- a/parkhub-web/src/i18n/locales/de.ts
+++ b/parkhub-web/src/i18n/locales/de.ts
@@ -807,6 +807,8 @@ export default {
         mono: 'Mono',
         ocean: 'Ozean',
         forest: 'Wald',
+        synthwave: 'Synthwave',
+        zen: 'Zen',
       },
       descriptions: {
         classic: 'Sauber, professionell. Der originale ParkHub-Look.',
@@ -819,6 +821,8 @@ export default {
         mono: 'Ultra-minimales Monochrom. Präzisions-Design.',
         ocean: 'Tiefblaue maritime Palette mit Türkis-Akzenten.',
         forest: 'Naturinspirierte Grüntöne. Nachhaltig und geerdet.',
+        synthwave: '80er-Retro-Futurismus mit Neon-Lila-Pink-Glühen.',
+        zen: 'Wabi-Sabi japanischer Minimalismus. Papier-Texturen, Tusche-Subtilität.',
       },
     },
     payment: {

--- a/parkhub-web/src/i18n/locales/en.ts
+++ b/parkhub-web/src/i18n/locales/en.ts
@@ -807,6 +807,8 @@ export default {
         mono: 'Mono',
         ocean: 'Ocean',
         forest: 'Forest',
+        synthwave: 'Synthwave',
+        zen: 'Zen',
       },
       descriptions: {
         classic: 'Clean, professional. The original ParkHub look.',
@@ -819,6 +821,8 @@ export default {
         mono: 'Hyper-minimal monochrome. Developer-aesthetic precision.',
         ocean: 'Deep blue maritime palette with teal accents.',
         forest: 'Nature-inspired organic greens. Grounded and sustainable.',
+        synthwave: '80s retro-futurism with neon purple-pink glow.',
+        zen: 'Wabi-sabi Japanese minimalism. Paper textures, ink-wash subtlety.',
       },
     },
     payment: {

--- a/parkhub-web/src/styles/themes.css
+++ b/parkhub-web/src/styles/themes.css
@@ -448,6 +448,96 @@
   --dt-header-bg: rgba(13, 26, 13, 0.9);
 }
 
+/* ── Theme: Synthwave ────────────────────────────────────────────────────────
+   80s retro-futurism. Purple-pink gradients, neon cyan/magenta accents,
+   grid horizons, CRT glow effects. Dark-first by design.
+   ──────────────────────────────────────────────────────────────────────────── */
+[data-design-theme="synthwave"] {
+  --dt-bg-primary: #f5f0ff;
+  --dt-bg-secondary: #faf5ff;
+  --dt-bg-card: #ffffff;
+  --dt-text-primary: #2e1065;
+  --dt-text-secondary: #7c3aed;
+  --dt-border: #ddd6fe;
+  --dt-border-subtle: #ede9fe;
+  --dt-card-shadow: 0 2px 12px rgba(139, 92, 246, 0.08);
+  --dt-card-radius: var(--radius-xl);
+  --dt-sidebar-bg: #faf5ff;
+  --dt-sidebar-blur: none;
+  --dt-sidebar-border: #ddd6fe;
+  --dt-accent-gradient: linear-gradient(135deg, #a855f7, #ec4899);
+  --dt-input-bg: #ffffff;
+  --dt-input-border: #c4b5fd;
+  --dt-badge-radius: var(--radius-md);
+  --dt-nav-active-bg: rgba(168, 85, 247, 0.08);
+  --dt-nav-hover-bg: #ede9fe;
+  --dt-header-bg: rgba(250, 245, 255, 0.9);
+}
+
+[data-design-theme="synthwave"].dark,
+.dark [data-design-theme="synthwave"] {
+  --dt-bg-primary: #0f0019;
+  --dt-bg-secondary: #1a0030;
+  --dt-bg-card: rgba(168, 85, 247, 0.06);
+  --dt-text-primary: #e9d5ff;
+  --dt-text-secondary: #c084fc;
+  --dt-border: rgba(168, 85, 247, 0.2);
+  --dt-border-subtle: rgba(168, 85, 247, 0.08);
+  --dt-card-shadow: 0 0 24px rgba(168, 85, 247, 0.1), 0 0 48px rgba(236, 72, 153, 0.05);
+  --dt-sidebar-bg: rgba(15, 0, 25, 0.95);
+  --dt-sidebar-border: rgba(168, 85, 247, 0.2);
+  --dt-input-bg: rgba(168, 85, 247, 0.06);
+  --dt-input-border: rgba(168, 85, 247, 0.25);
+  --dt-nav-active-bg: rgba(168, 85, 247, 0.15);
+  --dt-nav-hover-bg: rgba(168, 85, 247, 0.06);
+  --dt-header-bg: rgba(15, 0, 25, 0.95);
+}
+
+/* ── Theme: Zen ─────────────────────────────────────────────────────────────
+   Wabi-sabi Japanese minimalism. Maximum whitespace, muted earth palette,
+   hairline borders, paper textures, ink-wash subtlety.
+   ──────────────────────────────────────────────────────────────────────────── */
+[data-design-theme="zen"] {
+  --dt-bg-primary: #faf8f5;
+  --dt-bg-secondary: #fdfcfa;
+  --dt-bg-card: #fdfcfa;
+  --dt-text-primary: #3d3731;
+  --dt-text-secondary: #908880;
+  --dt-border: #e8e4df;
+  --dt-border-subtle: #f2efe9;
+  --dt-card-shadow: none;
+  --dt-card-radius: 4px;
+  --dt-sidebar-bg: #fdfcfa;
+  --dt-sidebar-blur: none;
+  --dt-sidebar-border: #e8e4df;
+  --dt-accent-gradient: linear-gradient(135deg, #87a68f, #6b8e72);
+  --dt-input-bg: #fdfcfa;
+  --dt-input-border: #d4cfc8;
+  --dt-badge-radius: 2px;
+  --dt-nav-active-bg: rgba(135, 166, 143, 0.08);
+  --dt-nav-hover-bg: #f2efe9;
+  --dt-header-bg: #fdfcfa;
+}
+
+[data-design-theme="zen"].dark,
+.dark [data-design-theme="zen"] {
+  --dt-bg-primary: #1a1815;
+  --dt-bg-secondary: #221f1b;
+  --dt-bg-card: #221f1b;
+  --dt-text-primary: #d4cfc8;
+  --dt-text-secondary: #908880;
+  --dt-border: #33302b;
+  --dt-border-subtle: #2a2722;
+  --dt-card-shadow: none;
+  --dt-sidebar-bg: #1a1815;
+  --dt-sidebar-border: #33302b;
+  --dt-input-bg: #2a2722;
+  --dt-input-border: #44403a;
+  --dt-nav-active-bg: rgba(135, 166, 143, 0.1);
+  --dt-nav-hover-bg: #2a2722;
+  --dt-header-bg: rgba(26, 24, 21, 0.95);
+}
+
 /* ═══════════════════════════════════════════════════════════════════════════════
    Theme Application Layer
    Maps design-theme tokens onto existing semantic tokens so all existing


### PR DESCRIPTION
## Summary
Adds 2 more design themes, bringing the total to **12**.

### New Themes
| Theme | Style | Dark Mode Highlight |
|---|---|---|
| **Synthwave** | 80s retro-futurism, purple-pink neon glow | Deep purple (#0f0019), dual glow shadows |
| **Zen** | Wabi-sabi Japanese minimalism, paper textures | Warm dark (#1a1815), no shadows, 4px radius |

### Design Decisions
- **Synthwave dark** uses dual-layer box-shadow (purple + pink) for authentic CRT glow
- **Zen** uses 4px border-radius and no shadows — the most restrained theme, inspired by traditional Japanese craft
- Both generated with Google Stitch design prompts + manual CSS refinement

### All 12 Themes
Classic, Glass, Bento, Brutalist, Neon, Warm, Liquid, Mono, Ocean, Forest, **Synthwave**, **Zen**