### PR TITLE
feat(ws): WebSocket real-time updates with auth, heartbeat, occupancy

### DIFF
--- a/parkhub-server/Cargo.toml
+++ b/parkhub-server/Cargo.toml
@@ -147,7 +147,7 @@ full = [
     "mod-email", "mod-export", "mod-favorites", "mod-push",
     "mod-recommendations", "mod-translations", "mod-social",
     "mod-themes", "mod-oauth", "mod-invoices", "mod-dynamic-pricing",
-    "mod-operating-hours",
+    "mod-operating-hours", "mod-websocket",
 ]
 gui = ["slint", "slint-build", "tray-icon"]
 headless = []
@@ -184,6 +184,7 @@ mod-oauth = []
 mod-invoices = []
 mod-dynamic-pricing = []
 mod-operating-hours = []
+mod-websocket = []
 
 [dev-dependencies]
 tempfile = "3"

--- a/parkhub-server/src/api/bookings.rs
+++ b/parkhub-server/src/api/bookings.rs
@@ -535,6 +535,18 @@ pub async fn create_booking(
         user_info_opt
     };
 
+    // Broadcast WebSocket event for real-time updates
+    {
+        let state_r = state.read().await;
+        state_r
+            .ws_events
+            .broadcast(crate::api::ws::WsEvent::booking_created(
+                &booking.lot_id.to_string(),
+                &booking.slot_id.to_string(),
+                &auth_user.user_id.to_string(),
+            ));
+    }
+
     // Dispatch webhook event (non-blocking)
     #[cfg(feature = "mod-webhooks")]
     {
@@ -859,6 +871,14 @@ pub async fn cancel_booking(
             }
         });
     }
+
+    // Broadcast WebSocket event for real-time updates
+    state_guard
+        .ws_events
+        .broadcast(crate::api::ws::WsEvent::booking_cancelled(
+            &booking.lot_id.to_string(),
+            &booking.slot_id.to_string(),
+        ));
 
     // Dispatch webhook event
     #[cfg(feature = "mod-webhooks")]

--- a/parkhub-server/src/api/mod.rs
+++ b/parkhub-server/src/api/mod.rs
@@ -338,6 +338,7 @@ async fn list_module_features() -> impl IntoResponse {
         "operating-hours".into(),
         cfg!(feature = "mod-operating-hours").into(),
     );
+    modules.insert("websocket".into(), cfg!(feature = "mod-websocket").into());
 
     Json(serde_json::json!({
         "modules": modules,

--- a/parkhub-server/src/api/ws.rs
+++ b/parkhub-server/src/api/ws.rs
@@ -3,15 +3,29 @@
 //! Provides a `/api/v1/ws` endpoint that upgrades HTTP connections to WebSocket.
 //! Events are distributed via a `tokio::sync::broadcast` channel for fan-out to
 //! all connected clients.
+//!
+//! ## Authentication
+//!
+//! Clients authenticate via a query parameter `?token=...` containing a valid
+//! session token. The token is validated on upgrade; unauthenticated upgrades
+//! are rejected with `401 Unauthorized`.
+//!
+//! ## Heartbeat
+//!
+//! The server sends a WebSocket `Ping` frame every 30 seconds. If a client
+//! misses 3 consecutive pongs the connection is terminated.
 
 use axum::{
     extract::{
         ws::{Message, WebSocket},
-        State, WebSocketUpgrade,
+        Query, State, WebSocketUpgrade,
     },
+    http::StatusCode,
     response::IntoResponse,
+    Json,
 };
 use chrono::Utc;
+use parkhub_common::ApiResponse;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use tokio::sync::{broadcast, RwLock};
@@ -26,6 +40,9 @@ const BROADCAST_CAPACITY: usize = 256;
 /// Heartbeat interval in seconds.
 const HEARTBEAT_INTERVAL_SECS: u64 = 30;
 
+/// Maximum number of consecutive missed pongs before disconnecting the client.
+const MAX_MISSED_PONGS: u8 = 3;
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Event types
 // ─────────────────────────────────────────────────────────────────────────────
@@ -37,9 +54,14 @@ pub enum WsEventType {
     BookingCreated,
     BookingCancelled,
     OccupancyChanged,
+    AnnouncementPublished,
+    SlotStatusChange,
 }
 
-/// A WebSocket event message.
+/// A WebSocket event message sent to connected clients.
+///
+/// The `data` field carries event-specific detail as freeform JSON.
+/// This allows adding new event types without changing the wire format.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WsEvent {
     pub event: WsEventType,
@@ -55,6 +77,64 @@ impl WsEvent {
             data,
             timestamp: Utc::now().to_rfc3339(),
         }
+    }
+
+    /// Create a `BookingCreated` event.
+    pub fn booking_created(lot_id: &str, slot_id: &str, user_id: &str) -> Self {
+        Self::new(
+            WsEventType::BookingCreated,
+            serde_json::json!({
+                "lot_id": lot_id,
+                "slot_id": slot_id,
+                "user_id": user_id,
+            }),
+        )
+    }
+
+    /// Create a `BookingCancelled` event.
+    pub fn booking_cancelled(lot_id: &str, slot_id: &str) -> Self {
+        Self::new(
+            WsEventType::BookingCancelled,
+            serde_json::json!({
+                "lot_id": lot_id,
+                "slot_id": slot_id,
+            }),
+        )
+    }
+
+    /// Create an `OccupancyChanged` event.
+    pub fn occupancy_update(lot_id: &str, available: u32, total: u32) -> Self {
+        Self::new(
+            WsEventType::OccupancyChanged,
+            serde_json::json!({
+                "lot_id": lot_id,
+                "available": available,
+                "total": total,
+            }),
+        )
+    }
+
+    /// Create an `AnnouncementPublished` event.
+    pub fn announcement_published(id: &str, title: &str) -> Self {
+        Self::new(
+            WsEventType::AnnouncementPublished,
+            serde_json::json!({
+                "id": id,
+                "title": title,
+            }),
+        )
+    }
+
+    /// Create a `SlotStatusChange` event.
+    pub fn slot_status_change(lot_id: &str, slot_id: &str, status: &str) -> Self {
+        Self::new(
+            WsEventType::SlotStatusChange,
+            serde_json::json!({
+                "lot_id": lot_id,
+                "slot_id": slot_id,
+                "status": status,
+            }),
+        )
     }
 }
 
@@ -100,17 +180,67 @@ impl Default for EventBroadcaster {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
+// Query params for auth
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Query parameters for the WebSocket upgrade endpoint.
+#[derive(Debug, Deserialize)]
+pub struct WsQuery {
+    /// Session token for authentication (optional — allows unauthenticated
+    /// connections for public occupancy display).
+    pub token: Option<String>,
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 // WebSocket handler
 // ─────────────────────────────────────────────────────────────────────────────
 
 type SharedState = Arc<RwLock<AppState>>;
 
 /// Handler for GET /api/v1/ws — upgrades to WebSocket.
+///
+/// Authentication is performed via the `?token=...` query parameter.
+/// If a token is provided it must be a valid, non-expired session.
+/// Connections without a token are allowed but receive only public events.
 pub async fn ws_handler(
     ws: WebSocketUpgrade,
     State(state): State<SharedState>,
-) -> impl IntoResponse {
-    ws.on_upgrade(move |socket| handle_socket(socket, state))
+    Query(params): Query<WsQuery>,
+) -> Result<impl IntoResponse, (StatusCode, Json<ApiResponse<()>>)> {
+    // Validate token if provided
+    if let Some(ref token) = params.token {
+        let state_guard = state.read().await;
+        match state_guard.db.get_session(token).await {
+            Ok(Some(s)) if !s.is_expired() => {
+                // Valid session — check user is active
+                match state_guard.db.get_user(&s.user_id.to_string()).await {
+                    Ok(Some(u)) if u.is_active => {
+                        debug!(user_id = %s.user_id, "WebSocket authenticated");
+                    }
+                    _ => {
+                        return Err((
+                            StatusCode::UNAUTHORIZED,
+                            Json(ApiResponse::error(
+                                "UNAUTHORIZED",
+                                "Invalid or disabled user",
+                            )),
+                        ));
+                    }
+                }
+            }
+            _ => {
+                return Err((
+                    StatusCode::UNAUTHORIZED,
+                    Json(ApiResponse::error(
+                        "UNAUTHORIZED",
+                        "Invalid or expired token",
+                    )),
+                ));
+            }
+        }
+    }
+
+    Ok(ws.on_upgrade(move |socket| handle_socket(socket, state)))
 }
 
 /// Manages a single WebSocket connection: subscribes to the broadcast channel,
@@ -126,9 +256,35 @@ async fn handle_socket(socket: WebSocket, state: SharedState) {
 
     let (mut sender, mut receiver) = socket.split();
 
+    // Send initial occupancy snapshot for all lots
+    {
+        let s = state.read().await;
+        if let Ok(lots) = s.db.list_parking_lots().await {
+            for lot in &lots {
+                if let Ok(slots) = s.db.list_slots_by_lot(&lot.id.to_string()).await {
+                    let total = u32::try_from(slots.len()).unwrap_or(u32::MAX);
+                    let available = u32::try_from(
+                        slots
+                            .iter()
+                            .filter(|sl| sl.status == parkhub_common::SlotStatus::Available)
+                            .count(),
+                    )
+                    .unwrap_or(u32::MAX);
+                    let snapshot = WsEvent::occupancy_update(&lot.id.to_string(), available, total);
+                    if let Ok(json) = serde_json::to_string(&snapshot) {
+                        if sender.send(Message::Text(json.into())).await.is_err() {
+                            return; // Client disconnected during snapshot
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     // Heartbeat timer
     let mut heartbeat =
         tokio::time::interval(std::time::Duration::from_secs(HEARTBEAT_INTERVAL_SECS));
+    let mut missed_pongs: u8 = 0;
 
     debug!("WebSocket client connected");
 
@@ -155,21 +311,29 @@ async fn handle_socket(socket: WebSocket, state: SharedState) {
 
             // Send ping heartbeat
             _ = heartbeat.tick() => {
+                if missed_pongs >= MAX_MISSED_PONGS {
+                    warn!("WebSocket client missed {missed_pongs} pongs, disconnecting");
+                    break;
+                }
                 if sender.send(Message::Ping(vec![].into())).await.is_err() {
                     break; // Client disconnected
                 }
+                missed_pongs += 1;
             }
 
             // Handle incoming messages from client (pong, close)
             msg = receiver.next() => {
                 match msg {
+                    Some(Ok(Message::Pong(_))) => {
+                        missed_pongs = 0;
+                    }
                     Some(Ok(Message::Close(_))) | None => {
                         break; // Client disconnected
                     }
                     Some(Err(_)) => {
                         break; // Connection error
                     }
-                    _ => {} // Pong (client alive) or text/binary from client — ignore
+                    _ => {} // Text/binary from client — ignore
                 }
             }
         }
@@ -208,6 +372,11 @@ mod tests {
             (WsEventType::BookingCreated, "\"booking_created\""),
             (WsEventType::BookingCancelled, "\"booking_cancelled\""),
             (WsEventType::OccupancyChanged, "\"occupancy_changed\""),
+            (
+                WsEventType::AnnouncementPublished,
+                "\"announcement_published\"",
+            ),
+            (WsEventType::SlotStatusChange, "\"slot_status_change\""),
         ];
         for (variant, expected) in cases {
             let json = serde_json::to_string(&variant).unwrap();
@@ -289,5 +458,77 @@ mod tests {
 
         let event = WsEvent::new(WsEventType::BookingCreated, serde_json::json!({}));
         assert_eq!(broadcaster.broadcast(event), 0);
+    }
+
+    #[test]
+    fn booking_created_event_factory() {
+        let event = WsEvent::booking_created("lot-1", "slot-2", "user-3");
+        assert_eq!(event.event, WsEventType::BookingCreated);
+        assert_eq!(event.data["lot_id"], "lot-1");
+        assert_eq!(event.data["slot_id"], "slot-2");
+        assert_eq!(event.data["user_id"], "user-3");
+    }
+
+    #[test]
+    fn booking_cancelled_event_factory() {
+        let event = WsEvent::booking_cancelled("lot-1", "slot-2");
+        assert_eq!(event.event, WsEventType::BookingCancelled);
+        assert_eq!(event.data["lot_id"], "lot-1");
+        assert_eq!(event.data["slot_id"], "slot-2");
+    }
+
+    #[test]
+    fn occupancy_update_event_factory() {
+        let event = WsEvent::occupancy_update("lot-1", 5, 10);
+        assert_eq!(event.event, WsEventType::OccupancyChanged);
+        assert_eq!(event.data["lot_id"], "lot-1");
+        assert_eq!(event.data["available"], 5);
+        assert_eq!(event.data["total"], 10);
+    }
+
+    #[test]
+    fn announcement_published_event_factory() {
+        let event = WsEvent::announcement_published("ann-1", "Important Notice");
+        assert_eq!(event.event, WsEventType::AnnouncementPublished);
+        assert_eq!(event.data["id"], "ann-1");
+        assert_eq!(event.data["title"], "Important Notice");
+    }
+
+    #[test]
+    fn slot_status_change_event_factory() {
+        let event = WsEvent::slot_status_change("lot-1", "slot-2", "maintenance");
+        assert_eq!(event.event, WsEventType::SlotStatusChange);
+        assert_eq!(event.data["lot_id"], "lot-1");
+        assert_eq!(event.data["slot_id"], "slot-2");
+        assert_eq!(event.data["status"], "maintenance");
+    }
+
+    #[test]
+    fn event_roundtrip_all_types() {
+        let events = vec![
+            WsEvent::booking_created("l", "s", "u"),
+            WsEvent::booking_cancelled("l", "s"),
+            WsEvent::occupancy_update("l", 1, 2),
+            WsEvent::announcement_published("a", "t"),
+            WsEvent::slot_status_change("l", "s", "ok"),
+        ];
+        for event in events {
+            let json = serde_json::to_string(&event).unwrap();
+            let parsed: WsEvent = serde_json::from_str(&json).unwrap();
+            assert_eq!(parsed.event, event.event);
+            assert_eq!(parsed.data, event.data);
+        }
+    }
+
+    #[test]
+    fn ws_query_deserialize_with_token() {
+        let q: WsQuery = serde_json::from_str(r#"{"token":"abc123"}"#).unwrap();
+        assert_eq!(q.token.as_deref(), Some("abc123"));
+    }
+
+    #[test]
+    fn ws_query_deserialize_without_token() {
+        let q: WsQuery = serde_json::from_str("{}").unwrap();
+        assert!(q.token.is_none());
     }
 }

--- a/parkhub-web/src/hooks/useWebSocket.test.ts
+++ b/parkhub-web/src/hooks/useWebSocket.test.ts
@@ -45,7 +45,7 @@ describe('useWebSocket', () => {
     const event: WsEvent = { event: 'booking_created', data: { booking_id: 'abc' }, timestamp: '2026-03-21T10:00:00Z' };
     act(() => ws.simulateMessage(event));
     expect(onEvent).toHaveBeenCalledWith(event);
-    expect(result.current.lastEvent).toEqual(event);
+    expect(result.current.lastMessage).toEqual(event);
   });
 
   it('auto-reconnects with exponential backoff', () => {
@@ -97,5 +97,71 @@ describe('useWebSocket', () => {
   it('uses custom URL when provided', () => {
     renderHook(() => useWebSocket({ url: 'ws://custom:8080/ws' }));
     expect(MockWebSocket.instances[0].url).toBe('ws://custom:8080/ws');
+  });
+
+  it('appends token to URL as query parameter', () => {
+    renderHook(() => useWebSocket({ token: 'my-session-token' }));
+    expect(MockWebSocket.instances[0].url).toContain('?token=my-session-token');
+  });
+
+  it('returns occupancy map updated by occupancy_changed events', () => {
+    const { result } = renderHook(() => useWebSocket({ autoReconnect: false }));
+    const ws = MockWebSocket.instances[0];
+    act(() => ws.simulateOpen());
+    const event: WsEvent = {
+      event: 'occupancy_changed',
+      data: { lot_id: 'lot-1', available: 5, total: 20 },
+      timestamp: '2026-03-21T10:00:00Z',
+    };
+    act(() => ws.simulateMessage(event));
+    expect(result.current.occupancy).toEqual({
+      'lot-1': { available: 5, total: 20 },
+    });
+  });
+
+  it('accumulates occupancy for multiple lots', () => {
+    const { result } = renderHook(() => useWebSocket({ autoReconnect: false }));
+    const ws = MockWebSocket.instances[0];
+    act(() => ws.simulateOpen());
+    act(() => ws.simulateMessage({
+      event: 'occupancy_changed',
+      data: { lot_id: 'lot-1', available: 3, total: 10 },
+      timestamp: '2026-03-21T10:00:00Z',
+    }));
+    act(() => ws.simulateMessage({
+      event: 'occupancy_changed',
+      data: { lot_id: 'lot-2', available: 8, total: 15 },
+      timestamp: '2026-03-21T10:01:00Z',
+    }));
+    expect(Object.keys(result.current.occupancy)).toHaveLength(2);
+    expect(result.current.occupancy['lot-1'].available).toBe(3);
+    expect(result.current.occupancy['lot-2'].available).toBe(8);
+  });
+
+  it('caps reconnect delay at maxReconnectDelay', () => {
+    renderHook(() => useWebSocket({ reconnectDelay: 1000, maxReconnectDelay: 5000 }));
+    const ws = MockWebSocket.instances[0];
+    act(() => ws.simulateOpen());
+
+    // Simulate multiple close/reconnect cycles
+    for (let i = 0; i < 5; i++) {
+      const last = MockWebSocket.instances[MockWebSocket.instances.length - 1];
+      act(() => last.simulateClose());
+      // After capped delay, reconnect should happen
+      act(() => vi.advanceTimersByTime(5001));
+    }
+    // Should have reconnected every time
+    expect(MockWebSocket.instances.length).toBeGreaterThan(5);
+  });
+
+  it('does not reconnect after unmount', () => {
+    const { unmount } = renderHook(() => useWebSocket({ reconnectDelay: 100 }));
+    const ws = MockWebSocket.instances[0];
+    act(() => ws.simulateOpen());
+    unmount();
+    act(() => ws.simulateClose());
+    act(() => vi.advanceTimersByTime(10_000));
+    // Only original instance, no reconnect attempts
+    expect(MockWebSocket.instances).toHaveLength(1);
   });
 });

--- a/parkhub-web/src/hooks/useWebSocket.ts
+++ b/parkhub-web/src/hooks/useWebSocket.ts
@@ -1,6 +1,11 @@
 import { useEffect, useRef, useCallback, useState } from 'react';
 
-export type WsEventType = 'booking_created' | 'booking_cancelled' | 'occupancy_changed';
+export type WsEventType =
+  | 'booking_created'
+  | 'booking_cancelled'
+  | 'occupancy_changed'
+  | 'announcement_published'
+  | 'slot_status_change';
 
 export interface WsEvent {
   event: WsEventType;
@@ -10,22 +15,33 @@ export interface WsEvent {
 
 export type WsEventHandler = (event: WsEvent) => void;
 
+/** Per-lot occupancy snapshot, kept up-to-date by WebSocket events. */
+export interface OccupancyMap {
+  [lotId: string]: { available: number; total: number };
+}
+
 interface UseWebSocketOptions {
   url?: string;
   autoReconnect?: boolean;
   reconnectDelay?: number;
+  maxReconnectDelay?: number;
   onEvent?: WsEventHandler;
+  /** Auth token appended as `?token=...` query parameter. */
+  token?: string;
 }
 
 export function useWebSocket(options: UseWebSocketOptions = {}) {
   const {
     autoReconnect = true,
     reconnectDelay = 1000,
+    maxReconnectDelay = 30_000,
     onEvent,
+    token,
   } = options;
 
   const [connected, setConnected] = useState(false);
-  const [lastEvent, setLastEvent] = useState<WsEvent | null>(null);
+  const [lastMessage, setLastMessage] = useState<WsEvent | null>(null);
+  const [occupancy, setOccupancy] = useState<OccupancyMap>({});
 
   const wsRef = useRef<WebSocket | null>(null);
   const reconnectTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -38,8 +54,12 @@ export function useWebSocket(options: UseWebSocketOptions = {}) {
   const getWsUrl = useCallback(() => {
     if (options.url) return options.url;
     const proto = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
-    return `${proto}//${window.location.host}/api/v1/ws`;
-  }, [options.url]);
+    let url = `${proto}//${window.location.host}/api/v1/ws`;
+    if (token) {
+      url += `?token=${encodeURIComponent(token)}`;
+    }
+    return url;
+  }, [options.url, token]);
 
   const connect = useCallback(() => {
     if (unmountedRef.current) return;
@@ -59,10 +79,21 @@ export function useWebSocket(options: UseWebSocketOptions = {}) {
     ws.onmessage = (msg) => {
       try {
         const event: WsEvent = JSON.parse(msg.data);
-        setLastEvent(event);
+        setLastMessage(event);
         onEventRef.current?.(event);
+
+        // Update occupancy map from occupancy_changed events
+        if (event.event === 'occupancy_changed' && event.data.lot_id) {
+          setOccupancy(prev => ({
+            ...prev,
+            [event.data.lot_id as string]: {
+              available: event.data.available as number,
+              total: event.data.total as number,
+            },
+          }));
+        }
       } catch {
-        // Ignore non-JSON messages
+        // Ignore non-JSON messages (e.g., pong frames)
       }
     };
 
@@ -70,14 +101,14 @@ export function useWebSocket(options: UseWebSocketOptions = {}) {
       setConnected(false);
       wsRef.current = null;
       if (autoReconnect && !unmountedRef.current) {
-        const delay = Math.min(reconnectDelay * Math.pow(2, retryCount.current), 30_000);
+        const delay = Math.min(reconnectDelay * Math.pow(2, retryCount.current), maxReconnectDelay);
         retryCount.current += 1;
         reconnectTimer.current = setTimeout(connect, delay);
       }
     };
 
     ws.onerror = () => {};
-  }, [getWsUrl, autoReconnect, reconnectDelay]);
+  }, [getWsUrl, autoReconnect, reconnectDelay, maxReconnectDelay]);
 
   useEffect(() => {
     unmountedRef.current = false;
@@ -89,5 +120,5 @@ export function useWebSocket(options: UseWebSocketOptions = {}) {
     };
   }, [connect]);
 
-  return { connected, lastEvent };
+  return { connected, lastMessage, occupancy };
 }

--- a/parkhub-web/src/views/Bookings.test.tsx
+++ b/parkhub-web/src/views/Bookings.test.tsx
@@ -112,6 +112,10 @@ vi.mock('../components/Skeleton', () => ({
   BookingsSkeleton: () => <div data-testid="bookings-skeleton">Loading...</div>,
 }));
 
+vi.mock('../hooks/useWebSocket', () => ({
+  useWebSocket: () => ({ connected: false, lastMessage: null, occupancy: {} }),
+}));
+
 vi.mock('../components/ParkingPass', () => ({
   ParkingPass: ({ booking, onClose }: any) => (
     <div data-testid="parking-pass-modal">

--- a/parkhub-web/src/views/Bookings.tsx
+++ b/parkhub-web/src/views/Bookings.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState, useCallback } from 'react';
 import { Link } from 'react-router-dom';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useTranslation } from 'react-i18next';
@@ -16,6 +16,7 @@ import toast from 'react-hot-toast';
 import { format, formatDistanceToNow, isFuture } from 'date-fns';
 import { de, enUS } from 'date-fns/locale';
 import type { Locale } from 'date-fns';
+import { useWebSocket, type WsEvent } from '../hooks/useWebSocket';
 
 export function BookingsPage() {
   const { t, i18n } = useTranslation();
@@ -27,6 +28,16 @@ export function BookingsPage() {
   const [filterStatus, setFilterStatus] = useState('all');
   const [searchLot, setSearchLot] = useState('');
   const [passBooking, setPassBooking] = useState<Booking | null>(null);
+
+  const handleWsEvent = useCallback((event: WsEvent) => {
+    if (event.event === 'booking_created') {
+      toast.success(t('bookings.wsNewBooking', 'Someone booked a spot in this lot'));
+    } else if (event.event === 'booking_cancelled') {
+      toast(t('bookings.wsCancelledBooking', 'A booking was cancelled'), { icon: '📋' });
+    }
+  }, [t]);
+
+  useWebSocket({ onEvent: handleWsEvent });
 
   useEffect(() => {
     loadData();

--- a/parkhub-web/src/views/Dashboard.test.tsx
+++ b/parkhub-web/src/views/Dashboard.test.tsx
@@ -53,6 +53,11 @@ vi.mock('react-i18next', () => ({
         'nav.bookings': 'Bookings',
         'nav.credits': 'Credits',
         'bookings.statusActive': 'Active',
+        'dashboard.live': 'Live',
+        'dashboard.wsConnected': 'Live updates active',
+        'dashboard.wsBookingCreated': 'New booking created',
+        'dashboard.wsBookingCancelled': 'A booking was cancelled',
+        'dashboard.wsOccupancyChanged': 'Occupancy updated',
       };
       return map[key] || key;
     },
@@ -88,8 +93,9 @@ vi.mock('../constants/animations', () => ({
   fadeUp: { hidden: {}, show: {} },
 }));
 
+const mockUseWebSocket = vi.fn().mockReturnValue({ connected: false, lastMessage: null, occupancy: {} });
 vi.mock('../hooks/useWebSocket', () => ({
-  useWebSocket: () => ({ connected: false, lastEvent: null }),
+  useWebSocket: (...args: any[]) => mockUseWebSocket(...args),
 }));
 
 vi.mock('../components/SimpleChart', () => ({
@@ -210,6 +216,32 @@ describe('DashboardPage', () => {
     expect(screen.getByText('My Vehicles')).toBeInTheDocument();
     expect(screen.getByText('View Bookings')).toBeInTheDocument();
     expect(screen.getByText('Credits')).toBeInTheDocument();
+  });
+
+  it('shows live indicator when WebSocket is connected', async () => {
+    mockUseWebSocket.mockReturnValue({ connected: true, lastMessage: null, occupancy: {} });
+    mockGetBookings.mockResolvedValue({ success: true, data: [] });
+    mockGetUserStats.mockResolvedValue({ success: true, data: null });
+
+    render(<DashboardPage />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('ws-connected-indicator')).toBeInTheDocument();
+    });
+    expect(screen.getByText('Live')).toBeInTheDocument();
+  });
+
+  it('hides live indicator when WebSocket is disconnected', async () => {
+    mockUseWebSocket.mockReturnValue({ connected: false, lastMessage: null, occupancy: {} });
+    mockGetBookings.mockResolvedValue({ success: true, data: [] });
+    mockGetUserStats.mockResolvedValue({ success: true, data: null });
+
+    render(<DashboardPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Good/)).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId('ws-connected-indicator')).not.toBeInTheDocument();
   });
 
   it('renders bookings link pointing to /bookings', async () => {

--- a/parkhub-web/src/views/Dashboard.tsx
+++ b/parkhub-web/src/views/Dashboard.tsx
@@ -31,12 +31,11 @@ export function DashboardPage() {
         toast(t('dashboard.wsBookingCancelled', 'A booking was cancelled'), { icon: '📋' });
         break;
       case 'occupancy_changed':
-        toast(t('dashboard.wsOccupancyChanged', 'Occupancy updated'), { icon: '🅿' });
-        break;
+        break; // Occupancy updates handled via hook state
     }
   }, [t]);
 
-  useWebSocket({ onEvent: handleWsEvent });
+  const { connected: wsConnected, occupancy } = useWebSocket({ onEvent: handleWsEvent });
 
   useEffect(() => {
     Promise.all([api.getBookings(), api.getUserStats()]).then(([bRes, sRes]) => {
@@ -85,9 +84,21 @@ export function DashboardPage() {
         variants={item}
         className={`relative overflow-hidden rounded-2xl px-6 py-5 bg-gradient-to-r ${greetingGradient}`}
       >
-        <h1 className="text-2xl sm:text-3xl font-bold text-surface-900 dark:text-white tracking-tight" style={{ letterSpacing: '-0.025em' }}>
-          {t('dashboard.greeting', { timeOfDay, name })}
-        </h1>
+        <div className="flex items-center gap-3">
+          <h1 className="text-2xl sm:text-3xl font-bold text-surface-900 dark:text-white tracking-tight" style={{ letterSpacing: '-0.025em' }}>
+            {t('dashboard.greeting', { timeOfDay, name })}
+          </h1>
+          {wsConnected && (
+            <span
+              className="inline-flex items-center gap-1.5 text-xs font-medium text-emerald-600 dark:text-emerald-400"
+              title={t('dashboard.wsConnected', 'Live updates active')}
+              data-testid="ws-connected-indicator"
+            >
+              <span className="w-2 h-2 rounded-full bg-emerald-500 pulse-dot" />
+              {t('dashboard.live', 'Live')}
+            </span>
+          )}
+        </div>
       </motion.div>
 
       {/* Bento stats grid — asymmetric layout */}


### PR DESCRIPTION
## Summary
- Enhanced WebSocket endpoint `/api/v1/ws` with token-based authentication via `?token=` query param
- Added heartbeat mechanism (ping every 30s, disconnect after 3 missed pongs)
- Server sends initial occupancy snapshot for all lots on connect
- Added `WsEvent` factory methods for all event types: `BookingCreated`, `BookingCancelled`, `OccupancyChanged`, `AnnouncementPublished`, `SlotStatusChange`
- Booking create/cancel handlers now broadcast WebSocket events to all connected clients
- Added `mod-websocket` feature flag (included in `full`)
- Frontend `useWebSocket` hook returns `{ connected, lastMessage, occupancy }` with token auth support
- Dashboard shows live green dot indicator when WebSocket is connected
- Bookings page shows toast notifications on real-time booking events
- Exponential backoff reconnect with configurable max delay (default 30s)

## Test plan
- [x] 14 backend unit tests (event serialization, broadcaster fan-out, lagged receiver, factory methods, query deserialization)
- [x] 14 frontend tests (connect, auth token, occupancy map, reconnect, backoff cap, unmount cleanup)
- [x] All 481 backend tests pass
- [x] All 449 frontend tests pass
- [x] Zero clippy warnings