### PR TITLE
release: v2.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [2.8.0] - 2026-03-22
+
+### Added
+- **WebSocket real-time updates**: Token-based auth via `?token=` query param, heartbeat with missed-pong tracking, initial occupancy snapshot on connect (`mod-websocket`)
+- **WsEvent factory methods**: `BookingCreated`, `BookingCancelled`, `OccupancyChanged`, `AnnouncementPublished`, `SlotStatusChange`
+- **Live booking broadcasts**: Booking create/cancel handlers broadcast WebSocket events to all connected clients
+- **Frontend useWebSocket hook**: Returns `{ connected, lastMessage, occupancy }` with token auth and exponential backoff reconnect
+- **Dashboard live indicator**: Green dot shows active WebSocket connection status
+- **Bookings real-time toasts**: Toast notifications on WebSocket booking events in Bookings page
+
+### Changed
+- **API module extraction (Phase 3)**: `mod.rs` reduced from 4517 to 1503 lines
+  - `system.rs`: health, version, maintenance, handshake, middleware (345 lines)
+  - `users.rs`: profile CRUD, GDPR, password, preferences, stats (757 lines)
+  - `admin_handlers.rs`: user/booking mgmt, stats, reports, audit, settings (1412 lines)
+  - `lots_ext.rs`: lot QR codes, admin dashboard charts (267 lines)
+  - `misc.rs`: legal/Impressum, public occupancy/display (384 lines)
+
+---
+
 ## [2.7.0] - 2026-03-22
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5400,7 +5400,7 @@ dependencies = [
 
 [[package]]
 name = "parkhub-client"
-version = "2.2.0"
+version = "2.8.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -5427,7 +5427,7 @@ dependencies = [
 
 [[package]]
 name = "parkhub-common"
-version = "2.2.0"
+version = "2.8.0"
 dependencies = [
  "chrono",
  "serde",
@@ -5439,7 +5439,7 @@ dependencies = [
 
 [[package]]
 name = "parkhub-server"
-version = "2.2.0"
+version = "2.8.0"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.2.0"
+version = "2.8.0"
 edition = "2021"
 rust-version = "1.85"
 authors = ["nash87"]

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <p align="center">
   <a href="https://github.com/nash87/parkhub-rust/actions/workflows/ci.yml"><img src="https://github.com/nash87/parkhub-rust/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <a href="CHANGELOG.md"><img src="https://img.shields.io/badge/Release-v2.7.0-brightgreen.svg?style=flat-square" alt="v2.7.0"></a>
+  <a href="CHANGELOG.md"><img src="https://img.shields.io/badge/Release-v2.8.0-brightgreen.svg?style=flat-square" alt="v2.8.0"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square" alt="MIT License"></a>
   <a href="https://www.rust-lang.org/"><img src="https://img.shields.io/badge/Rust-1.85%2B-orange.svg?style=flat-square&logo=rust&logoColor=white" alt="Rust 1.85+"></a>
   <a href="https://react.dev/"><img src="https://img.shields.io/badge/React-19-61DAFB.svg?style=flat-square&logo=react&logoColor=black" alt="React 19"></a>
@@ -67,8 +67,10 @@ cargo build --release --package parkhub-server --no-default-features --features 
 
 ## Features
 
-### v2.7.0 Highlights
+### v2.8.0 Highlights
 
+- **WebSocket real-time updates** -- Live booking/occupancy events with token auth, heartbeat, and auto-reconnect
+- **API architecture overhaul** -- mod.rs reduced from 4500 to 1500 lines via Phase 3 handler extraction
 - **12 switchable themes** -- Classic, Glass, Bento, Brutalist, Neon, Warm, Wabi-Sabi, Scandinavian, Cyberpunk, Terracotta, Oceanic, Art Deco
 - **httpOnly cookie auth** -- XSS-proof authentication with SameSite=Lax and CSRF protection
 - **OAuth/Social login** -- Self-service Google + GitHub OAuth (users configure their own apps)


### PR DESCRIPTION
## Summary
- Bump workspace version to 2.8.0
- CHANGELOG entry for v2.8.0 (WebSocket real-time + API extraction)
- README badge and highlights updated

## Test plan
- [x] Builds successfully with new version
- [x] All tests pass from prior PRs