### PR TITLE
feat: Lobby Display / Kiosk Mode (#198)

### DIFF
--- a/parkhub-server/Cargo.toml
+++ b/parkhub-server/Cargo.toml
@@ -147,7 +147,7 @@ full = [
     "mod-email", "mod-export", "mod-favorites", "mod-push",
     "mod-recommendations", "mod-translations", "mod-social",
     "mod-themes", "mod-oauth", "mod-invoices", "mod-dynamic-pricing",
-    "mod-operating-hours", "mod-websocket",
+    "mod-operating-hours", "mod-websocket", "mod-lobby-display",
 ]
 gui = ["slint", "slint-build", "tray-icon"]
 headless = []
@@ -185,6 +185,7 @@ mod-invoices = []
 mod-dynamic-pricing = []
 mod-operating-hours = []
 mod-websocket = []
+mod-lobby-display = []
 
 [dev-dependencies]
 tempfile = "3"

--- a/parkhub-server/src/api/lobby.rs
+++ b/parkhub-server/src/api/lobby.rs
@@ -1,0 +1,255 @@
+//! Lobby Display / Kiosk Mode — public endpoints for digital signage.
+//!
+//! `GET /api/v1/lots/:id/display` returns structured JSON for lobby monitors.
+//! No authentication required. Rate-limited to 10 requests per minute per IP.
+//! Feature flag: `mod-lobby-display`.
+
+use axum::{extract::Path, extract::State, http::StatusCode, Json};
+use chrono::Utc;
+use serde::Serialize;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
+use parkhub_common::ApiResponse;
+
+use crate::AppState;
+
+type SharedState = Arc<RwLock<AppState>>;
+
+/// Color status for occupancy indicator
+#[derive(Debug, Serialize, Clone, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum OccupancyColor {
+    Green,
+    Yellow,
+    Red,
+}
+
+/// Per-floor availability for lobby display
+#[derive(Debug, Serialize, Clone)]
+pub struct FloorDisplay {
+    pub floor_name: String,
+    pub floor_number: i32,
+    pub total_slots: i32,
+    pub available_slots: i32,
+    pub occupancy_percent: f64,
+}
+
+/// Response payload for the lobby display endpoint
+#[derive(Debug, Serialize, Clone)]
+pub struct LotDisplayData {
+    pub lot_id: String,
+    pub lot_name: String,
+    pub total_slots: i32,
+    pub available_slots: i32,
+    pub occupancy_percent: f64,
+    pub color_status: OccupancyColor,
+    pub floors: Vec<FloorDisplay>,
+    pub timestamp: String,
+}
+
+/// Determine the occupancy color: green <50%, yellow 50-80%, red >80%.
+fn occupancy_color(occupancy_percent: f64) -> OccupancyColor {
+    if occupancy_percent > 80.0 {
+        OccupancyColor::Red
+    } else if occupancy_percent >= 50.0 {
+        OccupancyColor::Yellow
+    } else {
+        OccupancyColor::Green
+    }
+}
+
+/// `GET /api/v1/lots/{id}/display` — public lobby display data for a single lot.
+///
+/// Returns lot name, total/available slots, occupancy percentage, color status,
+/// and per-floor breakdown. No authentication required.
+#[utoipa::path(
+    get,
+    path = "/api/v1/lots/{id}/display",
+    tag = "Public",
+    summary = "Lobby display data for a parking lot",
+    description = "Returns structured display data for digital signage / kiosk monitors. \
+        No auth required. Rate-limited to 10 req/min per IP.",
+    params(("id" = String, Path, description = "Parking lot ID")),
+    responses(
+        (status = 200, description = "Lobby display data"),
+        (status = 404, description = "Parking lot not found"),
+    )
+)]
+pub async fn lot_display(
+    State(state): State<SharedState>,
+    Path(id): Path<String>,
+) -> (StatusCode, Json<ApiResponse<LotDisplayData>>) {
+    let state_guard = state.read().await;
+
+    let lot = match state_guard.db.get_parking_lot(&id).await {
+        Ok(Some(lot)) => lot,
+        Ok(None) => {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(ApiResponse::error("NOT_FOUND", "Parking lot not found")),
+            );
+        }
+        Err(e) => {
+            tracing::error!(lot_id = %id, error = %e, "Failed to load lot for display");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ApiResponse::error("SERVER_ERROR", "Internal server error")),
+            );
+        }
+    };
+
+    // Count active bookings per lot
+    let now = Utc::now();
+    let bookings = state_guard.db.list_bookings().await.unwrap_or_default();
+    let active_bookings: Vec<_> = bookings
+        .iter()
+        .filter(|b| {
+            b.lot_id == lot.id
+                && b.start_time <= now
+                && b.end_time >= now
+                && matches!(
+                    b.status,
+                    parkhub_common::BookingStatus::Confirmed
+                        | parkhub_common::BookingStatus::Active
+                )
+        })
+        .collect();
+
+    let occupied = i32::try_from(active_bookings.len()).unwrap_or(i32::MAX);
+    let available = (lot.total_slots - occupied).max(0);
+    let occupancy_pct = if lot.total_slots > 0 {
+        (f64::from(occupied) / f64::from(lot.total_slots)) * 100.0
+    } else {
+        0.0
+    };
+
+    // Per-floor breakdown
+    let floors: Vec<FloorDisplay> = lot
+        .floors
+        .iter()
+        .map(|floor| {
+            let floor_occupied = i32::try_from(
+                active_bookings
+                    .iter()
+                    .filter(|b| {
+                        // Match bookings to floor via slot -> floor mapping
+                        floor
+                            .slots
+                            .iter()
+                            .any(|s| s.id.to_string() == b.slot_id.to_string())
+                    })
+                    .count(),
+            )
+            .unwrap_or(i32::MAX);
+
+            let floor_available = (floor.total_slots - floor_occupied).max(0);
+            let floor_occ = if floor.total_slots > 0 {
+                (f64::from(floor_occupied) / f64::from(floor.total_slots)) * 100.0
+            } else {
+                0.0
+            };
+
+            FloorDisplay {
+                floor_name: floor.name.clone(),
+                floor_number: floor.floor_number,
+                total_slots: floor.total_slots,
+                available_slots: floor_available,
+                occupancy_percent: floor_occ,
+            }
+        })
+        .collect();
+
+    let data = LotDisplayData {
+        lot_id: lot.id.to_string(),
+        lot_name: lot.name.clone(),
+        total_slots: lot.total_slots,
+        available_slots: available,
+        occupancy_percent: occupancy_pct,
+        color_status: occupancy_color(occupancy_pct),
+        floors,
+        timestamp: now.to_rfc3339(),
+    };
+
+    (StatusCode::OK, Json(ApiResponse::success(data)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_occupancy_color_green() {
+        assert_eq!(occupancy_color(0.0), OccupancyColor::Green);
+        assert_eq!(occupancy_color(25.0), OccupancyColor::Green);
+        assert_eq!(occupancy_color(49.9), OccupancyColor::Green);
+    }
+
+    #[test]
+    fn test_occupancy_color_yellow() {
+        assert_eq!(occupancy_color(50.0), OccupancyColor::Yellow);
+        assert_eq!(occupancy_color(65.0), OccupancyColor::Yellow);
+        assert_eq!(occupancy_color(80.0), OccupancyColor::Yellow);
+    }
+
+    #[test]
+    fn test_occupancy_color_red() {
+        assert_eq!(occupancy_color(80.1), OccupancyColor::Red);
+        assert_eq!(occupancy_color(95.0), OccupancyColor::Red);
+        assert_eq!(occupancy_color(100.0), OccupancyColor::Red);
+    }
+
+    #[test]
+    fn test_lot_display_data_serialization() {
+        let data = LotDisplayData {
+            lot_id: "lot-1".to_string(),
+            lot_name: "Test Garage".to_string(),
+            total_slots: 100,
+            available_slots: 30,
+            occupancy_percent: 70.0,
+            color_status: OccupancyColor::Yellow,
+            floors: vec![FloorDisplay {
+                floor_name: "Floor 1".to_string(),
+                floor_number: 1,
+                total_slots: 50,
+                available_slots: 15,
+                occupancy_percent: 70.0,
+            }],
+            timestamp: "2026-03-22T12:00:00Z".to_string(),
+        };
+
+        let json = serde_json::to_value(&data).unwrap();
+        assert_eq!(json["lot_name"], "Test Garage");
+        assert_eq!(json["total_slots"], 100);
+        assert_eq!(json["available_slots"], 30);
+        assert_eq!(json["color_status"], "yellow");
+        assert_eq!(json["floors"].as_array().unwrap().len(), 1);
+        assert_eq!(json["floors"][0]["floor_name"], "Floor 1");
+    }
+
+    #[test]
+    fn test_floor_display_serialization() {
+        let floor = FloorDisplay {
+            floor_name: "Basement".to_string(),
+            floor_number: -1,
+            total_slots: 20,
+            available_slots: 5,
+            occupancy_percent: 75.0,
+        };
+
+        let json = serde_json::to_value(&floor).unwrap();
+        assert_eq!(json["floor_name"], "Basement");
+        assert_eq!(json["floor_number"], -1);
+        assert_eq!(json["total_slots"], 20);
+        assert_eq!(json["available_slots"], 5);
+    }
+
+    #[test]
+    fn test_occupancy_color_boundary_values() {
+        // Exact boundaries
+        assert_eq!(occupancy_color(0.0), OccupancyColor::Green);
+        assert_eq!(occupancy_color(50.0), OccupancyColor::Yellow);
+        assert_eq!(occupancy_color(80.0), OccupancyColor::Yellow);
+        assert_eq!(occupancy_color(80.01), OccupancyColor::Red);
+    }
+}

--- a/parkhub-server/src/api/mod.rs
+++ b/parkhub-server/src/api/mod.rs
@@ -86,6 +86,8 @@ pub mod guest;
 pub mod import;
 #[cfg(feature = "mod-invoices")]
 pub mod invoices;
+#[cfg(feature = "mod-lobby-display")]
+pub mod lobby;
 pub mod lots;
 pub mod lots_ext;
 pub mod misc;
@@ -351,6 +353,10 @@ async fn list_module_features() -> impl IntoResponse {
         cfg!(feature = "mod-operating-hours").into(),
     );
     modules.insert("websocket".into(), cfg!(feature = "mod-websocket").into());
+    modules.insert(
+        "lobby-display".into(),
+        cfg!(feature = "mod-lobby-display").into(),
+    );
 
     Json(serde_json::json!({
         "modules": modules,
@@ -453,6 +459,19 @@ pub fn create_router(state: SharedState) -> (Router, demo::SharedDemoState) {
         .route("/api/v1/system/maintenance", get(system_maintenance))
         // WebSocket real-time events
         .route("/api/v1/ws", get(ws::ws_handler));
+
+    // Lobby display — rate-limited public route (10 req/min per IP)
+    #[cfg(feature = "mod-lobby-display")]
+    {
+        let lobby_limiter = rate_limiters.lobby_display.clone();
+        let lobby_route = Router::new()
+            .route("/api/v1/lots/{id}/display", get(lobby::lot_display))
+            .route_layer(middleware::from_fn(move |req, next| {
+                ip_rate_limit_middleware(lobby_limiter.clone(), req, next)
+            }))
+            .with_state(state.clone());
+        public_routes = public_routes.merge(lobby_route);
+    }
 
     // Feature-gated public routes
     #[cfg(feature = "mod-settings")]

--- a/parkhub-server/src/rate_limit.rs
+++ b/parkhub-server/src/rate_limit.rs
@@ -183,6 +183,8 @@ pub struct EndpointRateLimiters {
     pub demo: Arc<per_ip::IpRateLimiter>,
     /// QR pass generation — 10 per minute per IP
     pub qr_pass: Arc<per_ip::IpRateLimiter>,
+    /// Lobby display — 10 per minute per IP
+    pub lobby_display: Arc<per_ip::IpRateLimiter>,
     /// General API (relaxed global limiter)
     pub general: Arc<GlobalRateLimiter>,
 }
@@ -210,6 +212,8 @@ impl EndpointRateLimiters {
             demo: per_ip::create_ip_rate_limiter(3),
             // 10 QR pass requests per minute per IP
             qr_pass: per_ip::create_ip_rate_limiter(10),
+            // 10 lobby display requests per minute per IP
+            lobby_display: per_ip::create_ip_rate_limiter(10),
             // 100 requests per second globally
             general: create_rate_limiter(&RateLimitConfig::default()),
         }
@@ -293,6 +297,7 @@ mod tests {
         assert!(limiters.token_refresh.check_key(&test_ip).is_ok());
         assert!(limiters.forgot_password.check_key(&test_ip).is_ok());
         assert!(limiters.password_reset.check_key(&test_ip).is_ok());
+        assert!(limiters.lobby_display.check_key(&test_ip).is_ok());
         assert!(limiters.general.check().is_ok());
     }
 }

--- a/parkhub-web/src/App.tsx
+++ b/parkhub-web/src/App.tsx
@@ -26,6 +26,7 @@ const RegisterPage = lazy(() => import('./views/Register'), 'RegisterPage');
 const ForgotPasswordPage = lazy(() => import('./views/ForgotPassword'), 'ForgotPasswordPage');
 const UseCaseSelectorPage = lazy(() => import('./views/UseCaseSelector'), 'UseCaseSelectorPage');
 const NotFoundPage = lazy(() => import('./views/NotFound'), 'NotFoundPage');
+const LobbyDisplayPage = lazy(() => import('./views/LobbyDisplay'), 'LobbyDisplayPage');
 
 // Main app pages
 const DashboardPage = lazy(() => import('./views/Dashboard'), 'DashboardPage');
@@ -111,6 +112,7 @@ function AnimatedRoutes() {
         <Route path="/register" element={<SuspenseRoute><RegisterPage /></SuspenseRoute>} />
         <Route path="/forgot-password" element={<SuspenseRoute><ForgotPasswordPage /></SuspenseRoute>} />
         <Route path="/choose" element={<SuspenseRoute><UseCaseSelectorPage /></SuspenseRoute>} />
+        <Route path="/lobby/:lotId" element={<SuspenseRoute><LobbyDisplayPage /></SuspenseRoute>} />
         <Route path="/" element={<ProtectedRoute><Layout /></ProtectedRoute>}>
           <Route index element={<SuspenseRoute><DashboardPage /></SuspenseRoute>} />
           <Route path="book" element={<SuspenseRoute><BookPage /></SuspenseRoute>} />

--- a/parkhub-web/src/i18n/locales/de.ts
+++ b/parkhub-web/src/i18n/locales/de.ts
@@ -871,5 +871,14 @@ export default {
       genericError: 'Ein Fehler ist aufgetreten. Bitte versuchen Sie es erneut.',
       retry: 'Erneut versuchen',
     },
+    lobby: {
+      available: 'Verfugbar',
+      total: 'Gesamt',
+      floor: 'Etage',
+      lastUpdated: 'Zuletzt aktualisiert',
+      occupancy: 'Auslastung',
+      error: 'Parkplatz nicht gefunden',
+      networkError: 'Netzwerkfehler',
+    },
   },
 };

--- a/parkhub-web/src/i18n/locales/en.ts
+++ b/parkhub-web/src/i18n/locales/en.ts
@@ -871,5 +871,14 @@ export default {
       genericError: 'Something went wrong. Please try again.',
       retry: 'Try Again',
     },
+    lobby: {
+      available: 'Available',
+      total: 'Total',
+      floor: 'Floor',
+      lastUpdated: 'Last updated',
+      occupancy: 'Occupancy',
+      error: 'Lot not found',
+      networkError: 'Network error',
+    },
   },
 };

--- a/parkhub-web/src/views/LobbyDisplay.test.tsx
+++ b/parkhub-web/src/views/LobbyDisplay.test.tsx
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import React from 'react';
+import { render, screen, waitFor, act } from '@testing-library/react';
+
+// ── Mocks ──
+
+const mockUseParams = vi.fn().mockReturnValue({ lotId: 'lot-1' });
+
+vi.mock('react-router-dom', () => ({
+  useParams: () => mockUseParams(),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, fallback?: string) => {
+      const map: Record<string, string> = {
+        'lobby.available': 'Available',
+        'lobby.total': 'Total',
+        'lobby.floor': 'Floor',
+        'lobby.lastUpdated': 'Last updated',
+        'lobby.occupancy': 'Occupancy',
+        'lobby.error': 'Lot not found',
+        'lobby.networkError': 'Network error',
+      };
+      return map[key] || fallback || key;
+    },
+  }),
+}));
+
+import { LobbyDisplayPage } from './LobbyDisplay';
+
+const MOCK_DISPLAY_DATA = {
+  success: true,
+  data: {
+    lot_id: 'lot-1',
+    lot_name: 'Downtown Garage',
+    total_slots: 200,
+    available_slots: 80,
+    occupancy_percent: 60,
+    color_status: 'yellow' as const,
+    floors: [
+      { floor_name: 'B1', floor_number: -1, total_slots: 100, available_slots: 40, occupancy_percent: 60 },
+      { floor_name: 'B2', floor_number: -2, total_slots: 100, available_slots: 40, occupancy_percent: 60 },
+    ],
+    timestamp: '2026-03-22T12:00:00Z',
+  },
+};
+
+describe('LobbyDisplayPage', () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    mockUseParams.mockReturnValue({ lotId: 'lot-1' });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('shows loading state initially', () => {
+    global.fetch = vi.fn().mockReturnValue(new Promise(() => {}));
+    render(<LobbyDisplayPage />);
+    expect(screen.getByTestId('lobby-loading')).toBeInTheDocument();
+  });
+
+  it('renders lot name and availability after loading', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      json: () => Promise.resolve(MOCK_DISPLAY_DATA),
+    });
+
+    render(<LobbyDisplayPage />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('lobby-display')).toBeInTheDocument();
+    });
+    expect(screen.getByTestId('lobby-lot-name')).toHaveTextContent('Downtown Garage');
+    expect(screen.getByTestId('lobby-available')).toHaveTextContent('80');
+    expect(screen.getByTestId('lobby-total')).toHaveTextContent('200');
+  });
+
+  it('renders floor breakdown cards', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      json: () => Promise.resolve(MOCK_DISPLAY_DATA),
+    });
+
+    render(<LobbyDisplayPage />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('lobby-floors')).toBeInTheDocument();
+    });
+    const floorCards = screen.getAllByTestId('lobby-floor-card');
+    expect(floorCards).toHaveLength(2);
+    expect(screen.getByText(/B1/)).toBeInTheDocument();
+    expect(screen.getByText(/B2/)).toBeInTheDocument();
+  });
+
+  it('shows error state when lot is not found', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      json: () => Promise.resolve({ success: false, error: { code: 'NOT_FOUND', message: 'Parking lot not found' } }),
+    });
+
+    render(<LobbyDisplayPage />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('lobby-error')).toBeInTheDocument();
+    });
+    expect(screen.getByText('Parking lot not found')).toBeInTheDocument();
+  });
+
+  it('displays occupancy bar with correct aria attributes', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      json: () => Promise.resolve(MOCK_DISPLAY_DATA),
+    });
+
+    render(<LobbyDisplayPage />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('lobby-bar')).toBeInTheDocument();
+    });
+    const bar = screen.getByRole('progressbar');
+    expect(bar).toHaveAttribute('aria-valuenow', '60');
+    expect(bar).toHaveAttribute('aria-valuemin', '0');
+    expect(bar).toHaveAttribute('aria-valuemax', '100');
+  });
+
+  it('shows last updated timestamp', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      json: () => Promise.resolve(MOCK_DISPLAY_DATA),
+    });
+
+    render(<LobbyDisplayPage />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('lobby-last-updated')).toBeInTheDocument();
+    });
+    expect(screen.getByTestId('lobby-last-updated').textContent).toContain('Last updated');
+  });
+});

--- a/parkhub-web/src/views/LobbyDisplay.tsx
+++ b/parkhub-web/src/views/LobbyDisplay.tsx
@@ -1,0 +1,182 @@
+import { useEffect, useState, useCallback } from 'react';
+import { useParams } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+
+interface FloorDisplay {
+  floor_name: string;
+  floor_number: number;
+  total_slots: number;
+  available_slots: number;
+  occupancy_percent: number;
+}
+
+interface LotDisplayData {
+  lot_id: string;
+  lot_name: string;
+  total_slots: number;
+  available_slots: number;
+  occupancy_percent: number;
+  color_status: 'green' | 'yellow' | 'red';
+  floors: FloorDisplay[];
+  timestamp: string;
+}
+
+const COLOR_MAP = {
+  green: { bar: 'bg-emerald-500', text: 'text-emerald-400', glow: 'shadow-emerald-500/30' },
+  yellow: { bar: 'bg-amber-400', text: 'text-amber-400', glow: 'shadow-amber-400/30' },
+  red: { bar: 'bg-red-500', text: 'text-red-400', glow: 'shadow-red-500/30' },
+};
+
+/** Full-screen lobby display designed for parking garage monitors. */
+export function LobbyDisplayPage() {
+  const { lotId } = useParams<{ lotId: string }>();
+  const { t } = useTranslation();
+  const [data, setData] = useState<LotDisplayData | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
+  const [currentTime, setCurrentTime] = useState(new Date());
+
+  const fetchDisplay = useCallback(async () => {
+    if (!lotId) return;
+    try {
+      const res = await fetch(`/api/v1/lots/${lotId}/display`);
+      const json = await res.json();
+      if (json.success && json.data) {
+        setData(json.data);
+        setLastUpdated(new Date());
+        setError(null);
+      } else {
+        setError(json.error?.message || t('lobby.error', 'Lot not found'));
+      }
+    } catch {
+      setError(t('lobby.networkError', 'Network error'));
+    }
+  }, [lotId, t]);
+
+  // Poll every 10 seconds
+  useEffect(() => {
+    fetchDisplay();
+    const interval = setInterval(fetchDisplay, 10_000);
+    return () => clearInterval(interval);
+  }, [fetchDisplay]);
+
+  // Update clock every second
+  useEffect(() => {
+    const timer = setInterval(() => setCurrentTime(new Date()), 1000);
+    return () => clearInterval(timer);
+  }, []);
+
+  if (error) {
+    return (
+      <div className="min-h-dvh bg-gray-950 flex items-center justify-center" data-testid="lobby-error">
+        <p className="text-red-400 text-4xl font-bold">{error}</p>
+      </div>
+    );
+  }
+
+  if (!data) {
+    return (
+      <div className="min-h-dvh bg-gray-950 flex items-center justify-center" data-testid="lobby-loading">
+        <div className="w-16 h-16 border-4 border-white/20 border-t-white rounded-full animate-spin" />
+      </div>
+    );
+  }
+
+  const colors = COLOR_MAP[data.color_status] || COLOR_MAP.green;
+  const occupancyWidth = Math.min(data.occupancy_percent, 100);
+
+  return (
+    <div
+      className="min-h-dvh bg-gray-950 text-white flex flex-col p-8 select-none overflow-hidden"
+      data-testid="lobby-display"
+    >
+      {/* Header: lot name + clock */}
+      <div className="flex items-center justify-between mb-8">
+        <h1 className="text-[4rem] leading-tight font-black tracking-tight truncate" data-testid="lobby-lot-name">
+          {data.lot_name}
+        </h1>
+        <time className="text-3xl font-mono text-gray-400 tabular-nums shrink-0 ml-8" data-testid="lobby-clock">
+          {currentTime.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' })}
+        </time>
+      </div>
+
+      {/* Main number display */}
+      <div className="flex-1 flex flex-col items-center justify-center gap-6">
+        <div className="text-center">
+          <span
+            className={`text-[8rem] leading-none font-black tabular-nums ${colors.text}`}
+            data-testid="lobby-available"
+          >
+            {data.available_slots}
+          </span>
+          <span className="text-[4rem] text-gray-500 font-light mx-4">/</span>
+          <span className="text-[4rem] text-gray-400 font-semibold tabular-nums" data-testid="lobby-total">
+            {data.total_slots}
+          </span>
+        </div>
+        <p className="text-2xl text-gray-400 uppercase tracking-widest">
+          {t('lobby.available', 'Available')}
+        </p>
+
+        {/* Occupancy bar */}
+        <div className="w-full max-w-4xl mt-4" data-testid="lobby-bar">
+          <div className="w-full h-8 bg-gray-800 rounded-full overflow-hidden">
+            <div
+              className={`h-full ${colors.bar} rounded-full transition-all duration-700 ease-out shadow-lg ${colors.glow}`}
+              style={{ width: `${occupancyWidth}%` }}
+              role="progressbar"
+              aria-valuenow={Math.round(data.occupancy_percent)}
+              aria-valuemin={0}
+              aria-valuemax={100}
+              aria-label={t('lobby.occupancy', 'Occupancy')}
+            />
+          </div>
+          <p className="text-center text-xl text-gray-500 mt-2">
+            {t('lobby.occupancy', 'Occupancy')}: {Math.round(data.occupancy_percent)}%
+          </p>
+        </div>
+      </div>
+
+      {/* Floor breakdown */}
+      {data.floors.length > 0 && (
+        <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4 mt-8" data-testid="lobby-floors">
+          {data.floors.map((floor) => {
+            const floorOcc = Math.min(floor.occupancy_percent, 100);
+            const floorColor = floor.occupancy_percent > 80 ? 'red' : floor.occupancy_percent >= 50 ? 'yellow' : 'green';
+            const fc = COLOR_MAP[floorColor];
+            return (
+              <div
+                key={floor.floor_number}
+                className="bg-gray-900 rounded-2xl p-5 flex flex-col items-center"
+                data-testid="lobby-floor-card"
+              >
+                <p className="text-lg text-gray-400 mb-1">
+                  {t('lobby.floor', 'Floor')} {floor.floor_name || floor.floor_number}
+                </p>
+                <p className={`text-4xl font-black tabular-nums ${fc.text}`}>
+                  {floor.available_slots}
+                </p>
+                <p className="text-sm text-gray-500">
+                  / {floor.total_slots}
+                </p>
+                <div className="w-full h-2 bg-gray-800 rounded-full mt-3 overflow-hidden">
+                  <div
+                    className={`h-full ${fc.bar} rounded-full transition-all duration-700`}
+                    style={{ width: `${floorOcc}%` }}
+                  />
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {/* Footer: last updated */}
+      <div className="flex justify-center mt-8 text-gray-600 text-lg">
+        <p data-testid="lobby-last-updated">
+          {t('lobby.lastUpdated', 'Last updated')}: {lastUpdated?.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' }) || '—'}
+        </p>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Add public `GET /api/v1/lots/:id/display` endpoint for digital signage monitors (no auth, rate-limited 10 req/min per IP)
- New `LobbyDisplay` full-screen view at `/lobby/:lotId` with auto-refresh every 10 seconds
- Feature flag `mod-lobby-display` added to `full` feature set
- Large text (4rem+/8rem+), color-coded occupancy bar, per-floor breakdown cards, dark background

## Details
- **Backend**: `lobby.rs` module with `LotDisplayData` response including lot name, total/available slots, occupancy %, color status (green/yellow/red), floor breakdown, timestamp
- **Rate limiting**: Dedicated `lobby_display` limiter (10/min/IP) in `EndpointRateLimiters`
- **Frontend**: React view with 10s polling, clock, last-updated timestamp, responsive floor grid
- **i18n**: English and German strings added (lobby.available, lobby.total, lobby.floor, lobby.lastUpdated, lobby.occupancy)

## Tests
- 6 backend tests (color boundaries, serialization, floor data)
- 6 frontend tests (loading, display, floors, error, occupancy bar, timestamp)

Closes #198