### PR TITLE
release: v2.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [2.9.0] - 2026-03-22
+
+### Added
+- **Lobby Display / Kiosk Mode**: Public `GET /api/v1/lots/:id/display` endpoint for digital signage monitors — no auth required, rate-limited 10 req/min per IP. Returns lot name, available/total slots, occupancy percentage, color status (green/yellow/red), and per-floor breakdown. Feature flag: `mod-lobby-display`. (#198)
+- **LobbyDisplay frontend**: Full-screen view at `/lobby/:lotId` with auto-refresh every 10 seconds, 8rem+ numbers, color-coded occupancy bar, floor breakdown cards, dark background for screen burn-in prevention. i18n for en/de.
+- **Interactive Onboarding Wizard**: 4-step setup wizard at `/setup` — company info (name/logo/timezone), create lot (floors/slots), user invites, theme picker (all 12 themes). Feature flag: `mod-setup-wizard`. (#200)
+- **Wizard API**: `GET /api/v1/setup/wizard/status` + `POST /api/v1/setup/wizard` with per-step persistence and validation
+- **12 backend tests**: 6 lobby display (color boundaries, serialization) + 8 wizard (DTO serialization, theme list, step validation)
+- **12 frontend tests**: 6 lobby display (loading, display, floors, error, occupancy bar) + 6 wizard (render, validation, navigation, themes, redirect)
+
+### Closed
+- **#199 Digital Parking Pass**: Deferred — requires Apple Developer and Google Pay API accounts
+
+---
+
 ## [2.8.0] - 2026-03-22
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5400,7 +5400,7 @@ dependencies = [
 
 [[package]]
 name = "parkhub-client"
-version = "2.8.0"
+version = "2.9.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -5427,7 +5427,7 @@ dependencies = [
 
 [[package]]
 name = "parkhub-common"
-version = "2.8.0"
+version = "2.9.0"
 dependencies = [
  "chrono",
  "serde",
@@ -5439,7 +5439,7 @@ dependencies = [
 
 [[package]]
 name = "parkhub-server"
-version = "2.8.0"
+version = "2.9.0"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.8.0"
+version = "2.9.0"
 edition = "2021"
 rust-version = "1.85"
 authors = ["nash87"]

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <p align="center">
   <a href="https://github.com/nash87/parkhub-rust/actions/workflows/ci.yml"><img src="https://github.com/nash87/parkhub-rust/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <a href="CHANGELOG.md"><img src="https://img.shields.io/badge/Release-v2.8.0-brightgreen.svg?style=flat-square" alt="v2.8.0"></a>
+  <a href="CHANGELOG.md"><img src="https://img.shields.io/badge/Release-v2.9.0-brightgreen.svg?style=flat-square" alt="v2.9.0"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square" alt="MIT License"></a>
   <a href="https://www.rust-lang.org/"><img src="https://img.shields.io/badge/Rust-1.85%2B-orange.svg?style=flat-square&logo=rust&logoColor=white" alt="Rust 1.85+"></a>
   <a href="https://react.dev/"><img src="https://img.shields.io/badge/React-19-61DAFB.svg?style=flat-square&logo=react&logoColor=black" alt="React 19"></a>
@@ -67,8 +67,10 @@ cargo build --release --package parkhub-server --no-default-features --features 
 
 ## Features
 
-### v2.8.0 Highlights
+### v2.9.0 Highlights
 
+- **Lobby Display / Kiosk Mode** -- Full-screen public display at `/lobby/:lotId` for parking garage monitors (no auth, auto-refresh, per-floor breakdown)
+- **Interactive Onboarding Wizard** -- 4-step setup wizard at `/setup` (company info, create lot, invite users, pick theme)
 - **WebSocket real-time updates** -- Live booking/occupancy events with token auth, heartbeat, and auto-reconnect
 - **API architecture overhaul** -- mod.rs reduced from 4500 to 1500 lines via Phase 3 handler extraction
 - **12 switchable themes** -- Classic, Glass, Bento, Brutalist, Neon, Warm, Wabi-Sabi, Scandinavian, Cyberpunk, Terracotta, Oceanic, Art Deco


### PR DESCRIPTION
## Summary
- Version bump to 2.9.0
- CHANGELOG update with lobby display, onboarding wizard, #199 deferral
- README badge + highlights update

## Included in v2.9.0
- **Lobby Display / Kiosk Mode** (#198) — `mod-lobby-display`
- **Interactive Onboarding Wizard** (#200) — `mod-setup-wizard`
- **#199 Digital Parking Pass** — deferred (requires Apple/Google accounts)
- 24 new tests (12 backend + 12 frontend)