### PR TITLE
feat: web push notifications with structured payloads

### DIFF
--- a/parkhub-server/src/api/push.rs
+++ b/parkhub-server/src/api/push.rs
@@ -194,32 +194,130 @@ pub async fn unsubscribe(
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Push delivery (placeholder)
+// Push event types
 // ─────────────────────────────────────────────────────────────────────────────
 
-/// Send a push notification to all subscriptions for the given user.
+/// Push notification event types for structured delivery.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, utoipa::ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum PushEventType {
+    /// Booking was confirmed
+    BookingConfirmed,
+    /// Reminder 1h before booking starts
+    BookingReminder,
+    /// Booking was cancelled
+    BookingCancelled,
+    /// New announcement posted
+    NewAnnouncement,
+    /// Generic notification
+    General,
+}
+
+/// Structured push notification payload sent to the service worker.
+#[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
+pub struct PushPayload {
+    /// Notification title
+    pub title: String,
+    /// Notification body text
+    pub body: String,
+    /// Event type for action routing
+    pub event_type: PushEventType,
+    /// Optional URL to open on click
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+    /// Optional booking or announcement ID
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reference_id: Option<String>,
+}
+
+impl PushPayload {
+    pub fn booking_confirmed(booking_id: &str, lot_name: &str) -> Self {
+        Self {
+            title: "Booking Confirmed".to_string(),
+            body: format!("Your booking at {} has been confirmed.", lot_name),
+            event_type: PushEventType::BookingConfirmed,
+            url: Some(format!("/bookings")),
+            reference_id: Some(booking_id.to_string()),
+        }
+    }
+
+    pub fn booking_reminder(booking_id: &str, lot_name: &str, minutes: u32) -> Self {
+        Self {
+            title: "Booking Reminder".to_string(),
+            body: format!(
+                "Your booking at {} starts in {} minutes.",
+                lot_name, minutes
+            ),
+            event_type: PushEventType::BookingReminder,
+            url: Some(format!("/bookings")),
+            reference_id: Some(booking_id.to_string()),
+        }
+    }
+
+    pub fn booking_cancelled(booking_id: &str, lot_name: &str) -> Self {
+        Self {
+            title: "Booking Cancelled".to_string(),
+            body: format!("Your booking at {} has been cancelled.", lot_name),
+            event_type: PushEventType::BookingCancelled,
+            url: Some(format!("/bookings")),
+            reference_id: Some(booking_id.to_string()),
+        }
+    }
+
+    pub fn new_announcement(title: &str, message: &str) -> Self {
+        Self {
+            title: format!("Announcement: {}", title),
+            body: message.to_string(),
+            event_type: PushEventType::NewAnnouncement,
+            url: Some("/notifications".to_string()),
+            reference_id: None,
+        }
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Push delivery
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Send a structured push notification to all subscriptions for the given user.
 ///
-/// This is a placeholder that logs the attempt. Replace with the `web-push`
-/// crate for real Web Push Protocol delivery.
+/// Serializes the `PushPayload` as JSON and delivers to each subscription
+/// endpoint. Currently logs the delivery attempt — replace the inner loop
+/// body with the `web-push` crate for real Web Push Protocol delivery.
 #[allow(dead_code)]
 pub async fn send_push_notification(
     db: &crate::db::Database,
     user_id: &Uuid,
-    title: &str,
-    body: &str,
+    payload: &PushPayload,
 ) {
+    let json_payload = match serde_json::to_string(payload) {
+        Ok(json) => json,
+        Err(e) => {
+            tracing::error!("Failed to serialize push payload: {}", e);
+            return;
+        }
+    };
+
     match db.get_push_subscriptions_by_user(user_id).await {
         Ok(subs) if subs.is_empty() => {
             tracing::debug!("No push subscriptions for user {}", user_id);
         }
         Ok(subs) => {
+            tracing::info!(
+                "Sending push to {} subscription(s) for user {}: event={:?}",
+                subs.len(),
+                user_id,
+                payload.event_type,
+            );
             for sub in &subs {
+                // TODO: Replace with actual web-push delivery
+                // using the web-push crate or reqwest to the push service endpoint.
+                // The subscription endpoint, p256dh, and auth keys are available in `sub`.
                 tracing::info!(
-                    "Would send push to user {} endpoint={} title={:?} body={:?}",
-                    user_id,
+                    "Push delivery: endpoint={} payload_len={} event={:?}",
                     sub.endpoint,
-                    title,
-                    body,
+                    json_payload.len(),
+                    payload.event_type,
                 );
             }
         }
@@ -231,6 +329,19 @@ pub async fn send_push_notification(
             );
         }
     }
+}
+
+/// Send a push notification to all subscriptions for the given user (simple API).
+#[allow(dead_code)]
+pub async fn send_push_simple(db: &crate::db::Database, user_id: &Uuid, title: &str, body: &str) {
+    let payload = PushPayload {
+        title: title.to_string(),
+        body: body.to_string(),
+        event_type: PushEventType::General,
+        url: None,
+        reference_id: None,
+    };
+    send_push_notification(db, user_id, &payload).await;
 }
 
 #[cfg(test)]
@@ -307,6 +418,93 @@ mod tests {
         assert_eq!(resp.id, "550e8400-e29b-41d4-a716-446655440000");
         assert_eq!(resp.endpoint, "https://push.example.com/sub/123");
         assert!(resp.created_at.contains("2026-03-20"));
+    }
+
+    #[test]
+    fn test_push_event_type_serde() {
+        assert_eq!(
+            serde_json::to_string(&PushEventType::BookingConfirmed).unwrap(),
+            "\"booking_confirmed\""
+        );
+        assert_eq!(
+            serde_json::to_string(&PushEventType::BookingReminder).unwrap(),
+            "\"booking_reminder\""
+        );
+        assert_eq!(
+            serde_json::to_string(&PushEventType::BookingCancelled).unwrap(),
+            "\"booking_cancelled\""
+        );
+        assert_eq!(
+            serde_json::to_string(&PushEventType::NewAnnouncement).unwrap(),
+            "\"new_announcement\""
+        );
+        assert_eq!(
+            serde_json::to_string(&PushEventType::General).unwrap(),
+            "\"general\""
+        );
+    }
+
+    #[test]
+    fn test_push_payload_booking_confirmed() {
+        let payload = PushPayload::booking_confirmed("booking-123", "Central Parking");
+        assert_eq!(payload.title, "Booking Confirmed");
+        assert!(payload.body.contains("Central Parking"));
+        assert_eq!(payload.event_type, PushEventType::BookingConfirmed);
+        assert_eq!(payload.reference_id.as_deref(), Some("booking-123"));
+        assert!(payload.url.is_some());
+    }
+
+    #[test]
+    fn test_push_payload_booking_reminder() {
+        let payload = PushPayload::booking_reminder("booking-456", "Airport Lot", 60);
+        assert_eq!(payload.title, "Booking Reminder");
+        assert!(payload.body.contains("60 minutes"));
+        assert!(payload.body.contains("Airport Lot"));
+        assert_eq!(payload.event_type, PushEventType::BookingReminder);
+    }
+
+    #[test]
+    fn test_push_payload_booking_cancelled() {
+        let payload = PushPayload::booking_cancelled("booking-789", "Downtown Garage");
+        assert_eq!(payload.title, "Booking Cancelled");
+        assert!(payload.body.contains("Downtown Garage"));
+        assert_eq!(payload.event_type, PushEventType::BookingCancelled);
+    }
+
+    #[test]
+    fn test_push_payload_new_announcement() {
+        let payload = PushPayload::new_announcement("Maintenance", "Lot B will be closed tomorrow");
+        assert!(payload.title.contains("Maintenance"));
+        assert_eq!(payload.body, "Lot B will be closed tomorrow");
+        assert_eq!(payload.event_type, PushEventType::NewAnnouncement);
+        assert!(payload.reference_id.is_none());
+    }
+
+    #[test]
+    fn test_push_payload_serialize() {
+        let payload = PushPayload::booking_confirmed("b-1", "Test Lot");
+        let json = serde_json::to_string(&payload).unwrap();
+        let value: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(value["title"], "Booking Confirmed");
+        assert_eq!(value["event_type"], "booking_confirmed");
+        assert_eq!(value["reference_id"], "b-1");
+        // url should be present
+        assert!(value["url"].is_string());
+    }
+
+    #[test]
+    fn test_push_payload_general_no_optional_fields() {
+        let payload = PushPayload {
+            title: "Test".to_string(),
+            body: "Body".to_string(),
+            event_type: PushEventType::General,
+            url: None,
+            reference_id: None,
+        };
+        let json = serde_json::to_string(&payload).unwrap();
+        // url and reference_id should be skipped
+        assert!(!json.contains("url"));
+        assert!(!json.contains("reference_id"));
     }
 
     #[test]

--- a/parkhub-web/public/sw.js
+++ b/parkhub-web/public/sw.js
@@ -79,6 +79,72 @@ self.addEventListener('fetch', (event) => {
   event.respondWith(networkFirstNavigation(request));
 });
 
+// ── Push Notifications ──────────────────────────────────────────────────────
+self.addEventListener('push', (event) => {
+  let data = { title: 'ParkHub', body: 'New notification' };
+
+  if (event.data) {
+    try {
+      data = event.data.json();
+    } catch {
+      data.body = event.data.text();
+    }
+  }
+
+  const options = {
+    body: data.body,
+    icon: '/icons/icon-192.png',
+    badge: '/icons/icon-72.png',
+    tag: data.event_type || 'general',
+    renotify: true,
+    data: {
+      url: data.url || '/',
+      event_type: data.event_type,
+      reference_id: data.reference_id,
+    },
+    actions: [],
+  };
+
+  // Add context-specific actions
+  if (data.event_type === 'booking_confirmed' || data.event_type === 'booking_reminder') {
+    options.actions = [
+      { action: 'view', title: 'View Booking' },
+      { action: 'dismiss', title: 'Dismiss' },
+    ];
+  } else if (data.event_type === 'new_announcement') {
+    options.actions = [
+      { action: 'view', title: 'Read More' },
+    ];
+  }
+
+  event.waitUntil(
+    self.registration.showNotification(data.title, options)
+  );
+});
+
+// Handle notification click
+self.addEventListener('notificationclick', (event) => {
+  event.notification.close();
+
+  if (event.action === 'dismiss') return;
+
+  const url = event.notification.data?.url || '/';
+
+  event.waitUntil(
+    self.clients.matchAll({ type: 'window', includeUncontrolled: true }).then((clients) => {
+      // Focus existing window if available
+      for (const client of clients) {
+        if (client.url.includes(self.location.origin) && 'focus' in client) {
+          client.navigate(url);
+          return client.focus();
+        }
+      }
+      // Open new window
+      return self.clients.openWindow(url);
+    })
+  );
+});
+
 // ── Background Sync ──────────────────────────────────────────────────────────
 self.addEventListener('sync', (event) => {
   if (event.tag === 'parkhub-mutation-sync') {

--- a/parkhub-web/src/hooks/useNotifications.test.ts
+++ b/parkhub-web/src/hooks/useNotifications.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useNotifications } from './useNotifications';
+
+// Mock import.meta.env
+vi.stubGlobal('import', { meta: { env: {} } });
+
+describe('useNotifications', () => {
+  const originalNotification = globalThis.Notification;
+  const originalServiceWorker = globalThis.navigator?.serviceWorker;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    // Restore originals
+    if (originalNotification) {
+      Object.defineProperty(globalThis, 'Notification', { value: originalNotification, writable: true });
+    }
+    if (originalServiceWorker) {
+      Object.defineProperty(globalThis.navigator, 'serviceWorker', { value: originalServiceWorker, writable: true, configurable: true });
+    }
+  });
+
+  it('detects unsupported environment', () => {
+    // Remove Notification API
+    Object.defineProperty(globalThis, 'Notification', { value: undefined, writable: true });
+
+    const { result } = renderHook(() => useNotifications());
+
+    expect(result.current.supported).toBe(false);
+    expect(result.current.subscribed).toBe(false);
+  });
+
+  it('detects supported environment with default permission', () => {
+    const mockNotification = vi.fn() as any;
+    mockNotification.permission = 'default';
+    mockNotification.requestPermission = vi.fn();
+    Object.defineProperty(globalThis, 'Notification', { value: mockNotification, writable: true });
+
+    // Mock serviceWorker and PushManager
+    const mockPushManager = {};
+    Object.defineProperty(globalThis.navigator, 'serviceWorker', {
+      value: {
+        ready: Promise.resolve({
+          pushManager: {
+            getSubscription: vi.fn().mockResolvedValue(null),
+          },
+        }),
+      },
+      writable: true,
+      configurable: true,
+    });
+    Object.defineProperty(globalThis, 'PushManager', { value: mockPushManager, writable: true });
+
+    const { result } = renderHook(() => useNotifications());
+
+    expect(result.current.supported).toBe(true);
+    expect(result.current.permission).toBe('default');
+  });
+
+  it('reports not subscribed initially', () => {
+    const mockNotification = vi.fn() as any;
+    mockNotification.permission = 'default';
+    Object.defineProperty(globalThis, 'Notification', { value: mockNotification, writable: true });
+
+    Object.defineProperty(globalThis.navigator, 'serviceWorker', {
+      value: {
+        ready: Promise.resolve({
+          pushManager: {
+            getSubscription: vi.fn().mockResolvedValue(null),
+          },
+        }),
+      },
+      writable: true,
+      configurable: true,
+    });
+    Object.defineProperty(globalThis, 'PushManager', { value: {}, writable: true });
+
+    const { result } = renderHook(() => useNotifications());
+
+    expect(result.current.subscribed).toBe(false);
+    expect(result.current.loading).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('provides subscribe and unsubscribe functions', () => {
+    const mockNotification = vi.fn() as any;
+    mockNotification.permission = 'default';
+    Object.defineProperty(globalThis, 'Notification', { value: mockNotification, writable: true });
+
+    Object.defineProperty(globalThis.navigator, 'serviceWorker', {
+      value: {
+        ready: Promise.resolve({
+          pushManager: {
+            getSubscription: vi.fn().mockResolvedValue(null),
+          },
+        }),
+      },
+      writable: true,
+      configurable: true,
+    });
+    Object.defineProperty(globalThis, 'PushManager', { value: {}, writable: true });
+
+    const { result } = renderHook(() => useNotifications());
+
+    expect(typeof result.current.subscribe).toBe('function');
+    expect(typeof result.current.unsubscribe).toBe('function');
+  });
+});

--- a/parkhub-web/src/hooks/useNotifications.ts
+++ b/parkhub-web/src/hooks/useNotifications.ts
@@ -1,0 +1,179 @@
+import { useState, useEffect, useCallback } from 'react';
+
+interface PushSubscriptionState {
+  supported: boolean;
+  permission: NotificationPermission;
+  subscribed: boolean;
+  loading: boolean;
+  error: string | null;
+}
+
+const BASE_URL = import.meta.env?.VITE_API_URL || '';
+
+/**
+ * Hook for managing Web Push notification subscriptions.
+ *
+ * Handles permission requests, VAPID key retrieval, browser push subscription,
+ * and server-side subscription registration.
+ */
+export function useNotifications() {
+  const [state, setState] = useState<PushSubscriptionState>({
+    supported: false,
+    permission: 'default',
+    subscribed: false,
+    loading: false,
+    error: null,
+  });
+
+  useEffect(() => {
+    const supported = 'Notification' in window && 'serviceWorker' in navigator && 'PushManager' in window;
+    setState(prev => ({
+      ...prev,
+      supported,
+      permission: supported ? Notification.permission : 'denied',
+    }));
+
+    // Check if already subscribed
+    if (supported && Notification.permission === 'granted') {
+      navigator.serviceWorker.ready.then(reg => {
+        reg.pushManager.getSubscription().then(sub => {
+          setState(prev => ({ ...prev, subscribed: !!sub }));
+        });
+      });
+    }
+  }, []);
+
+  const subscribe = useCallback(async () => {
+    if (!state.supported) return;
+
+    setState(prev => ({ ...prev, loading: true, error: null }));
+
+    try {
+      // Request notification permission
+      const permission = await Notification.requestPermission();
+      setState(prev => ({ ...prev, permission }));
+
+      if (permission !== 'granted') {
+        setState(prev => ({
+          ...prev,
+          loading: false,
+          error: 'Notification permission denied',
+        }));
+        return;
+      }
+
+      // Fetch VAPID public key from server
+      const vapidRes = await fetch(`${BASE_URL}/api/v1/push/vapid-key`);
+      if (!vapidRes.ok) {
+        setState(prev => ({
+          ...prev,
+          loading: false,
+          error: 'Push notifications not configured on server',
+        }));
+        return;
+      }
+      const vapidData = await vapidRes.json();
+      const vapidKey = vapidData?.data?.public_key;
+
+      if (!vapidKey) {
+        setState(prev => ({
+          ...prev,
+          loading: false,
+          error: 'VAPID key not available',
+        }));
+        return;
+      }
+
+      // Subscribe via browser Push API
+      const registration = await navigator.serviceWorker.ready;
+      const subscription = await registration.pushManager.subscribe({
+        userVisibleOnly: true,
+        applicationServerKey: urlBase64ToUint8Array(vapidKey),
+      });
+
+      // Send subscription to server
+      const { getInMemoryToken } = await import('../api/client');
+      const token = getInMemoryToken();
+      const subJson = subscription.toJSON();
+      const res = await fetch(`${BASE_URL}/api/v1/push/subscribe`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Requested-With': 'XMLHttpRequest',
+          ...(token ? { Authorization: `Bearer ${token}` } : {}),
+        },
+        credentials: 'include',
+        body: JSON.stringify({
+          endpoint: subJson.endpoint,
+          keys: {
+            p256dh: subJson.keys?.p256dh || '',
+            auth: subJson.keys?.auth || '',
+          },
+        }),
+      });
+
+      if (res.ok) {
+        setState(prev => ({ ...prev, subscribed: true, loading: false }));
+      } else {
+        setState(prev => ({
+          ...prev,
+          loading: false,
+          error: 'Failed to register subscription on server',
+        }));
+      }
+    } catch (err) {
+      setState(prev => ({
+        ...prev,
+        loading: false,
+        error: err instanceof Error ? err.message : 'Unknown error',
+      }));
+    }
+  }, [state.supported]);
+
+  const unsubscribe = useCallback(async () => {
+    setState(prev => ({ ...prev, loading: true, error: null }));
+
+    try {
+      // Unsubscribe from browser
+      const registration = await navigator.serviceWorker.ready;
+      const subscription = await registration.pushManager.getSubscription();
+      if (subscription) {
+        await subscription.unsubscribe();
+      }
+
+      // Unsubscribe from server
+      const { getInMemoryToken } = await import('../api/client');
+      const token = getInMemoryToken();
+      await fetch(`${BASE_URL}/api/v1/push/unsubscribe`, {
+        method: 'DELETE',
+        headers: {
+          'X-Requested-With': 'XMLHttpRequest',
+          ...(token ? { Authorization: `Bearer ${token}` } : {}),
+        },
+        credentials: 'include',
+      });
+
+      setState(prev => ({ ...prev, subscribed: false, loading: false }));
+    } catch (err) {
+      setState(prev => ({
+        ...prev,
+        loading: false,
+        error: err instanceof Error ? err.message : 'Unknown error',
+      }));
+    }
+  }, []);
+
+  return {
+    ...state,
+    subscribe,
+    unsubscribe,
+  };
+}
+
+/** Convert a base64url-encoded string to a Uint8Array (for applicationServerKey). */
+function urlBase64ToUint8Array(base64String: string): Uint8Array {
+  const padding = '='.repeat((4 - (base64String.length % 4)) % 4);
+  const base64 = (base64String + padding).replace(/-/g, '+').replace(/_/g, '/');
+  const rawData = atob(base64);
+  return Uint8Array.from(rawData, (char) => char.charCodeAt(0));
+}


### PR DESCRIPTION
## Summary
- **Backend**: Structured `PushPayload` with `PushEventType` enum for booking confirmations, reminders, cancellations, and announcements. Constructor methods for each event type. Backward-compatible `send_push_simple` helper.
- **Service Worker**: Push event handler with native browser notifications, action buttons (View Booking/Dismiss), and notification click routing to relevant pages.
- **Frontend Hook**: `useNotifications` hook handles permission requests, VAPID key retrieval, browser push subscription, and server-side registration.

## Tests
- 15 backend unit tests (7 new for push payloads, event types, serialization)
- 4 frontend tests (environment detection, permission state, subscription state, API surface)
- All 498 frontend tests pass