### PR TITLE
release: v3.8.0 — absence approval, calendar drag, admin widgets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [3.8.0] - 2026-03-23
+
+### Added
+- **Absence Approval Workflows**: Submit absence requests that require admin approval. `POST /api/v1/absences/requests`, `GET /api/v1/admin/absences/pending`, `PUT /api/v1/admin/absences/{id}/approve`, `PUT /api/v1/admin/absences/{id}/reject`, `GET /api/v1/absences/my`. Auto-notification on status change. Frontend: submit form with date range + type + reason, admin pending queue with approve/reject + comment, status badges. Feature flag: `mod-absence-approval`. 14 backend + 8 frontend tests. (#245)
+- **Calendar Drag-to-Reschedule**: Drag booking events to new dates on the calendar. `PUT /api/v1/bookings/{id}/reschedule` with slot availability validation and conflict detection. Visual drop target feedback, confirmation dialog. Feature flag: `mod-calendar-drag`. 10 backend + 5 frontend tests. (#246)
+- **Customizable Admin Dashboard Widgets**: Per-user dashboard widget system. `GET/PUT /api/v1/admin/widgets` for layout persistence, `GET /api/v1/admin/widgets/data/{widget_id}` for data. 8 widget types: occupancy_chart, revenue_summary, recent_bookings, user_growth, booking_heatmap, active_alerts, maintenance_status, ev_charging_status. Grid layout with widget catalog sidebar. Feature flag: `mod-widgets`. 13 backend + 8 frontend tests. (#247)
+- **i18n**: absenceApproval, calendarDrag, widgets keys added to all 10 locales
+- **51 feature flags**: Added `mod-absence-approval`, `mod-calendar-drag`, `mod-widgets` (was 48)
+
+---
+
 ## [3.7.0] - 2026-03-22
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "3.7.0"
+version = "3.8.0"
 edition = "2021"
 rust-version = "1.85"
 authors = ["nash87"]

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <p align="center">
   <a href="https://github.com/nash87/parkhub-rust/actions/workflows/ci.yml"><img src="https://github.com/nash87/parkhub-rust/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <a href="CHANGELOG.md"><img src="https://img.shields.io/badge/Release-v3.7.0-brightgreen.svg?style=flat-square" alt="v3.7.0"></a>
+  <a href="CHANGELOG.md"><img src="https://img.shields.io/badge/Release-v3.8.0-brightgreen.svg?style=flat-square" alt="v3.8.0"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square" alt="MIT License"></a>
   <a href="https://www.rust-lang.org/"><img src="https://img.shields.io/badge/Rust-1.85%2B-orange.svg?style=flat-square&logo=rust&logoColor=white" alt="Rust 1.85+"></a>
   <a href="https://react.dev/"><img src="https://img.shields.io/badge/React-19-61DAFB.svg?style=flat-square&logo=react&logoColor=black" alt="React 19"></a>


### PR DESCRIPTION
## Summary
- Bump version to 3.8.0
- Update CHANGELOG.md with 3 new features
- Update README.md version badge

## Features in this release
- **Absence Approval Workflows** (#245) — `mod-absence-approval`
- **Calendar Drag-to-Reschedule** (#246) — `mod-calendar-drag`
- **Customizable Admin Dashboard Widgets** (#247) — `mod-widgets`
- 51 total feature flags (was 48)
- 37 backend tests + 21 frontend tests added