### PR TITLE
feat(helm): Kubernetes Helm chart

### DIFF
--- a/helm/README.md
+++ b/helm/README.md
@@ -1,0 +1,86 @@
+# ParkHub Helm Chart
+
+Deploy ParkHub to Kubernetes using Helm.
+
+## Prerequisites
+
+- Kubernetes 1.25+
+- Helm 3.10+
+
+## Install
+
+```bash
+helm install parkhub ./helm/parkhub \
+  --namespace parkhub --create-namespace
+```
+
+## Install with custom values
+
+```bash
+helm install parkhub ./helm/parkhub \
+  --namespace parkhub --create-namespace \
+  -f my-values.yaml
+```
+
+## Configuration
+
+Key values (see `helm/parkhub/values.yaml` for full reference):
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `replicaCount` | `1` | Number of replicas |
+| `image.repository` | `ghcr.io/nash87/parkhub-rust` | Container image |
+| `image.tag` | `appVersion` | Image tag |
+| `service.type` | `ClusterIP` | Service type |
+| `ingress.enabled` | `false` | Enable ingress |
+| `persistence.enabled` | `true` | Enable persistent storage |
+| `persistence.size` | `1Gi` | PVC size |
+| `config.adminPassword` | `""` | Admin password (auto-generated if empty) |
+| `config.dbPassphrase` | `""` | AES-256-GCM encryption key |
+| `config.smtp.*` | `""` | SMTP settings |
+| `config.stripe.*` | `""` | Stripe payment keys |
+| `config.oauth.*` | `""` | OAuth provider credentials |
+| `modules.*` | `true` | Feature flag toggles |
+| `autoscaling.enabled` | `false` | Enable HPA |
+| `resources.limits.memory` | `256Mi` | Memory limit |
+
+## Module flags
+
+All 51 module flags are exposed in `values.yaml` under `modules.*`. Set any to `false` to disable:
+
+```yaml
+modules:
+  evCharging: false
+  dynamicPricing: false
+```
+
+## Ingress with TLS
+
+```yaml
+ingress:
+  enabled: true
+  className: nginx
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+  hosts:
+    - host: parking.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: parkhub-tls
+      hosts:
+        - parking.example.com
+```
+
+## Upgrade
+
+```bash
+helm upgrade parkhub ./helm/parkhub --namespace parkhub
+```
+
+## Uninstall
+
+```bash
+helm uninstall parkhub --namespace parkhub
+```

--- a/helm/parkhub/.helmignore
+++ b/helm/parkhub/.helmignore
@@ -1,0 +1,17 @@
+.DS_Store
+.git
+.gitignore
+.bzr
+.bzrignore
+.hg
+.hgignore
+.svn
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+.project
+.idea
+*.tmproj
+.vscode

--- a/helm/parkhub/Chart.yaml
+++ b/helm/parkhub/Chart.yaml
@@ -1,0 +1,18 @@
+apiVersion: v2
+name: parkhub
+description: Self-hosted parking management platform — single binary, zero dependencies
+type: application
+version: 1.0.0
+appVersion: "3.9.0"
+home: https://github.com/nash87/parkhub-rust
+sources:
+  - https://github.com/nash87/parkhub-rust
+maintainers:
+  - name: nash87
+    url: https://github.com/nash87
+keywords:
+  - parking
+  - management
+  - self-hosted
+  - gdpr
+icon: https://raw.githubusercontent.com/nash87/parkhub-rust/main/assets/app.png

--- a/helm/parkhub/templates/NOTES.txt
+++ b/helm/parkhub/templates/NOTES.txt
@@ -1,0 +1,25 @@
+ParkHub has been deployed successfully!
+
+1. Get the application URL:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "parkhub.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "parkhub.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else }}
+  kubectl --namespace {{ .Release.Namespace }} port-forward svc/{{ include "parkhub.fullname" . }} 8080:{{ .Values.service.port }}
+  echo "Visit http://localhost:8080"
+{{- end }}
+
+2. Default admin credentials are printed in the pod logs on first start:
+  kubectl logs -n {{ .Release.Namespace }} deploy/{{ include "parkhub.fullname" . }} | head -20
+
+3. API docs: http://<host>/api/v1/docs
+4. Health check: http://<host>/health
+5. Metrics: http://<host>/metrics

--- a/helm/parkhub/templates/_helpers.tpl
+++ b/helm/parkhub/templates/_helpers.tpl
@@ -1,0 +1,56 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "parkhub.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a fully qualified app name.
+*/}}
+{{- define "parkhub.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "parkhub.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "parkhub.labels" -}}
+helm.sh/chart: {{ include "parkhub.chart" . }}
+{{ include "parkhub.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "parkhub.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "parkhub.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Image tag — defaults to appVersion
+*/}}
+{{- define "parkhub.imageTag" -}}
+{{- default .Chart.AppVersion .Values.image.tag }}
+{{- end }}

--- a/helm/parkhub/templates/configmap.yaml
+++ b/helm/parkhub/templates/configmap.yaml
@@ -1,0 +1,66 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "parkhub.fullname" . }}
+  labels:
+    {{- include "parkhub.labels" . | nindent 4 }}
+data:
+  PARKHUB_PORT: {{ .Values.config.port | quote }}
+  RUST_LOG: {{ .Values.config.logLevel | quote }}
+  DEMO_MODE: {{ .Values.config.demoMode | quote }}
+  SMTP_PORT: {{ .Values.config.smtp.port | quote }}
+  SMTP_FROM: {{ .Values.config.smtp.from | quote }}
+  # Module feature flags
+  MODULE_BOOKINGS: {{ .Values.modules.bookings | quote }}
+  MODULE_VEHICLES: {{ .Values.modules.vehicles | quote }}
+  MODULE_ABSENCES: {{ .Values.modules.absences | quote }}
+  MODULE_BRANDING: {{ .Values.modules.branding | quote }}
+  MODULE_IMPORT: {{ .Values.modules.import | quote }}
+  MODULE_QR: {{ .Values.modules.qr | quote }}
+  MODULE_PWA: {{ .Values.modules.pwa | quote }}
+  MODULE_PAYMENTS: {{ .Values.modules.payments | quote }}
+  MODULE_WEBHOOKS: {{ .Values.modules.webhooks | quote }}
+  MODULE_NOTIFICATIONS: {{ .Values.modules.notifications | quote }}
+  MODULE_ANNOUNCEMENTS: {{ .Values.modules.announcements | quote }}
+  MODULE_RECURRING: {{ .Values.modules.recurring | quote }}
+  MODULE_GUEST: {{ .Values.modules.guest | quote }}
+  MODULE_CALENDAR: {{ .Values.modules.calendar | quote }}
+  MODULE_TEAM: {{ .Values.modules.team | quote }}
+  MODULE_SETTINGS: {{ .Values.modules.settings | quote }}
+  MODULE_JOBS: {{ .Values.modules.jobs | quote }}
+  MODULE_SWAP: {{ .Values.modules.swap | quote }}
+  MODULE_WAITLIST: {{ .Values.modules.waitlist | quote }}
+  MODULE_ZONES: {{ .Values.modules.zones | quote }}
+  MODULE_CREDITS: {{ .Values.modules.credits | quote }}
+  MODULE_EMAIL: {{ .Values.modules.email | quote }}
+  MODULE_EXPORT: {{ .Values.modules.export | quote }}
+  MODULE_FAVORITES: {{ .Values.modules.favorites | quote }}
+  MODULE_PUSH: {{ .Values.modules.push | quote }}
+  MODULE_RECOMMENDATIONS: {{ .Values.modules.recommendations | quote }}
+  MODULE_TRANSLATIONS: {{ .Values.modules.translations | quote }}
+  MODULE_SOCIAL: {{ .Values.modules.social | quote }}
+  MODULE_THEMES: {{ .Values.modules.themes | quote }}
+  MODULE_INVOICES: {{ .Values.modules.invoices | quote }}
+  MODULE_DYNAMIC_PRICING: {{ .Values.modules.dynamicPricing | quote }}
+  MODULE_OPERATING_HOURS: {{ .Values.modules.operatingHours | quote }}
+  MODULE_OAUTH: {{ .Values.modules.oauth | quote }}
+  MODULE_MAP: {{ .Values.modules.map | quote }}
+  MODULE_STRIPE: {{ .Values.modules.stripe | quote }}
+  MODULE_TENANTS: {{ .Values.modules.tenants | quote }}
+  MODULE_RATE_LIMIT: {{ .Values.modules.rateLimit | quote }}
+  MODULE_ACCESSIBLE: {{ .Values.modules.accessible | quote }}
+  MODULE_MAINTENANCE: {{ .Values.modules.maintenance | quote }}
+  MODULE_COST_CENTER: {{ .Values.modules.costCenter | quote }}
+  MODULE_FLEET: {{ .Values.modules.fleet | quote }}
+  MODULE_DATA_MANAGEMENT: {{ .Values.modules.dataManagement | quote }}
+  MODULE_AUDIT_LOG_UI: {{ .Values.modules.auditLogUi | quote }}
+  MODULE_HISTORY: {{ .Values.modules.history | quote }}
+  MODULE_GEOFENCE: {{ .Values.modules.geofence | quote }}
+  MODULE_VISITORS: {{ .Values.modules.visitors | quote }}
+  MODULE_EV_CHARGING: {{ .Values.modules.evCharging | quote }}
+  MODULE_WAITLIST_EXT: {{ .Values.modules.waitlistExt | quote }}
+  MODULE_PARKING_PASS: {{ .Values.modules.parkingPass | quote }}
+  MODULE_API_DOCS: {{ .Values.modules.apiDocs | quote }}
+  MODULE_ABSENCE_APPROVAL: {{ .Values.modules.absenceApproval | quote }}
+  MODULE_CALENDAR_DRAG: {{ .Values.modules.calendarDrag | quote }}
+  MODULE_WIDGETS: {{ .Values.modules.widgets | quote }}

--- a/helm/parkhub/templates/deployment.yaml
+++ b/helm/parkhub/templates/deployment.yaml
@@ -1,0 +1,99 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "parkhub.fullname" . }}
+  labels:
+    {{- include "parkhub.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "parkhub.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "parkhub.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ include "parkhub.imageTag" . }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.config.port }}
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 15
+            timeoutSeconds: 3
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 3
+            periodSeconds: 10
+            timeoutSeconds: 3
+          startupProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 2
+            periodSeconds: 5
+            failureThreshold: 10
+          envFrom:
+            - configMapRef:
+                name: {{ include "parkhub.fullname" . }}
+            - secretRef:
+                name: {{ include "parkhub.fullname" . }}
+          {{- with .Values.extraEnv }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          {{- if .Values.persistence.enabled }}
+          volumeMounts:
+            - name: data
+              mountPath: {{ .Values.persistence.mountPath }}
+          {{- end }}
+      {{- if .Values.persistence.enabled }}
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: {{ include "parkhub.fullname" . }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/helm/parkhub/templates/hpa.yaml
+++ b/helm/parkhub/templates/hpa.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "parkhub.fullname" . }}
+  labels:
+    {{- include "parkhub.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "parkhub.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/helm/parkhub/templates/ingress.yaml
+++ b/helm/parkhub/templates/ingress.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "parkhub.fullname" . }}
+  labels:
+    {{- include "parkhub.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "parkhub.fullname" $ }}
+                port:
+                  name: http
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/helm/parkhub/templates/pvc.yaml
+++ b/helm/parkhub/templates/pvc.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.persistence.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "parkhub.fullname" . }}
+  labels:
+    {{- include "parkhub.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.accessMode }}
+  {{- if .Values.persistence.storageClass }}
+  storageClassName: {{ .Values.persistence.storageClass | quote }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size }}
+{{- end }}

--- a/helm/parkhub/templates/secret.yaml
+++ b/helm/parkhub/templates/secret.yaml
@@ -1,0 +1,41 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "parkhub.fullname" . }}
+  labels:
+    {{- include "parkhub.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  {{- if .Values.config.adminPassword }}
+  PARKHUB_ADMIN_PASSWORD: {{ .Values.config.adminPassword | quote }}
+  {{- end }}
+  {{- if .Values.config.dbPassphrase }}
+  PARKHUB_DB_PASSPHRASE: {{ .Values.config.dbPassphrase | quote }}
+  {{- end }}
+  {{- if .Values.config.smtp.host }}
+  SMTP_HOST: {{ .Values.config.smtp.host | quote }}
+  {{- end }}
+  {{- if .Values.config.smtp.user }}
+  SMTP_USER: {{ .Values.config.smtp.user | quote }}
+  {{- end }}
+  {{- if .Values.config.smtp.password }}
+  SMTP_PASS: {{ .Values.config.smtp.password | quote }}
+  {{- end }}
+  {{- if .Values.config.stripe.secretKey }}
+  STRIPE_SECRET_KEY: {{ .Values.config.stripe.secretKey | quote }}
+  {{- end }}
+  {{- if .Values.config.stripe.webhookSecret }}
+  STRIPE_WEBHOOK_SECRET: {{ .Values.config.stripe.webhookSecret | quote }}
+  {{- end }}
+  {{- if .Values.config.oauth.google.clientId }}
+  OAUTH_GOOGLE_CLIENT_ID: {{ .Values.config.oauth.google.clientId | quote }}
+  {{- end }}
+  {{- if .Values.config.oauth.google.clientSecret }}
+  OAUTH_GOOGLE_CLIENT_SECRET: {{ .Values.config.oauth.google.clientSecret | quote }}
+  {{- end }}
+  {{- if .Values.config.oauth.github.clientId }}
+  OAUTH_GITHUB_CLIENT_ID: {{ .Values.config.oauth.github.clientId | quote }}
+  {{- end }}
+  {{- if .Values.config.oauth.github.clientSecret }}
+  OAUTH_GITHUB_CLIENT_SECRET: {{ .Values.config.oauth.github.clientSecret | quote }}
+  {{- end }}

--- a/helm/parkhub/templates/service.yaml
+++ b/helm/parkhub/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "parkhub.fullname" . }}
+  labels:
+    {{- include "parkhub.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "parkhub.selectorLabels" . | nindent 4 }}

--- a/helm/parkhub/values.yaml
+++ b/helm/parkhub/values.yaml
@@ -1,0 +1,174 @@
+# ParkHub Helm Chart — default values
+
+replicaCount: 1
+
+image:
+  repository: ghcr.io/nash87/parkhub-rust
+  pullPolicy: IfNotPresent
+  tag: ""  # defaults to appVersion
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  create: false
+  name: ""
+  annotations: {}
+
+podAnnotations: {}
+podLabels: {}
+
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  fsGroup: 1000
+
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop:
+      - ALL
+
+service:
+  type: ClusterIP
+  port: 8080
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # cert-manager.io/cluster-issuer: letsencrypt-prod
+  hosts:
+    - host: parkhub.local
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []
+  #  - secretName: parkhub-tls
+  #    hosts:
+  #      - parkhub.local
+
+resources:
+  limits:
+    cpu: 500m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 5
+  targetCPUUtilizationPercentage: 80
+  targetMemoryUtilizationPercentage: 80
+
+persistence:
+  enabled: true
+  storageClass: ""
+  accessMode: ReadWriteOnce
+  size: 1Gi
+  mountPath: /data
+
+nodeSelector: {}
+tolerations: []
+affinity: {}
+
+# -- Application configuration
+config:
+  # Server
+  port: 8080
+  logLevel: info
+  demoMode: false
+
+  # Admin
+  adminPassword: ""  # auto-generated if empty
+
+  # Database encryption
+  dbPassphrase: ""  # leave empty to disable AES-256-GCM at rest
+
+  # SMTP
+  smtp:
+    host: ""
+    port: 587
+    user: ""
+    password: ""
+    from: "noreply@parkhub.local"
+
+  # Stripe
+  stripe:
+    secretKey: ""
+    webhookSecret: ""
+
+  # OAuth
+  oauth:
+    google:
+      clientId: ""
+      clientSecret: ""
+    github:
+      clientId: ""
+      clientSecret: ""
+
+# -- Module feature flags (all enabled by default)
+modules:
+  bookings: true
+  vehicles: true
+  absences: true
+  branding: true
+  import: true
+  qr: true
+  pwa: true
+  payments: true
+  webhooks: true
+  notifications: true
+  announcements: true
+  recurring: true
+  guest: true
+  calendar: true
+  team: true
+  settings: true
+  jobs: true
+  swap: true
+  waitlist: true
+  zones: true
+  credits: true
+  email: true
+  export: true
+  favorites: true
+  push: true
+  recommendations: true
+  translations: true
+  social: true
+  themes: true
+  invoices: true
+  dynamicPricing: true
+  operatingHours: true
+  oauth: true
+  map: true
+  stripe: true
+  tenants: true
+  rateLimit: true
+  accessible: true
+  maintenance: true
+  costCenter: true
+  fleet: true
+  dataManagement: true
+  auditLogUi: true
+  history: true
+  geofence: true
+  visitors: true
+  evCharging: true
+  waitlistExt: true
+  parkingPass: true
+  apiDocs: true
+  absenceApproval: true
+  calendarDrag: true
+  widgets: true
+
+# -- Extra environment variables
+extraEnv: []
+#  - name: CUSTOM_VAR
+#    value: "custom-value"


### PR DESCRIPTION
## Summary
- Full Helm chart in `helm/parkhub/` for Kubernetes deployment
- Deployment with health/readiness/startup probes, resource limits, PVC
- ConfigMap with all 51 module feature flags, Secret for credentials
- Optional ingress with TLS, HPA for autoscaling
- `helm/README.md` with install/upgrade/config docs

## Files
- `helm/parkhub/Chart.yaml` — chart metadata (v1.0.0, appVersion 3.9.0)
- `helm/parkhub/values.yaml` — all configurable values
- `helm/parkhub/templates/` — deployment, service, ingress, configmap, secret, hpa, pvc, helpers, notes
- `helm/README.md` — usage documentation