### PR TITLE
feat(k6): load testing scripts

### DIFF
--- a/tests/load/README.md
+++ b/tests/load/README.md
@@ -1,0 +1,87 @@
+# ParkHub Load Tests (k6)
+
+Performance and load testing scripts using [k6](https://grafana.com/docs/k6/).
+
+## Prerequisites
+
+Install k6:
+
+```bash
+# macOS
+brew install k6
+
+# Linux (Debian/Ubuntu)
+sudo gpg -k
+sudo gpg --no-default-keyring --keyring /usr/share/keyrings/k6-archive-keyring.gpg \
+  --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C5AD17C747E3415A3642D57D77C6C491D6AC1D69
+echo "deb [signed-by=/usr/share/keyrings/k6-archive-keyring.gpg] https://dl.k6.io/deb stable main" \
+  | sudo tee /etc/apt/sources.list.d/k6.list
+sudo apt-get update && sudo apt-get install k6
+
+# Docker
+docker run --rm -i grafana/k6 run - <tests/load/smoke.js
+```
+
+## Test Scenarios
+
+| Script | VUs | Duration | Purpose |
+|--------|-----|----------|---------|
+| `smoke.js` | 1 | 30s | Sanity check — health, login, bookings |
+| `load.js` | 50 | 5min | Sustained load — full booking flow |
+| `stress.js` | 100 | 10min | All endpoints under heavy load |
+| `spike.js` | 200 | ~4min | Sudden traffic surge (1 to 200 VUs) |
+
+## Running
+
+```bash
+# Start ParkHub first
+./target/release/parkhub-server --headless --unattended
+
+# Smoke test (quick sanity)
+k6 run tests/load/smoke.js
+
+# Load test
+k6 run tests/load/load.js
+
+# Stress test
+k6 run tests/load/stress.js
+
+# Spike test
+k6 run tests/load/spike.js
+```
+
+## Configuration
+
+Override defaults via environment variables:
+
+```bash
+K6_BASE_URL=https://parking.example.com \
+K6_ADMIN_EMAIL=admin@corp.com \
+K6_ADMIN_PASSWORD=secret \
+K6_USER_EMAIL=user@corp.com \
+K6_USER_PASSWORD=secret \
+  k6 run tests/load/load.js
+```
+
+## Interpreting Results
+
+Key metrics to watch:
+
+| Metric | Target | Description |
+|--------|--------|-------------|
+| `http_req_duration (p95)` | < 500ms | 95th percentile response time |
+| `http_req_duration (p99)` | < 1500ms | 99th percentile response time |
+| `http_req_failed` | < 1% | Error rate |
+| `http_reqs` | > 10/s | Throughput |
+
+## Output
+
+Export results to JSON or InfluxDB for dashboarding:
+
+```bash
+# JSON output
+k6 run --out json=results.json tests/load/load.js
+
+# InfluxDB (for Grafana dashboards)
+k6 run --out influxdb=http://localhost:8086/k6 tests/load/load.js
+```

--- a/tests/load/config.js
+++ b/tests/load/config.js
@@ -1,0 +1,53 @@
+// ParkHub k6 shared configuration
+// Override via environment: K6_BASE_URL, K6_USERNAME, K6_PASSWORD
+
+export const BASE_URL = __ENV.K6_BASE_URL || "http://localhost:8080";
+
+export const CREDENTIALS = {
+  admin: {
+    email: __ENV.K6_ADMIN_EMAIL || "admin@parkhub.test",
+    password: __ENV.K6_ADMIN_PASSWORD || "admin123",
+  },
+  user: {
+    email: __ENV.K6_USER_EMAIL || "user@parkhub.test",
+    password: __ENV.K6_USER_PASSWORD || "user123",
+  },
+};
+
+export const THRESHOLDS = {
+  http_req_duration: ["p(95)<500", "p(99)<1500"],
+  http_req_failed: ["rate<0.01"],
+  http_reqs: ["rate>10"],
+};
+
+export const HEADERS = {
+  "Content-Type": "application/json",
+  Accept: "application/json",
+};
+
+/**
+ * Login and return auth headers with token.
+ */
+export function login(http, credentials) {
+  const res = http.post(
+    `${BASE_URL}/api/v1/auth/login`,
+    JSON.stringify({
+      email: credentials.email,
+      password: credentials.password,
+    }),
+    { headers: HEADERS }
+  );
+
+  if (res.status !== 200) {
+    console.error(`Login failed: ${res.status} ${res.body}`);
+    return HEADERS;
+  }
+
+  const body = res.json();
+  const token = body.token || body.access_token || "";
+
+  return {
+    ...HEADERS,
+    Authorization: `Bearer ${token}`,
+  };
+}

--- a/tests/load/load.js
+++ b/tests/load/load.js
@@ -1,0 +1,84 @@
+// ParkHub — Load Test
+// Sustained load: ramp to 50 VUs over 5 minutes
+// Run: k6 run tests/load/load.js
+
+import http from "k6/http";
+import { check, sleep } from "k6";
+import { BASE_URL, CREDENTIALS, HEADERS, THRESHOLDS, login } from "./config.js";
+
+export const options = {
+  stages: [
+    { duration: "1m", target: 10 },
+    { duration: "2m", target: 50 },
+    { duration: "1m", target: 50 },
+    { duration: "1m", target: 0 },
+  ],
+  thresholds: THRESHOLDS,
+};
+
+export function setup() {
+  const authHeaders = login(http, CREDENTIALS.user);
+  return { authHeaders };
+}
+
+export default function (data) {
+  // 1. Login
+  const loginRes = http.post(
+    `${BASE_URL}/api/v1/auth/login`,
+    JSON.stringify({
+      email: CREDENTIALS.user.email,
+      password: CREDENTIALS.user.password,
+    }),
+    { headers: HEADERS }
+  );
+  check(loginRes, { "login ok": (r) => r.status === 200 });
+
+  // 2. List lots
+  const lots = http.get(`${BASE_URL}/api/v1/lots`, {
+    headers: data.authHeaders,
+  });
+  check(lots, { "lots ok": (r) => r.status === 200 });
+
+  let lotId = null;
+  if (lots.status === 200) {
+    const body = lots.json();
+    const items = Array.isArray(body) ? body : body.data || body.lots || [];
+    if (items.length > 0) {
+      lotId = items[0].id;
+    }
+  }
+
+  // 3. Create booking
+  if (lotId) {
+    const tomorrow = new Date();
+    tomorrow.setDate(tomorrow.getDate() + 1);
+    const dateStr = tomorrow.toISOString().split("T")[0];
+
+    const bookRes = http.post(
+      `${BASE_URL}/api/v1/bookings`,
+      JSON.stringify({ lot_id: lotId, date: dateStr }),
+      { headers: data.authHeaders }
+    );
+    check(bookRes, {
+      "booking created": (r) => r.status === 200 || r.status === 201,
+    });
+
+    // 4. Cancel booking
+    if (bookRes.status === 200 || bookRes.status === 201) {
+      const booking = bookRes.json();
+      const bookingId = booking.id || booking.booking_id;
+      if (bookingId) {
+        const cancelRes = http.del(
+          `${BASE_URL}/api/v1/bookings/${bookingId}`,
+          null,
+          { headers: data.authHeaders }
+        );
+        check(cancelRes, {
+          "booking cancelled": (r) => r.status === 200 || r.status === 204,
+        });
+      }
+    }
+  }
+
+  sleep(0.5);
+}

--- a/tests/load/smoke.js
+++ b/tests/load/smoke.js
@@ -1,0 +1,56 @@
+// ParkHub — Smoke Test
+// Quick sanity check: 1 VU, 30s
+// Run: k6 run tests/load/smoke.js
+
+import http from "k6/http";
+import { check, sleep } from "k6";
+import { BASE_URL, CREDENTIALS, HEADERS, login } from "./config.js";
+
+export const options = {
+  vus: 1,
+  duration: "30s",
+  thresholds: {
+    http_req_duration: ["p(95)<300"],
+    http_req_failed: ["rate<0.01"],
+  },
+};
+
+export function setup() {
+  const authHeaders = login(http, CREDENTIALS.user);
+  return { authHeaders };
+}
+
+export default function (data) {
+  // Health check
+  const health = http.get(`${BASE_URL}/health`);
+  check(health, {
+    "health returns 200": (r) => r.status === 200,
+  });
+
+  // Login flow
+  const loginRes = http.post(
+    `${BASE_URL}/api/v1/auth/login`,
+    JSON.stringify({
+      email: CREDENTIALS.user.email,
+      password: CREDENTIALS.user.password,
+    }),
+    { headers: HEADERS }
+  );
+  check(loginRes, {
+    "login returns 200": (r) => r.status === 200,
+    "login has token": (r) => {
+      const body = r.json();
+      return body.token || body.access_token;
+    },
+  });
+
+  // List bookings
+  const bookings = http.get(`${BASE_URL}/api/v1/bookings`, {
+    headers: data.authHeaders,
+  });
+  check(bookings, {
+    "bookings returns 200": (r) => r.status === 200,
+  });
+
+  sleep(1);
+}

--- a/tests/load/spike.js
+++ b/tests/load/spike.js
@@ -1,0 +1,64 @@
+// ParkHub — Spike Test
+// Sudden load surge: 1 → 200 → 1 VUs
+// Run: k6 run tests/load/spike.js
+
+import http from "k6/http";
+import { check, sleep } from "k6";
+import { Rate } from "k6/metrics";
+import { BASE_URL, CREDENTIALS, HEADERS, login } from "./config.js";
+
+const failRate = new Rate("failed_requests");
+
+export const options = {
+  stages: [
+    { duration: "30s", target: 1 },     // warm up
+    { duration: "30s", target: 200 },    // spike
+    { duration: "1m", target: 200 },     // hold spike
+    { duration: "30s", target: 1 },      // recover
+    { duration: "1m", target: 1 },       // cool down
+  ],
+  thresholds: {
+    http_req_duration: ["p(95)<2000"],
+    failed_requests: ["rate<0.10"],
+  },
+};
+
+export function setup() {
+  const authHeaders = login(http, CREDENTIALS.user);
+  return { authHeaders };
+}
+
+export default function (data) {
+  // Health (always fast, tests infrastructure)
+  const health = http.get(`${BASE_URL}/health`);
+  failRate.add(health.status !== 200);
+  check(health, { "health ok": (r) => r.status === 200 });
+
+  // Login (auth under pressure)
+  const loginRes = http.post(
+    `${BASE_URL}/api/v1/auth/login`,
+    JSON.stringify({
+      email: CREDENTIALS.user.email,
+      password: CREDENTIALS.user.password,
+    }),
+    { headers: HEADERS }
+  );
+  failRate.add(loginRes.status !== 200);
+  check(loginRes, { "login ok": (r) => r.status === 200 });
+
+  // List bookings (read under pressure)
+  const bookings = http.get(`${BASE_URL}/api/v1/bookings`, {
+    headers: data.authHeaders,
+  });
+  failRate.add(bookings.status !== 200);
+  check(bookings, { "bookings ok": (r) => r.status === 200 });
+
+  // List lots
+  const lots = http.get(`${BASE_URL}/api/v1/lots`, {
+    headers: data.authHeaders,
+  });
+  failRate.add(lots.status !== 200);
+  check(lots, { "lots ok": (r) => r.status === 200 });
+
+  sleep(0.2);
+}

--- a/tests/load/stress.js
+++ b/tests/load/stress.js
@@ -1,0 +1,72 @@
+// ParkHub — Stress Test
+// Push limits: ramp to 100 VUs over 10 minutes, hit all major endpoints
+// Run: k6 run tests/load/stress.js
+
+import http from "k6/http";
+import { check, sleep } from "k6";
+import { Counter } from "k6/metrics";
+import { BASE_URL, CREDENTIALS, HEADERS, login } from "./config.js";
+
+const errorCount = new Counter("errors");
+
+export const options = {
+  stages: [
+    { duration: "2m", target: 25 },
+    { duration: "3m", target: 50 },
+    { duration: "3m", target: 100 },
+    { duration: "1m", target: 100 },
+    { duration: "1m", target: 0 },
+  ],
+  thresholds: {
+    http_req_duration: ["p(95)<1000", "p(99)<3000"],
+    http_req_failed: ["rate<0.05"],
+    errors: ["count<100"],
+  },
+};
+
+export function setup() {
+  const userHeaders = login(http, CREDENTIALS.user);
+  const adminHeaders = login(http, CREDENTIALS.admin);
+  return { userHeaders, adminHeaders };
+}
+
+function hitEndpoint(url, headers, name) {
+  const res = http.get(url, { headers, tags: { name } });
+  const ok = check(res, { [`${name} ok`]: (r) => r.status === 200 });
+  if (!ok) errorCount.add(1);
+  return res;
+}
+
+export default function (data) {
+  const endpoints = [
+    // Public
+    { url: `${BASE_URL}/health`, headers: HEADERS, name: "health" },
+
+    // User endpoints
+    { url: `${BASE_URL}/api/v1/bookings`, headers: data.userHeaders, name: "bookings" },
+    { url: `${BASE_URL}/api/v1/lots`, headers: data.userHeaders, name: "lots" },
+    { url: `${BASE_URL}/api/v1/me`, headers: data.userHeaders, name: "profile" },
+    { url: `${BASE_URL}/api/v1/vehicles`, headers: data.userHeaders, name: "vehicles" },
+    { url: `${BASE_URL}/api/v1/notifications`, headers: data.userHeaders, name: "notifications" },
+    { url: `${BASE_URL}/api/v1/credits`, headers: data.userHeaders, name: "credits" },
+    { url: `${BASE_URL}/api/v1/favorites`, headers: data.userHeaders, name: "favorites" },
+    { url: `${BASE_URL}/api/v1/absences`, headers: data.userHeaders, name: "absences" },
+    { url: `${BASE_URL}/api/v1/bookings/history`, headers: data.userHeaders, name: "history" },
+
+    // Admin endpoints
+    { url: `${BASE_URL}/api/v1/admin/users`, headers: data.adminHeaders, name: "admin-users" },
+    { url: `${BASE_URL}/api/v1/admin/lots`, headers: data.adminHeaders, name: "admin-lots" },
+    { url: `${BASE_URL}/api/v1/admin/bookings`, headers: data.adminHeaders, name: "admin-bookings" },
+    { url: `${BASE_URL}/api/v1/admin/analytics`, headers: data.adminHeaders, name: "admin-analytics" },
+  ];
+
+  // Hit 3-5 random endpoints per iteration
+  const count = 3 + Math.floor(Math.random() * 3);
+  for (let i = 0; i < count; i++) {
+    const ep = endpoints[Math.floor(Math.random() * endpoints.length)];
+    hitEndpoint(ep.url, ep.headers, ep.name);
+    sleep(0.1);
+  }
+
+  sleep(0.3);
+}


### PR DESCRIPTION
## Summary
- k6 load testing suite in `tests/load/` with 4 scenarios
- **smoke.js**: 1 VU, 30s — basic health/login/bookings sanity check
- **load.js**: 50 VUs, 5min — full booking lifecycle (login, list lots, book, cancel)
- **stress.js**: 100 VUs, 10min — all major endpoints under heavy load
- **spike.js**: 1-200-1 VUs — sudden traffic surge simulation
- Shared config with env var overrides for BASE_URL, credentials, thresholds

## Files
- `tests/load/config.js` — shared config + login helper
- `tests/load/smoke.js`, `load.js`, `stress.js`, `spike.js` — test scripts
- `tests/load/README.md` — install, run, interpret docs