### PR TITLE
release: v3.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [3.9.0] - 2026-03-23
+
+### Added
+- **Kubernetes Helm Chart**: Full Helm chart in `helm/parkhub/` for K8s deployment. Deployment with health/readiness/startup probes, resource limits, PVC persistence. ConfigMap with all 51 module feature flags, Secret for credentials (SMTP, Stripe, OAuth, DB encryption). Optional ingress with TLS, HPA for autoscaling. `helm/README.md` with install/upgrade/config docs. (#249)
+- **k6 Load Testing Suite**: Performance testing scripts in `tests/load/`. Smoke test (1 VU, 30s), load test (50 VUs, 5min ramp), stress test (100 VUs, 10min, all endpoints), spike test (1-200-1 VUs). Shared config with environment variable overrides. `tests/load/README.md` with install, run, and interpretation guides. (#250)
+- **Postman Collection & Auto-Generation**: `GET /api/v1/docs/postman.json` endpoint that auto-generates a Postman v2.1 collection from the OpenAPI spec. Static collection in `docs/postman/` with 100+ requests in 17 folders (Auth, Bookings, Lots, Admin, etc.), environment template, login auto-sets token. Feature flag: `mod-api-docs`. 4 backend tests. (#251)
+
+---
+
 ## [3.8.0] - 2026-03-23
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "3.8.0"
+version = "3.9.0"
 edition = "2021"
 rust-version = "1.85"
 authors = ["nash87"]

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <p align="center">
   <a href="https://github.com/nash87/parkhub-rust/actions/workflows/ci.yml"><img src="https://github.com/nash87/parkhub-rust/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <a href="CHANGELOG.md"><img src="https://img.shields.io/badge/Release-v3.8.0-brightgreen.svg?style=flat-square" alt="v3.8.0"></a>
+  <a href="CHANGELOG.md"><img src="https://img.shields.io/badge/Release-v3.9.0-brightgreen.svg?style=flat-square" alt="v3.9.0"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square" alt="MIT License"></a>
   <a href="https://www.rust-lang.org/"><img src="https://img.shields.io/badge/Rust-1.85%2B-orange.svg?style=flat-square&logo=rust&logoColor=white" alt="Rust 1.85+"></a>
   <a href="https://react.dev/"><img src="https://img.shields.io/badge/React-19-61DAFB.svg?style=flat-square&logo=react&logoColor=black" alt="React 19"></a>
@@ -244,7 +244,7 @@ cargo build --release -p parkhub-server --no-default-features \
 ParkHub runs anywhere -- from a Raspberry Pi to Kubernetes.
 
 - **Docker Compose** (recommended) -- `docker compose up -d` and you're done
-- **Kubernetes** -- Health probes, Prometheus metrics, Helm-ready manifests, designed for GitOps with Flux CD
+- **Kubernetes / Helm** -- Full Helm chart in `helm/parkhub/` with health probes, HPA, PVC, all 51 module flags, ingress with TLS. See [helm/README.md](helm/README.md)
 - **Bare Metal** -- Download the single binary, run it. No runtime dependencies. x86_64 and ARM64
 - **Windows** -- GUI installer with system tray icon and setup wizard
 
@@ -260,6 +260,36 @@ See [docs/INSTALLATION.md](docs/INSTALLATION.md) for detailed guides.
 cargo test --workspace           # Rust backend
 cd parkhub-web && npx vitest run # Frontend
 npx playwright test              # E2E
+```
+
+### Load Testing (k6)
+
+Performance testing with [k6](https://grafana.com/docs/k6/) in `tests/load/`:
+
+```bash
+k6 run tests/load/smoke.js    # 1 VU, 30s — quick sanity
+k6 run tests/load/load.js     # 50 VUs, 5min — sustained load
+k6 run tests/load/stress.js   # 100 VUs, 10min — all endpoints
+k6 run tests/load/spike.js    # 1→200→1 VUs — sudden surge
+```
+
+See [tests/load/README.md](tests/load/README.md) for setup and interpretation.
+
+---
+
+## Postman Collection
+
+Import the ready-made Postman collection to explore the API interactively:
+
+1. Import `docs/postman/ParkHub.postman_collection.json` into Postman
+2. Import `docs/postman/ParkHub.postman_environment.json` as environment
+3. Set `base_url` to your ParkHub instance
+4. Run the **Login** request — it auto-sets the `{{token}}` variable
+
+Or fetch the auto-generated collection from a running server:
+
+```
+GET /api/v1/docs/postman.json
 ```
 
 ---


### PR DESCRIPTION
## Summary
- Bump version to 3.9.0
- CHANGELOG: Helm chart (#249), k6 load tests (#250), Postman collection (#251)
- README: add Helm, k6, Postman sections; update version badge

## What's New in v3.9.0
- **Kubernetes Helm Chart** — full chart with all 51 module flags, probes, HPA, ingress
- **k6 Load Testing** — smoke, load, stress, spike scenarios
- **Postman Collection** — auto-generated endpoint + static 100+ request collection