### PR TITLE
ci(hygiene): tier-1 workflow cleanup

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -9,6 +9,10 @@ on:
     paths:
       - .github/workflows/copilot-setup-steps.yml
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   copilot-setup-steps:
     runs-on: ubuntu-latest

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -6,6 +6,10 @@ permissions:
   contents: write
   pull-requests: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   dependabot:
     runs-on: ubuntu-latest

--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -14,6 +14,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     name: Lint + Template

--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -4,6 +4,10 @@ on:
     - cron: '0 7 * * *'  # 07:00 UTC nightly
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   docker-compose:
     runs-on: ubuntu-latest

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -1,26 +1,22 @@
 name: Visual Regression
 
-# Soft-fail visual regression gate (T-1770). Not yet a required check — triage
-# diff artifacts in the PR review before requiring this to be green. Once the
-# baselines are stable for a few weeks, promote to required in branch
-# protection.
+# Nightly visual regression. Runs against `main` once per day so baseline
+# drift is caught within 24h without surfacing flaky red X's on every PR.
+# GitHub-hosted runners render with slight anti-aliasing / font-hinting
+# differences from local baselines, which made the per-PR gate noisy
+# without providing matching merge-blocking value (the job was already
+# `continue-on-error: true`).
+#
+# Run manually via `workflow_dispatch` when intentionally rebasing
+# baselines.
 
 on:
-  pull_request:
-    paths:
-      - 'parkhub-server/**'
-      - 'parkhub-web/**'
-      - 'parkhub-common/**'
-      - 'parkhub-client/**'
-      - 'e2e/visual.spec.ts'
-      - 'e2e/helpers.ts'
-      - 'e2e/visual.spec.ts-snapshots/**'
-      - 'playwright.config.ts'
-      - '.github/workflows/visual-regression.yml'
+  schedule:
+    - cron: '0 3 * * *'  # 03:00 UTC daily
   workflow_dispatch:
 
 concurrency:
-  group: visual-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: visual-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 permissions:


### PR DESCRIPTION
## Summary
Two reductions in per-PR CI noise. No behavior change on `main`.

1. **Concurrency cancel-in-progress** on 4 workflows that lacked it: `copilot-setup-steps`, `helm`, `install-smoke` → `cancel-in-progress: true`. `dependabot-auto-merge` → `cancel-in-progress: false` (never cancel a bot merge mid-flight). Force-pushes (we did two today) no longer burn runners on superseded commits.

2. **Visual regression: `pull_request` → `schedule: 0 3 * * *`**. The job was already `continue-on-error: true` (advisory), so its per-PR red X had zero merge-blocking value — but kept surfacing as 'failing check' whenever inter-runner font-hinting / subpixel AA drift exceeded `maxDiffPixelRatio`. 24h detection against `main` suffices for solo-maintainer velocity. `workflow_dispatch` still available for intentional baseline rebases.

## Follow-up

Slim required status checks from **7 → 4** (`CI`, `CodeQL`, `Security`, `Dependency Review`) — requires branch-protection write via `gh api`. Kept as a separate manual step so the context list is explicit.

## Test plan
- [x] Workflow YAMLs parse (confirmed locally via yaml.safe_load)
- [ ] After merge, push a trivial commit → verify visual-regression does NOT run on PR
- [ ] Force-push a branch → verify superseded CI run is cancelled