### PR TITLE
fix(sec): clear CodeQL warnings in Settings + AdminModules

### DIFF
--- a/parkhub-web/src/views/AdminModules.tsx
+++ b/parkhub-web/src/views/AdminModules.tsx
@@ -46,8 +46,8 @@ function categoryLabel(t: (k: string, d?: string) => string, cat: string): strin
 /** Status pill reflects runtime_enabled (green), runtime off (amber), or compile-time off (gray). */
 function StatusDot({ m }: { m: ModuleInfo }) {
   const runtime = m.runtime_enabled ?? m.enabled;
-  let cls = 'bg-neutral-500';
-  let label = 'disabled';
+  let cls: string;
+  let label: string;
   if (!m.enabled) {
     // Compile-time disabled — nothing admins can do at runtime.
     cls = 'bg-neutral-500';
@@ -375,7 +375,7 @@ export function AdminModulesPage() {
       {configOpenFor && (
         <ConfigEditorModal
           moduleName={configOpenFor}
-          isOpen={configOpenFor !== null}
+          isOpen
           onClose={() => setConfigOpenFor(null)}
         />
       )}

--- a/parkhub-web/src/views/Settings.tsx
+++ b/parkhub-web/src/views/Settings.tsx
@@ -15,7 +15,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
-import { User, Building, Palette, Bell, Car, Keyboard, Shield, Coins, ChartLine, FileText, ArrowRight } from '@phosphor-icons/react';
+import { User, Building, Bell, Car, Keyboard, Shield, Coins, ChartLine, FileText, ArrowRight } from '@phosphor-icons/react';
 import {
   SCard,
   SRow,


### PR DESCRIPTION
## Summary

Clears 4 CodeQL alerts that opened on main after the v3+v4 design integration merge:

| # | File:Line | Rule | Fix |
|---|---|---|---|
| #462 | AdminModules.tsx:49 | js/useless-assignment-to-local | `let cls = '...'` → `let cls: string;` (always overwritten in if/else branches) |
| #463 | AdminModules.tsx:50 | js/useless-assignment-to-local | same for `label` |
| #464 | AdminModules.tsx:378 | js/comparison-between-incompatible-types | `isOpen={configOpenFor !== null}` → `isOpen` (the outer `configOpenFor &&` already guards) |
| #470 | Settings.tsx:18 | js/unused-local-variable | drop unused `Palette` icon import |

All four are static-analysis-only; no runtime behaviour change.

## Not included (handled separately)

- **#469 App.tsx:51** (`SettingsPage unused`) — false positive; CodeQL's JS pass doesn't see the lazy-import + JSX usage at `<SettingsPage />`. Dismiss as *won't fix / design false positive*.
- **#465 encryption.rs:29** (`hard-coded-cryptographic-value`) — needs domain review (could be legitimate KDF salt vs a real secret). Separate task.
- **#461 / #460 / #459** (Helm chart KSV-0020/0021/0125) — separate CI-hygiene task.

## Test plan

- [x] `npm run build` clean (12.4s)
- [x] Byte-identical mirror to parkhub-php (both `Settings.tsx` + `AdminModules.tsx`)
- [ ] CodeQL on this PR should report all 4 as *closed* (normally fires on re-scan of the modified files)