### PR TITLE
fix(helm): bump UID/GID > 10000 (Trivy KSV-0020 + KSV-0021)

### DIFF
--- a/helm/parkhub/values.yaml
+++ b/helm/parkhub/values.yaml
@@ -21,8 +21,14 @@ podLabels: {}
 
 podSecurityContext:
   runAsNonRoot: true
-  runAsUser: 1000
-  fsGroup: 1000
+  # Trivy KSV-0020 / KSV-0021 require UID and GID > 10000 to stay clear
+  # of any user/group IDs that may be pre-created by the base image or
+  # mounted filesystems. We use 10001 across the board; the parkhub-data
+  # volume is created by the container at startup so the UID can be
+  # freely chosen without touching the host.
+  runAsUser: 10001
+  runAsGroup: 10001
+  fsGroup: 10001
   # PSS "restricted" profile — constrains syscalls to the RuntimeDefault
   # seccomp profile (blocks known-dangerous calls like unshare, kexec,
   # swapon, etc.). parkhub-server is a pure-async axum binary and has no


### PR DESCRIPTION
Clears 2 CodeQL Helm-scanner findings:

- **KSV-0020** (runAsUser > 10000): 1000 → 10001
- **KSV-0021** (runAsGroup > 10000): previously unset → 10001
- fsGroup: 1000 → 10001 (matches the user/group)

Zero operator impact — parkhub-data is container-created on startup, so UID choice is free. Fixes 2 alerts out of the 4 CodeQL items on main.