### PR TITLE
fix(ci): explicit rustup target add for macOS universal build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -163,6 +163,13 @@ jobs:
         with:
           targets: aarch64-apple-darwin,x86_64-apple-darwin
 
+      # macos-latest is now arm64 and rust-toolchain doesn't always cross-install
+      # the x86_64 target. Explicit rustup fallback guarantees both are present.
+      - name: Ensure both macOS targets installed
+        run: |
+          rustup target add aarch64-apple-darwin x86_64-apple-darwin
+          rustup target list --installed
+
       - name: Rust cache (macOS)
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:

--- a/parkhub-web/src/views/SwapRequests.test.tsx
+++ b/parkhub-web/src/views/SwapRequests.test.tsx
@@ -184,8 +184,10 @@ describe('SwapRequestsPage', () => {
   it('handleCreate is no-op when no booking selected', async () => {
     render(<SwapRequestsPage />);
     await waitFor(() => fireEvent.click(screen.getByText('swap.create')));
-    // Submit without selecting source/target
-    fireEvent.click(screen.getByTestId('submit-swap'));
+    // AnimatePresence delays mounting the modal body; wait for submit button
+    // to be present, then click without having selected source/target.
+    const submit = await screen.findByTestId('submit-swap');
+    fireEvent.click(submit);
     // No fetch call to /swap-request
   });
 


### PR DESCRIPTION
## Summary

v4.14.0 release failed the macOS universal build step because the x86_64 build leg ran before the x86_64-apple-darwin target was available:

\`\`\`
error[E0463]: can't find crate for \`core\`
  = note: the \`x86_64-apple-darwin\` target may not be installed
  = help: consider downloading the target with \`rustup target add x86_64-apple-darwin\`
\`\`\`

\`macos-latest\` is now an arm64 runner, and \`dtolnay/rust-toolchain\`'s \`targets:\` parameter installed \`aarch64-apple-darwin\` (native) but silently dropped \`x86_64-apple-darwin\`. aarch64 compiled fine; x86_64 failed on the very first crate (\`zeroize\`).

### Fix

Explicit \`rustup target add aarch64-apple-darwin x86_64-apple-darwin\` step right after the toolchain install, guaranteeing both are present before either build leg runs. Idempotent — already-installed targets are no-ops.

### Follow-up

v4.14.0 shipped Linux x64, Linux ARM64, and Windows assets. macOS universal binary is missing and will need to be added either via re-triggered workflow (if we move to tagged rebuild) or backfilled in v4.14.1.

## Test plan
- [ ] CI reruns macOS build leg successfully
- [ ] Verify next tagged release publishes all 4 platform assets