### PR TITLE
chore: bump workspace version to 4.14.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6731,7 +6731,7 @@ dependencies = [
 
 [[package]]
 name = "parkhub-client"
-version = "4.14.0"
+version = "4.14.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6758,7 +6758,7 @@ dependencies = [
 
 [[package]]
 name = "parkhub-common"
-version = "4.14.0"
+version = "4.14.1"
 dependencies = [
  "chrono",
  "proptest",
@@ -6771,7 +6771,7 @@ dependencies = [
 
 [[package]]
 name = "parkhub-desktop"
-version = "4.14.0"
+version = "4.14.1"
 dependencies = [
  "directories",
  "serde",
@@ -6795,7 +6795,7 @@ dependencies = [
 
 [[package]]
 name = "parkhub-server"
-version = "4.14.0"
+version = "4.14.1"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "4.14.0"
+version = "4.14.1"
 edition = "2024"
 rust-version = "1.94"
 authors = ["nash87"]


### PR DESCRIPTION
## Summary

Patch release to ship the macOS universal binary that v4.14.0 missed.

v4.14.0 release workflow failed on macOS x86_64 build because the \`macos-latest\` runner (now arm64) didn't cross-install \`x86_64-apple-darwin\` via the \`dtolnay/rust-toolchain\` \`targets:\` parameter. Fix landed in #342 (explicit \`rustup target add\` step).

Linux x64, Linux ARM64, and Windows assets are already live on v4.14.0. Tagging v4.14.1 will produce all four platform artefacts with no other user-facing changes.

## Test plan
- [ ] Release workflow completes all 4 platform builds
- [ ] Universal binary (\`parkhub-macos-universal.tar.gz\`) attached to the v4.14.1 release