### PR TITLE
fix(ci): vendor OpenSSL per-target for macOS universal build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -176,13 +176,10 @@ jobs:
           workspaces: "."
           key: macos-release
 
-      - name: Install OpenSSL (Homebrew)
-        run: |
-          brew install openssl@3
-          {
-            echo "OPENSSL_DIR=$(brew --prefix openssl@3)"
-            echo "OPENSSL_STATIC=1"
-          } >> "$GITHUB_ENV"
+      # OpenSSL is now built from source (vendored) by openssl-sys per target —
+      # see parkhub-server/Cargo.toml [target.'cfg(target_os = "macos")']. No
+      # Homebrew install needed; Homebrew's arm64 openssl can't link into the
+      # x86_64 leg of the universal build anyway.
 
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6554,6 +6554,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
+name = "openssl-src"
+version = "300.6.0+3.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8e8cbfd3a4a8c8f089147fd7aaa33cf8c7450c4d09f8f80698a0cf093abeff4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.113"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6561,6 +6570,7 @@ checksum = "ad2f2c0eba47118757e4c6d2bff2838f3e0523380021356e7875e858372ce644"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]
@@ -6824,6 +6834,7 @@ dependencies = [
  "metrics-exporter-prometheus",
  "mime_guess",
  "once_cell",
+ "openssl-sys",
  "parkhub-common",
  "pbkdf2",
  "printpdf",

--- a/parkhub-server/Cargo.toml
+++ b/parkhub-server/Cargo.toml
@@ -151,6 +151,14 @@ slint-build = { version = "1.15", optional = true }  # updated from 1.14
 [target.'cfg(windows)'.build-dependencies]
 winres = "0.1"
 
+# macOS universal build cross-compiles x86_64 on an arm64 runner, where
+# Homebrew's openssl@3 is arm64-only and the linker refuses to mix archs.
+# Pulling in openssl-sys with `vendored` forces build.rs to compile OpenSSL
+# from source for each target architecture — Linux is unaffected because
+# the distro pkg-config path still wins when the env var isn't set.
+[target.'cfg(target_os = "macos")'.dependencies]
+openssl-sys = { version = "0.9", features = ["vendored"] }
+
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.61", features = [
     "Win32_UI_WindowsAndMessaging",


### PR DESCRIPTION
## Summary

v4.14.1 release failed the macOS universal build for the same reason v4.14.0 did, just a layer deeper: after #342 installed the x86_64-apple-darwin target correctly, the linker now fails because Homebrew's arm64 OpenSSL can't be linked into the x86_64 leg.

### Root cause

\`web-push 0.11\` (no rustls feature) pulls \`openssl-sys\` via:
- \`curl → isahc\`
- \`hyper-tls → native-tls\`
- \`ece\` (for ECDH)

On the arm64 \`macos-latest\` runner, \`brew install openssl@3\` installs arm64 only. The x86_64 build leg inherits \`OPENSSL_DIR\` from env, picks up the arm64 \`.o\` files, and ld bails:

\`\`\`
ld: warning: ignoring file '...libopenssl_sys-*.rlib(libcommon-lib-*.o)':
    found architecture 'arm64', required architecture 'x86_64'
error: linking with \`cc\` failed: exit status: 1
\`\`\`

### Fix

Added a conditional direct dep on \`openssl-sys\` with the \`vendored\` feature only for macOS:

\`\`\`toml
[target.'cfg(target_os = \"macos\")'.dependencies]
openssl-sys = { version = \"0.9\", features = [\"vendored\"] }
\`\`\`

With \`vendored\`, \`openssl-sys\`'s build script compiles OpenSSL from source per target triple — arm64 build gets arm64 OpenSSL, x86_64 build gets x86_64 OpenSSL, lipo joins them. Linux is unaffected (pkg-config path still wins when env vars aren't set).

Also dropped the now-useless and actively-harmful Homebrew OpenSSL install step from release.yml.

### Size / build time impact

Vendored OpenSSL adds ~45s to first build, ~0s to incremental (cache picks up). Binary size impact: negligible on release (LTO-fat + strip).

## Test plan
- [ ] Release workflow completes macOS universal build
- [ ] \`lipo -info parkhub-server\` reports both arm64 and x86_64 slices
- [ ] Next tagged release (v4.14.2 or later) publishes the macOS artefact