### PR TITLE
chore: bump workspace version to 4.14.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6741,7 +6741,7 @@ dependencies = [
 
 [[package]]
 name = "parkhub-client"
-version = "4.14.1"
+version = "4.14.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6768,7 +6768,7 @@ dependencies = [
 
 [[package]]
 name = "parkhub-common"
-version = "4.14.1"
+version = "4.14.2"
 dependencies = [
  "chrono",
  "proptest",
@@ -6781,7 +6781,7 @@ dependencies = [
 
 [[package]]
 name = "parkhub-desktop"
-version = "4.14.1"
+version = "4.14.2"
 dependencies = [
  "directories",
  "serde",
@@ -6805,7 +6805,7 @@ dependencies = [
 
 [[package]]
 name = "parkhub-server"
-version = "4.14.1"
+version = "4.14.2"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "4.14.1"
+version = "4.14.2"
 edition = "2024"
 rust-version = "1.94"
 authors = ["nash87"]


### PR DESCRIPTION
Second patch release to ship the macOS universal binary. Builds on #344 (vendored openssl-sys) and #342 (explicit rustup target add). Linux x64, Linux ARM64, Windows x64 are unchanged from v4.14.1.