### PR TITLE
feat(nav): implement Rail, Top-tabs, Dock layouts + version-sync footer

### DIFF
--- a/parkhub-web/astro.config.mjs
+++ b/parkhub-web/astro.config.mjs
@@ -4,12 +4,30 @@ import react from '@astrojs/react';
 import tailwindcss from '@tailwindcss/vite';
 import reactCompiler from 'babel-plugin-react-compiler';
 import { execSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
 
 const buildHash = (() => {
   try {
     return execSync('git rev-parse --short HEAD', { encoding: 'utf8' }).trim();
   } catch {
     return Date.now().toString(36);
+  }
+})();
+
+// Pull the workspace version from the Cargo.toml so the footer stays in sync
+// with every release tag. Fails gracefully to the package.json version if the
+// Cargo manifest is missing (docker build contexts that only ship parkhub-web).
+const appVersion = (() => {
+  try {
+    const cargo = readFileSync(new URL('../Cargo.toml', import.meta.url), 'utf8');
+    const m = cargo.match(/^version\s*=\s*"([^"]+)"/m);
+    if (m) return m[1];
+  } catch { /* fall through */ }
+  try {
+    const pkg = JSON.parse(readFileSync(new URL('./package.json', import.meta.url), 'utf8'));
+    return pkg.version || 'dev';
+  } catch {
+    return 'dev';
   }
 })();
 
@@ -104,6 +122,7 @@ export default defineConfig({
     plugins: [tailwindcss()],
     define: {
       'import.meta.env.VITE_API_URL': JSON.stringify(process.env.VITE_API_URL || ''),
+      'import.meta.env.VITE_APP_VERSION': JSON.stringify(appVersion),
     },
     build: {
       rollupOptions: {

--- a/parkhub-web/src/components/Layout.tsx
+++ b/parkhub-web/src/components/Layout.tsx
@@ -21,15 +21,20 @@ import { NotificationBadge } from './ui/NotificationBadge';
 import { languages } from '../i18n/index';
 import { getInMemoryToken } from '../api/client';
 import { preloadRoute } from '../lib/routePreload';
+import { useNavLayout } from '../hooks/useNavLayout';
+import { RailSidebar } from './nav/RailSidebar';
+import { FloatingDock } from './nav/FloatingDock';
+import { TopTabs } from './nav/TopTabs';
+import { APP_VERSION } from '../lib/appVersion';
 
-type NavItem = {
+export type NavItem = {
   to: string;
   icon: React.ElementType;
   key: string;
   end?: boolean;
 };
 
-type NavSection = {
+export type NavSection = {
   id: 'core' | 'fleet' | 'settings';
   labelKey: string;
   defaultOpen: boolean;
@@ -39,7 +44,8 @@ type NavSection = {
 
 // 3-section layout. Core is always visible. Fleet defaults open. Settings defaults closed.
 // Routes, icons, and per-item i18n keys are preserved from the previous flat list.
-const NAV_SECTIONS: readonly NavSection[] = [
+// Exported so alternative layouts (Rail, Dock, TopTabs) share the single source of truth.
+export const NAV_SECTIONS: readonly NavSection[] = [
   {
     id: 'core',
     labelKey: 'nav.sections.core',
@@ -400,12 +406,34 @@ export function Layout() {
     [user?.role],
   );
 
+  // Nav-layout branch — see SettingsPrimitives NavLayoutGrid and Settings view.
+  // Classic renders the wide sidebar. Rail/Top/Dock render their own
+  // components and suppress the classic aside.
+  const [navLayout] = useNavLayout();
+  const useTopTabs = navLayout === 'top';
+  const useDock = navLayout === 'dock';
+  const outerLayout = useTopTabs ? 'flex flex-col' : 'flex';
+
   return (
-    <div className="min-h-dvh bg-surface-50 dark:bg-surface-950 flex">
+    <div className={`min-h-dvh bg-surface-50 dark:bg-surface-950 ${outerLayout}`}>
       <a href="#main-content" className="sr-only focus:not-sr-only focus:absolute focus:top-2 focus:left-2 focus:z-50 focus:px-4 focus:py-2 focus:bg-primary-600 focus:text-white focus:rounded-lg">{t('nav.skipToContent')}</a>
 
-      {/* Sidebar — desktop — glass morphism */}
-      <aside className="hidden lg:flex flex-col w-64 bg-white/70 dark:bg-surface-900/70 backdrop-blur-2xl border-r border-surface-200/40 dark:border-surface-800/40 p-4 sticky top-0 h-dvh" aria-label="Main navigation">
+      {/* Rail layout — narrow icon sidebar */}
+      {navLayout === 'rail' && (
+        <RailSidebar unreadCount={unreadCount} onLogout={handleLogout} isAdmin={isAdmin} />
+      )}
+
+      {/* Top tabs — horizontal header */}
+      {useTopTabs && (
+        <TopTabs unreadCount={unreadCount} onLogout={handleLogout} isAdmin={isAdmin} />
+      )}
+
+      {/* Classic sidebar — wide glass-morphism column. Hidden when the user
+          opted into Rail/Top/Dock. */}
+      <aside
+        className={`${navLayout === 'classic' ? 'hidden lg:flex' : 'hidden'} flex-col w-64 bg-white/70 dark:bg-surface-900/70 backdrop-blur-2xl border-r border-surface-200/40 dark:border-surface-800/40 p-4 sticky top-0 h-dvh`}
+        aria-label="Main navigation"
+      >
         <div className="flex items-center gap-3 px-3 mb-8">
           <div className="w-10 h-10 rounded-xl bg-gradient-to-br from-primary-600 to-primary-500 flex items-center justify-center shadow-lg shadow-primary-500/20">
             <CarSimple weight="fill" className="w-5 h-5 text-white" />
@@ -554,10 +582,14 @@ export function Layout() {
           <div className="lg:hidden"><Breadcrumb /></div>
           <Outlet />
         </main>
-        <footer className="py-3 text-center text-xs text-surface-400 dark:text-surface-600 border-t border-surface-200/40 dark:border-surface-800/40">
-          ParkHub v4.9.0
+        <footer className={`py-3 text-center text-xs text-surface-400 dark:text-surface-600 border-t border-surface-200/40 dark:border-surface-800/40 ${useDock ? 'pb-24' : ''}`}>
+          ParkHub v{APP_VERSION}
         </footer>
       </div>
+
+      {/* Floating dock — renders over the top of the main area, so the
+          footer gets extra padding above to avoid overlap. */}
+      {useDock && <FloatingDock unreadCount={unreadCount} isAdmin={isAdmin} />}
 
       <CommandPalette open={commandPaletteOpen} onClose={() => setCommandPaletteOpen(false)} />
       <ShortcutsHelp open={shortcutsHelpOpen} onClose={() => setShortcutsHelpOpen(false)} />

--- a/parkhub-web/src/components/nav/FloatingDock.tsx
+++ b/parkhub-web/src/components/nav/FloatingDock.tsx
@@ -1,0 +1,216 @@
+/**
+ * Floating dock — macOS-style horizontal pill pinned to bottom-center.
+ * Ported from claude.ai/design v4 nav-variants bundle.
+ *
+ * UX notes:
+ *  - Curated to the 8 most-used nav items (core + 2 favourites); everything
+ *    else lives behind a "More" overflow that pops open a compact grid.
+ *  - Pointer-proximity magnification matches the macOS dock feel: icons
+ *    under the cursor scale up subtly, neighbors a bit, rest stay flat.
+ *  - On mobile the dock replaces the hamburger menu entirely — feels more
+ *    native than a drawer.
+ */
+import { useRef, useState } from 'react';
+import { NavLink, useLocation } from 'react-router-dom';
+import { motion, useMotionValue, useSpring, useTransform, AnimatePresence } from 'framer-motion';
+import { useTranslation } from 'react-i18next';
+import { DotsThree, X } from '@phosphor-icons/react';
+import { preloadRoute } from '../../lib/routePreload';
+import { NotificationBadge } from '../ui/NotificationBadge';
+import { NAV_SECTIONS, type NavItem } from '../Layout';
+
+interface FloatingDockProps {
+  unreadCount: number;
+  isAdmin: boolean;
+}
+
+// 8 most-used items for the main dock. Everything else goes under "More".
+// Keys match the NavItem key field so i18n lookups stay consistent.
+const PINNED_KEYS = [
+  'dashboard', 'bookings', 'bookSpot', 'vehicles', 'calendar',
+  'favorites', 'map', 'notifications',
+];
+
+export function FloatingDock({ unreadCount, isAdmin }: FloatingDockProps) {
+  const { t } = useTranslation();
+  const location = useLocation();
+  const mouseX = useMotionValue<number | null>(null);
+  const [overflowOpen, setOverflowOpen] = useState(false);
+  const dockRef = useRef<HTMLDivElement>(null);
+
+  // Flatten NAV_SECTIONS into a single item list, partition into pinned
+  // vs overflow. Admin route goes into overflow as "settings".
+  const allItems: NavItem[] = NAV_SECTIONS.flatMap(s => s.items);
+  const pinned = PINNED_KEYS
+    .map(k => allItems.find(i => i.key === k))
+    .filter((i): i is NavItem => !!i);
+  const pinnedSet = new Set(pinned.map(i => i.key));
+  const overflow = allItems.filter(i => !pinnedSet.has(i.key));
+
+  return (
+    <>
+      <motion.nav
+        ref={dockRef}
+        aria-label="Main navigation"
+        onMouseMove={(e) => {
+          const rect = dockRef.current?.getBoundingClientRect();
+          if (rect) mouseX.set(e.clientX - rect.left);
+        }}
+        onMouseLeave={() => mouseX.set(null)}
+        className="fixed bottom-4 left-1/2 -translate-x-1/2 z-40 flex items-end gap-1 px-3 py-2 rounded-2xl bg-white/80 dark:bg-surface-900/80 backdrop-blur-2xl border border-surface-200/60 dark:border-surface-800/60 shadow-2xl shadow-black/10"
+      >
+        {pinned.map(item => (
+          <DockIcon
+            key={item.key}
+            item={item}
+            active={
+              location.pathname === item.to ||
+              (item.to !== '/' && location.pathname.startsWith(item.to))
+            }
+            badge={item.key === 'notifications' ? unreadCount : 0}
+            mouseX={mouseX}
+            label={t(`nav.${item.key}`)}
+          />
+        ))}
+
+        <div aria-hidden="true" className="w-px h-8 mx-1 bg-surface-200 dark:bg-surface-700" />
+
+        <button
+          type="button"
+          onClick={() => setOverflowOpen(v => !v)}
+          aria-label={t('nav.more', 'More')}
+          aria-expanded={overflowOpen}
+          className={`flex flex-col items-center justify-center w-12 h-12 rounded-xl transition-all ${
+            overflowOpen
+              ? 'bg-primary-100 dark:bg-primary-950/50 text-primary-700 dark:text-primary-300'
+              : 'text-surface-600 dark:text-surface-400 hover:bg-surface-100 dark:hover:bg-surface-800'
+          }`}
+        >
+          <DotsThree weight="bold" className="w-6 h-6" />
+        </button>
+      </motion.nav>
+
+      <AnimatePresence>
+        {overflowOpen && (
+          <motion.div
+            initial={{ opacity: 0, y: 12, scale: 0.95 }}
+            animate={{ opacity: 1, y: 0, scale: 1 }}
+            exit={{ opacity: 0, y: 12, scale: 0.95 }}
+            transition={{ type: 'spring', stiffness: 500, damping: 40 }}
+            role="dialog"
+            aria-label={t('nav.more', 'More')}
+            className="fixed bottom-[86px] left-1/2 -translate-x-1/2 z-40 w-[min(480px,92vw)] p-3 rounded-2xl bg-white/95 dark:bg-surface-900/95 backdrop-blur-2xl border border-surface-200 dark:border-surface-800 shadow-2xl"
+          >
+            <div className="flex items-center justify-between mb-2 px-1">
+              <span className="text-[11px] font-bold uppercase tracking-wider text-surface-500 dark:text-surface-500">
+                {t('nav.more', 'More')}
+              </span>
+              <button
+                type="button"
+                onClick={() => setOverflowOpen(false)}
+                className="btn btn-ghost btn-icon w-6 h-6"
+                aria-label={t('common.close', 'Close')}
+              >
+                <X weight="bold" className="w-3.5 h-3.5" />
+              </button>
+            </div>
+            <div className="grid grid-cols-3 sm:grid-cols-4 gap-1">
+              {overflow.map(item => (
+                <NavLink
+                  key={item.key}
+                  to={item.to}
+                  end={item.end}
+                  onClick={() => setOverflowOpen(false)}
+                  onMouseEnter={() => preloadRoute(item.to)}
+                  className={({ isActive }) =>
+                    `flex flex-col items-center gap-1 p-2 rounded-lg text-[11px] font-medium transition-colors ${
+                      isActive
+                        ? 'text-primary-700 dark:text-primary-300 bg-primary-50 dark:bg-primary-950/30'
+                        : 'text-surface-600 dark:text-surface-400 hover:bg-surface-100 dark:hover:bg-surface-800'
+                    }`
+                  }
+                >
+                  <item.icon weight="fill" className="w-5 h-5" />
+                  <span className="truncate w-full text-center">{t(`nav.${item.key}`)}</span>
+                </NavLink>
+              ))}
+              {isAdmin && (
+                <NavLink
+                  to="/admin"
+                  onClick={() => setOverflowOpen(false)}
+                  className={({ isActive }) =>
+                    `flex flex-col items-center gap-1 p-2 rounded-lg text-[11px] font-medium transition-colors ${
+                      isActive
+                        ? 'text-primary-700 dark:text-primary-300 bg-primary-50 dark:bg-primary-950/30'
+                        : 'text-surface-600 dark:text-surface-400 hover:bg-surface-100 dark:hover:bg-surface-800'
+                    }`
+                  }
+                >
+                  <span className="text-lg">⚙</span>
+                  <span>{t('nav.admin')}</span>
+                </NavLink>
+              )}
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </>
+  );
+}
+
+interface DockIconProps {
+  item: NavItem;
+  active: boolean;
+  badge: number;
+  mouseX: ReturnType<typeof useMotionValue<number | null>>;
+  label: string;
+}
+
+/**
+ * Single dock icon with pointer-proximity magnification. Uses framer-motion
+ * useTransform to map the distance from cursor to a scale (1.0 - 1.4) via
+ * a spring for the macOS dock feel.
+ */
+function DockIcon({ item, active, badge, mouseX, label }: DockIconProps) {
+  const ref = useRef<HTMLAnchorElement>(null);
+  const distance = useTransform(mouseX, (mx) => {
+    if (mx === null || !ref.current) return 0;
+    const rect = ref.current.getBoundingClientRect();
+    const parent = ref.current.parentElement?.getBoundingClientRect();
+    if (!parent) return 0;
+    const iconCenter = rect.left - parent.left + rect.width / 2;
+    return Math.abs(mx - iconCenter);
+  });
+  const raw = useTransform(distance, [0, 50, 120], [1.35, 1.15, 1]);
+  const scale = useSpring(raw, { stiffness: 400, damping: 28 });
+
+  return (
+    <motion.div style={{ scale }} className="origin-bottom">
+      <NavLink
+        ref={ref}
+        to={item.to}
+        end={item.end}
+        aria-label={label}
+        aria-current={active ? 'page' : undefined}
+        onMouseEnter={() => preloadRoute(item.to)}
+        onFocus={() => preloadRoute(item.to)}
+        className={`relative flex items-center justify-center w-12 h-12 rounded-xl transition-colors ${
+          active
+            ? 'text-primary-700 dark:text-primary-300 bg-primary-50 dark:bg-primary-950/30'
+            : 'text-surface-600 dark:text-surface-400 hover:text-surface-900 dark:hover:text-white hover:bg-surface-100 dark:hover:bg-surface-800'
+        }`}
+      >
+        <span className="relative">
+          <item.icon weight="fill" className="w-6 h-6" />
+          {badge > 0 && <NotificationBadge count={badge} />}
+        </span>
+        {active && (
+          <span
+            aria-hidden="true"
+            className="absolute -bottom-1 left-1/2 -translate-x-1/2 w-1 h-1 rounded-full bg-primary-500"
+          />
+        )}
+      </NavLink>
+    </motion.div>
+  );
+}

--- a/parkhub-web/src/components/nav/FloatingDock.tsx
+++ b/parkhub-web/src/components/nav/FloatingDock.tsx
@@ -18,6 +18,7 @@ import { DotsThree, X } from '@phosphor-icons/react';
 import { preloadRoute } from '../../lib/routePreload';
 import { NotificationBadge } from '../ui/NotificationBadge';
 import { NAV_SECTIONS, type NavItem } from '../Layout';
+import { isActivePath } from './navActive';
 
 interface FloatingDockProps {
   unreadCount: number;
@@ -63,10 +64,7 @@ export function FloatingDock({ unreadCount, isAdmin }: FloatingDockProps) {
           <DockIcon
             key={item.key}
             item={item}
-            active={
-              location.pathname === item.to ||
-              (item.to !== '/' && location.pathname.startsWith(item.to))
-            }
+            active={isActivePath(location.pathname, item.to)}
             badge={item.key === 'notifications' ? unreadCount : 0}
             mouseX={mouseX}
             label={t(`nav.${item.key}`)}
@@ -173,11 +171,17 @@ interface DockIconProps {
  */
 function DockIcon({ item, active, badge, mouseX, label }: DockIconProps) {
   const ref = useRef<HTMLAnchorElement>(null);
+  // Resting distance kept past the magnification ceiling so the scale
+  // ramp (0..50..120) bottoms out at 1.0 whenever the cursor isn't on
+  // the dock. A naive `return 0` would map the null/idle state to the
+  // MAXIMUM scale — every icon permanently zoomed, which is exactly
+  // the opposite of the desired "springs up as you approach" feel.
+  const REST_DISTANCE = 1_000;
   const distance = useTransform(mouseX, (mx) => {
-    if (mx === null || !ref.current) return 0;
+    if (mx === null || !ref.current) return REST_DISTANCE;
     const rect = ref.current.getBoundingClientRect();
     const parent = ref.current.parentElement?.getBoundingClientRect();
-    if (!parent) return 0;
+    if (!parent) return REST_DISTANCE;
     const iconCenter = rect.left - parent.left + rect.width / 2;
     return Math.abs(mx - iconCenter);
   });

--- a/parkhub-web/src/components/nav/RailSidebar.tsx
+++ b/parkhub-web/src/components/nav/RailSidebar.tsx
@@ -1,0 +1,211 @@
+/**
+ * Rail layout — 72px icon-only sidebar. Ported from the claude.ai/design
+ * v4 nav-variants bundle. Shares NAV_SECTIONS with the classic layout so
+ * every new route added in Layout.tsx appears here automatically.
+ *
+ * UX notes:
+ *  - Hovering an icon reveals a side-popping label — no drawer, stays
+ *    lightweight. Matches Linear/GitHub Desktop rail patterns.
+ *  - Section dividers replace the uppercase labels used by Classic
+ *    (no room for text in a rail).
+ *  - Active-state is a glowing left accent bar that animates between
+ *    items via framer-motion's layoutId (matches the Classic indicator).
+ */
+import { useRef, useState } from 'react';
+import { NavLink, useLocation } from 'react-router-dom';
+import { motion, AnimatePresence } from 'framer-motion';
+import { useTranslation } from 'react-i18next';
+import {
+  CarSimple, GearSix, SignOut, SunDim, Moon,
+} from '@phosphor-icons/react';
+import { useAuth } from '../../context/AuthContext';
+import { useTheme } from '../../context/ThemeContext';
+import { NotificationCenter } from '../NotificationCenter';
+import { NotificationBadge } from '../ui/NotificationBadge';
+import { preloadRoute } from '../../lib/routePreload';
+import { NAV_SECTIONS, type NavItem } from '../Layout';
+
+interface RailSidebarProps {
+  unreadCount: number;
+  onLogout: () => void;
+  isAdmin: boolean;
+}
+
+export function RailSidebar({ unreadCount, onLogout, isAdmin }: RailSidebarProps) {
+  const { t } = useTranslation();
+  const { user } = useAuth();
+  const { resolved, setTheme } = useTheme();
+  const location = useLocation();
+
+  const renderItem = (item: NavItem) => {
+    const isActive =
+      location.pathname === item.to ||
+      (item.to !== '/' && location.pathname.startsWith(item.to));
+    return (
+      <RailIconButton
+        key={item.key}
+        to={item.to}
+        icon={item.icon}
+        label={t(`nav.${item.key}`)}
+        badge={item.key === 'notifications' ? unreadCount : 0}
+        active={isActive}
+        end={item.end}
+      />
+    );
+  };
+
+  return (
+    <aside
+      aria-label="Main navigation"
+      className="hidden lg:flex flex-col items-center w-[72px] bg-white/70 dark:bg-surface-900/70 backdrop-blur-2xl border-r border-surface-200/40 dark:border-surface-800/40 py-4 sticky top-0 h-dvh"
+    >
+      {/* Brand mark */}
+      <div
+        className="w-10 h-10 rounded-xl bg-gradient-to-br from-primary-600 to-primary-500 flex items-center justify-center shadow-lg shadow-primary-500/20 mb-4"
+        title="ParkHub"
+      >
+        <CarSimple weight="fill" className="w-5 h-5 text-white" />
+      </div>
+
+      {/* Nav — sections separated by thin dividers since labels won't fit */}
+      <nav className="flex-1 flex flex-col items-center gap-0.5 w-full overflow-y-auto px-2">
+        {NAV_SECTIONS.map((section, index) => (
+          <div key={section.id} className="flex flex-col items-center gap-0.5 w-full">
+            {index > 0 && (
+              <div
+                aria-hidden="true"
+                className="w-8 h-px my-2 bg-surface-200 dark:bg-surface-800"
+              />
+            )}
+            {section.items.map(renderItem)}
+          </div>
+        ))}
+
+        {isAdmin && (
+          <>
+            <div
+              aria-hidden="true"
+              className="w-8 h-px my-2 bg-surface-200 dark:bg-surface-800"
+            />
+            <RailIconButton
+              to="/admin"
+              icon={GearSix}
+              label={t('nav.admin')}
+              active={location.pathname.startsWith('/admin')}
+            />
+          </>
+        )}
+      </nav>
+
+      {/* Footer cluster */}
+      <div className="flex flex-col items-center gap-1 w-full pt-2 border-t border-surface-200/60 dark:border-surface-800/60">
+        <button
+          onClick={() => setTheme(resolved === 'dark' ? 'light' : 'dark')}
+          className="flex items-center justify-center w-10 h-10 rounded-lg text-surface-500 hover:text-surface-900 dark:hover:text-white hover:bg-surface-100/60 dark:hover:bg-surface-800/40 transition-all"
+          aria-label={resolved === 'dark' ? t('nav.lightMode') : t('nav.darkMode')}
+          title={resolved === 'dark' ? t('nav.lightMode') : t('nav.darkMode')}
+        >
+          {resolved === 'dark' ? <SunDim weight="fill" className="w-5 h-5" /> : <Moon weight="fill" className="w-5 h-5" />}
+        </button>
+
+        <div className="my-1 scale-90">
+          <NotificationCenter />
+        </div>
+
+        <div
+          className="relative"
+          title={user?.name || user?.username}
+        >
+          <div className="w-9 h-9 rounded-full bg-gradient-to-br from-primary-200 to-primary-100 dark:from-primary-800 dark:to-primary-900 flex items-center justify-center ring-2 ring-primary-500/20 dark:ring-primary-400/20">
+            <span className="text-sm font-bold text-primary-700 dark:text-primary-300">
+              {(user?.name || user?.username || 'U').charAt(0).toUpperCase()}
+            </span>
+          </div>
+          <span className="absolute -bottom-0.5 -right-0.5 w-2.5 h-2.5 rounded-full bg-emerald-500 border-2 border-white dark:border-surface-900" />
+        </div>
+
+        <button
+          onClick={onLogout}
+          className="flex items-center justify-center w-10 h-10 rounded-lg text-red-500 hover:text-red-600 dark:hover:text-red-400 hover:bg-red-50/60 dark:hover:bg-red-950/20 transition-all mt-1"
+          aria-label={t('nav.logout')}
+          title={t('nav.logout')}
+        >
+          <SignOut weight="bold" className="w-5 h-5" />
+        </button>
+      </div>
+    </aside>
+  );
+}
+
+interface RailIconButtonProps {
+  to: string;
+  icon: React.ElementType;
+  label: string;
+  badge?: number;
+  active?: boolean;
+  end?: boolean;
+}
+
+/**
+ * Single rail cell — NavLink + side-popping label tooltip. Uses a
+ * ref-positioned absolute label that animates in on pointer-enter /
+ * focus so keyboard users get the same discovery affordance as mouse
+ * users.
+ */
+function RailIconButton({ to, icon: Icon, label, badge = 0, active = false, end }: RailIconButtonProps) {
+  const ref = useRef<HTMLAnchorElement>(null);
+  const [hover, setHover] = useState(false);
+
+  return (
+    <NavLink
+      ref={ref}
+      to={to}
+      end={end}
+      onMouseEnter={() => {
+        setHover(true);
+        preloadRoute(to);
+      }}
+      onMouseLeave={() => setHover(false)}
+      onFocus={() => {
+        setHover(true);
+        preloadRoute(to);
+      }}
+      onBlur={() => setHover(false)}
+      aria-label={label}
+      aria-current={active ? 'page' : undefined}
+      className={`relative flex items-center justify-center w-10 h-10 rounded-xl transition-colors ${
+        active
+          ? 'text-primary-700 dark:text-primary-300 bg-primary-50/80 dark:bg-primary-950/30'
+          : 'text-surface-500 dark:text-surface-400 hover:text-surface-900 dark:hover:text-white hover:bg-surface-100/60 dark:hover:bg-surface-800/40'
+      }`}
+    >
+      {active && (
+        <motion.span
+          layoutId="rail-indicator"
+          aria-hidden="true"
+          className="absolute left-0 top-1/2 -translate-y-1/2 w-[3px] h-[60%] -ml-[13px] rounded-full bg-gradient-to-b from-primary-500 to-primary-400"
+          transition={{ type: 'spring', stiffness: 380, damping: 30 }}
+        />
+      )}
+      <span className="relative">
+        <Icon weight="fill" className="w-5 h-5" />
+        {badge > 0 && <NotificationBadge count={badge} />}
+      </span>
+
+      <AnimatePresence>
+        {hover && (
+          <motion.span
+            initial={{ opacity: 0, x: -6 }}
+            animate={{ opacity: 1, x: 0 }}
+            exit={{ opacity: 0, x: -6 }}
+            transition={{ duration: 0.12 }}
+            role="tooltip"
+            className="pointer-events-none absolute left-full ml-3 px-2.5 py-1.5 rounded-lg bg-surface-900 dark:bg-surface-100 text-white dark:text-surface-900 text-[12px] font-semibold whitespace-nowrap shadow-xl z-50"
+          >
+            {label}
+          </motion.span>
+        )}
+      </AnimatePresence>
+    </NavLink>
+  );
+}

--- a/parkhub-web/src/components/nav/RailSidebar.tsx
+++ b/parkhub-web/src/components/nav/RailSidebar.tsx
@@ -24,6 +24,7 @@ import { NotificationCenter } from '../NotificationCenter';
 import { NotificationBadge } from '../ui/NotificationBadge';
 import { preloadRoute } from '../../lib/routePreload';
 import { NAV_SECTIONS, type NavItem } from '../Layout';
+import { isActivePath } from './navActive';
 
 interface RailSidebarProps {
   unreadCount: number;
@@ -38,9 +39,7 @@ export function RailSidebar({ unreadCount, onLogout, isAdmin }: RailSidebarProps
   const location = useLocation();
 
   const renderItem = (item: NavItem) => {
-    const isActive =
-      location.pathname === item.to ||
-      (item.to !== '/' && location.pathname.startsWith(item.to));
+    const isActive = isActivePath(location.pathname, item.to);
     return (
       <RailIconButton
         key={item.key}
@@ -91,7 +90,7 @@ export function RailSidebar({ unreadCount, onLogout, isAdmin }: RailSidebarProps
               to="/admin"
               icon={GearSix}
               label={t('nav.admin')}
-              active={location.pathname.startsWith('/admin')}
+              active={isActivePath(location.pathname, '/admin')}
             />
           </>
         )}

--- a/parkhub-web/src/components/nav/TopTabs.tsx
+++ b/parkhub-web/src/components/nav/TopTabs.tsx
@@ -25,6 +25,7 @@ import { NotificationCenter } from '../NotificationCenter';
 import { NotificationBadge } from '../ui/NotificationBadge';
 import { preloadRoute } from '../../lib/routePreload';
 import { NAV_SECTIONS, type NavItem } from '../Layout';
+import { isActivePath } from './navActive';
 
 interface TopTabsProps {
   unreadCount: number;
@@ -66,9 +67,7 @@ export function TopTabs({ unreadCount, onLogout, isAdmin }: TopTabsProps) {
 
       <nav className="flex items-center gap-1 flex-1 min-w-0 overflow-x-auto">
         {primary.map(item => {
-          const isActive =
-            location.pathname === item.to ||
-            (item.to !== '/' && location.pathname.startsWith(item.to));
+          const isActive = isActivePath(location.pathname, item.to);
           return (
             <NavLink
               key={item.key}

--- a/parkhub-web/src/components/nav/TopTabs.tsx
+++ b/parkhub-web/src/components/nav/TopTabs.tsx
@@ -1,0 +1,259 @@
+/**
+ * Top tabs — horizontal navigation strip across the top of the viewport.
+ * Ported from the claude.ai/design v4 nav-variants bundle. Same footprint
+ * as the mobile header but wider and used on desktop.
+ *
+ * UX notes:
+ *  - Too many items for a single row, so we curate 6 "core + favourites"
+ *    and push everything else behind a More dropdown.
+ *  - Animated underline indicator mirrors the Classic sidebar's side
+ *    accent bar — framer-motion layoutId keeps motion continuous.
+ *  - On viewport < lg, the top-tabs layout still uses the mobile drawer
+ *    (same as Classic) so this component only has to reason about
+ *    desktop sizing.
+ */
+import { useRef, useState, useEffect } from 'react';
+import { NavLink, useLocation } from 'react-router-dom';
+import { motion, AnimatePresence } from 'framer-motion';
+import { useTranslation } from 'react-i18next';
+import {
+  CarSimple, CaretDown, GearSix, SignOut, SunDim, Moon,
+} from '@phosphor-icons/react';
+import { useAuth } from '../../context/AuthContext';
+import { useTheme } from '../../context/ThemeContext';
+import { NotificationCenter } from '../NotificationCenter';
+import { NotificationBadge } from '../ui/NotificationBadge';
+import { preloadRoute } from '../../lib/routePreload';
+import { NAV_SECTIONS, type NavItem } from '../Layout';
+
+interface TopTabsProps {
+  unreadCount: number;
+  onLogout: () => void;
+  isAdmin: boolean;
+}
+
+const PRIMARY_KEYS = [
+  'dashboard', 'bookings', 'bookSpot', 'calendar', 'vehicles', 'favorites',
+];
+
+export function TopTabs({ unreadCount, onLogout, isAdmin }: TopTabsProps) {
+  const { t } = useTranslation();
+  const { user } = useAuth();
+  const { resolved, setTheme } = useTheme();
+  const location = useLocation();
+
+  const allItems: NavItem[] = NAV_SECTIONS.flatMap(s => s.items);
+  const primary = PRIMARY_KEYS
+    .map(k => allItems.find(i => i.key === k))
+    .filter((i): i is NavItem => !!i);
+  const primarySet = new Set(primary.map(i => i.key));
+  const overflow = allItems.filter(i => !primarySet.has(i.key));
+
+  return (
+    <header
+      aria-label="Main navigation"
+      className="hidden lg:flex items-center gap-2 h-14 px-6 sticky top-0 z-30 bg-white/75 dark:bg-surface-900/75 backdrop-blur-2xl border-b border-surface-200/40 dark:border-surface-800/40"
+    >
+      {/* Brand */}
+      <NavLink to="/" className="flex items-center gap-2 mr-4">
+        <div className="w-8 h-8 rounded-lg bg-gradient-to-br from-primary-600 to-primary-500 flex items-center justify-center shadow-sm">
+          <CarSimple weight="fill" className="w-4 h-4 text-white" />
+        </div>
+        <span className="text-base font-bold text-surface-900 dark:text-white" style={{ letterSpacing: '-0.02em' }}>
+          ParkHub
+        </span>
+      </NavLink>
+
+      <nav className="flex items-center gap-1 flex-1 min-w-0 overflow-x-auto">
+        {primary.map(item => {
+          const isActive =
+            location.pathname === item.to ||
+            (item.to !== '/' && location.pathname.startsWith(item.to));
+          return (
+            <NavLink
+              key={item.key}
+              to={item.to}
+              end={item.end}
+              onMouseEnter={() => preloadRoute(item.to)}
+              onFocus={() => preloadRoute(item.to)}
+              aria-current={isActive ? 'page' : undefined}
+              className={`relative flex items-center gap-1.5 px-3 h-full text-sm font-medium transition-colors whitespace-nowrap ${
+                isActive
+                  ? 'text-primary-700 dark:text-primary-300'
+                  : 'text-surface-600 dark:text-surface-400 hover:text-surface-900 dark:hover:text-white'
+              }`}
+            >
+              {isActive && (
+                <motion.span
+                  layoutId="top-tab-indicator"
+                  aria-hidden="true"
+                  className="absolute bottom-0 left-0 right-0 h-[2px] bg-gradient-to-r from-primary-500 to-primary-400 rounded-full"
+                  transition={{ type: 'spring', stiffness: 380, damping: 30 }}
+                />
+              )}
+              <item.icon weight="fill" className="w-4 h-4" />
+              {t(`nav.${item.key}`)}
+            </NavLink>
+          );
+        })}
+
+        <OverflowDropdown items={overflow} unreadCount={unreadCount} isAdmin={isAdmin} />
+      </nav>
+
+      <div className="flex items-center gap-1.5 ml-2">
+        <NotificationCenter />
+        <button
+          onClick={() => setTheme(resolved === 'dark' ? 'light' : 'dark')}
+          className="flex items-center justify-center w-9 h-9 rounded-lg text-surface-500 hover:text-surface-900 dark:hover:text-white hover:bg-surface-100/60 dark:hover:bg-surface-800/40 transition-all"
+          aria-label={resolved === 'dark' ? t('nav.lightMode') : t('nav.darkMode')}
+          title={resolved === 'dark' ? t('nav.lightMode') : t('nav.darkMode')}
+        >
+          {resolved === 'dark' ? <SunDim weight="fill" className="w-4 h-4" /> : <Moon weight="fill" className="w-4 h-4" />}
+        </button>
+        <UserMenu user={user} onLogout={onLogout} />
+      </div>
+    </header>
+  );
+}
+
+function OverflowDropdown({ items, unreadCount, isAdmin }: { items: NavItem[]; unreadCount: number; isAdmin: boolean }) {
+  const { t } = useTranslation();
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    function onDocClick(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    }
+    document.addEventListener('mousedown', onDocClick);
+    return () => document.removeEventListener('mousedown', onDocClick);
+  }, []);
+
+  return (
+    <div ref={ref} className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen(v => !v)}
+        aria-expanded={open}
+        aria-haspopup="menu"
+        className={`flex items-center gap-1.5 px-3 h-full text-sm font-medium transition-colors ${
+          open
+            ? 'text-primary-700 dark:text-primary-300'
+            : 'text-surface-600 dark:text-surface-400 hover:text-surface-900 dark:hover:text-white'
+        }`}
+      >
+        {t('nav.more', 'More')}
+        <CaretDown weight="bold" className={`w-3 h-3 transition-transform ${open ? 'rotate-180' : ''}`} />
+      </button>
+
+      <AnimatePresence>
+        {open && (
+          <motion.div
+            initial={{ opacity: 0, y: -4 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: -4 }}
+            transition={{ duration: 0.12 }}
+            role="menu"
+            className="absolute top-full left-0 mt-1 w-[280px] p-1 rounded-xl bg-white dark:bg-surface-800 border border-surface-200 dark:border-surface-700 shadow-xl z-50 max-h-[70vh] overflow-y-auto"
+          >
+            {items.map(item => (
+              <NavLink
+                key={item.key}
+                to={item.to}
+                end={item.end}
+                onClick={() => setOpen(false)}
+                onMouseEnter={() => preloadRoute(item.to)}
+                className={({ isActive }) =>
+                  `flex items-center gap-2.5 px-2.5 py-2 rounded-lg text-sm transition-colors ${
+                    isActive
+                      ? 'text-primary-700 dark:text-primary-300 bg-primary-50 dark:bg-primary-950/30'
+                      : 'text-surface-700 dark:text-surface-300 hover:bg-surface-100 dark:hover:bg-surface-700/50'
+                  }`
+                }
+              >
+                <span className="relative">
+                  <item.icon weight="fill" className="w-4 h-4" />
+                  {item.key === 'notifications' && unreadCount > 0 && <NotificationBadge count={unreadCount} />}
+                </span>
+                {t(`nav.${item.key}`)}
+              </NavLink>
+            ))}
+            {isAdmin && (
+              <>
+                <div className="my-1 h-px bg-surface-200 dark:bg-surface-700" />
+                <NavLink
+                  to="/admin"
+                  onClick={() => setOpen(false)}
+                  className={({ isActive }) =>
+                    `flex items-center gap-2.5 px-2.5 py-2 rounded-lg text-sm transition-colors ${
+                      isActive
+                        ? 'text-primary-700 dark:text-primary-300 bg-primary-50 dark:bg-primary-950/30'
+                        : 'text-surface-700 dark:text-surface-300 hover:bg-surface-100 dark:hover:bg-surface-700/50'
+                    }`
+                  }
+                >
+                  <GearSix weight="fill" className="w-4 h-4" />
+                  {t('nav.admin')}
+                </NavLink>
+              </>
+            )}
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}
+
+function UserMenu({ user, onLogout }: { user: { name?: string; username?: string; email?: string } | null; onLogout: () => void }) {
+  const { t } = useTranslation();
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    function onDocClick(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    }
+    document.addEventListener('mousedown', onDocClick);
+    return () => document.removeEventListener('mousedown', onDocClick);
+  }, []);
+
+  const initial = (user?.name || user?.username || 'U').charAt(0).toUpperCase();
+
+  return (
+    <div ref={ref} className="relative">
+      <button
+        onClick={() => setOpen(v => !v)}
+        aria-expanded={open}
+        className="relative flex items-center justify-center w-9 h-9 rounded-full bg-gradient-to-br from-primary-200 to-primary-100 dark:from-primary-800 dark:to-primary-900 ring-2 ring-primary-500/20 dark:ring-primary-400/20 hover:scale-105 transition-transform"
+      >
+        <span className="text-sm font-bold text-primary-700 dark:text-primary-300">{initial}</span>
+        <span className="absolute -bottom-0.5 -right-0.5 w-2.5 h-2.5 rounded-full bg-emerald-500 border-2 border-white dark:border-surface-900" />
+      </button>
+
+      <AnimatePresence>
+        {open && (
+          <motion.div
+            initial={{ opacity: 0, y: -4 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: -4 }}
+            transition={{ duration: 0.12 }}
+            role="menu"
+            className="absolute right-0 top-full mt-1 w-[240px] rounded-xl bg-white dark:bg-surface-800 border border-surface-200 dark:border-surface-700 shadow-xl z-50 overflow-hidden"
+          >
+            <div className="p-3 border-b border-surface-200 dark:border-surface-700">
+              <p className="text-sm font-medium text-surface-900 dark:text-white truncate">{user?.name || user?.username}</p>
+              <p className="text-xs text-surface-500 dark:text-surface-400 truncate">{user?.email}</p>
+            </div>
+            <button
+              onClick={() => { setOpen(false); onLogout(); }}
+              className="flex items-center gap-2.5 w-full px-3 py-2.5 text-sm text-red-600 hover:bg-red-50/60 dark:hover:bg-red-950/20 transition-colors"
+            >
+              <SignOut weight="bold" className="w-4 h-4" />
+              {t('nav.logout')}
+            </button>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}

--- a/parkhub-web/src/components/nav/navActive.test.ts
+++ b/parkhub-web/src/components/nav/navActive.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { isActivePath } from './navActive';
+
+describe('isActivePath', () => {
+  it('matches exact paths', () => {
+    expect(isActivePath('/bookings', '/bookings')).toBe(true);
+  });
+
+  it('does not match sibling paths that share a prefix', () => {
+    // Regression for Codex P2 #349: `/book` should not be active when
+    // the user is on `/bookings`.
+    expect(isActivePath('/bookings', '/book')).toBe(false);
+  });
+
+  it('matches deeper segments under the same root', () => {
+    expect(isActivePath('/bookings/123', '/bookings')).toBe(true);
+    expect(isActivePath('/admin/users', '/admin')).toBe(true);
+  });
+
+  it('matches paths with query strings', () => {
+    expect(isActivePath('/bookings?filter=active', '/bookings')).toBe(true);
+  });
+
+  it('only matches root for root paths', () => {
+    expect(isActivePath('/', '/')).toBe(true);
+    expect(isActivePath('/anywhere', '/')).toBe(false);
+  });
+});

--- a/parkhub-web/src/components/nav/navActive.ts
+++ b/parkhub-web/src/components/nav/navActive.ts
@@ -1,0 +1,20 @@
+/**
+ * Segment-aware active-path check shared by every nav variant
+ * (Classic, Rail, TopTabs, FloatingDock).
+ *
+ * `pathname.startsWith(to)` misclassifies sibling paths that share a
+ * prefix — e.g. `/book` vs `/bookings` would both be marked active when
+ * the user visits `/bookings`. This helper only accepts the match when
+ * the next character is a segment boundary ('/') or a query ('?'), or
+ * when the whole path equals `to`.
+ *
+ * Exported as a standalone module so it can be unit-tested and reused
+ * without pulling in any React dependency.
+ */
+export function isActivePath(pathname: string, to: string): boolean {
+  if (pathname === to) return true;
+  if (to === '/') return false;
+  if (pathname.startsWith(to + '/')) return true;
+  if (pathname.startsWith(to + '?')) return true;
+  return false;
+}

--- a/parkhub-web/src/components/ui/SettingsPrimitives.tsx
+++ b/parkhub-web/src/components/ui/SettingsPrimitives.tsx
@@ -232,14 +232,14 @@ export function ThemeSwatches({
   );
 }
 
-// ─── Nav layout picker (stub — full variants port tracked as T-1842) ───
+// ─── Nav layout picker — all four variants now live (see components/nav/) ───
 
 export type NavLayout = 'classic' | 'rail' | 'top' | 'dock';
 
 export const NAV_LAYOUTS: { value: NavLayout; label: string; description: string }[] = [
-  { value: 'classic', label: 'Classic sidebar', description: 'Left rail with labels (current)' },
-  { value: 'rail', label: 'Icon rail', description: 'Icons only, drawer on hover' },
-  { value: 'top', label: 'Top tabs', description: 'Horizontal navigation' },
+  { value: 'classic', label: 'Classic sidebar', description: 'Left rail with labels' },
+  { value: 'rail', label: 'Icon rail', description: 'Icons only, side-popping tooltip' },
+  { value: 'top', label: 'Top tabs', description: 'Horizontal navigation + overflow' },
   { value: 'dock', label: 'Floating dock', description: 'macOS-style bottom dock' },
 ];
 
@@ -259,37 +259,105 @@ export function NavLayoutGrid({
     >
       {NAV_LAYOUTS.map((l) => {
         const active = l.value === value;
-        // Only "classic" renders today; until T-1842 lands the others are
-        // preview-only. Disable non-classic to avoid broken UX.
-        const selectable = l.value === 'classic';
         return (
           <button
             key={l.value}
             type="button"
             role="radio"
             aria-checked={active}
-            onClick={() => selectable && onChange(l.value)}
-            disabled={!selectable}
-            className={`relative flex flex-col items-start gap-1 p-4 rounded-xl border-2 text-left transition-colors ${
+            onClick={() => onChange(l.value)}
+            className={`relative flex flex-col items-start gap-1 p-4 rounded-xl border-2 text-left transition-colors cursor-pointer ${
               active
                 ? 'border-primary-500 bg-primary-500/5'
                 : 'border-surface-200 dark:border-surface-800 hover:border-surface-300 dark:hover:border-surface-700'
-            } ${!selectable ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}`}
+            }`}
           >
-            <span className="text-sm font-semibold text-surface-900 dark:text-white">
+            <NavLayoutPreview layout={l.value} active={active} />
+            <span className="text-sm font-semibold text-surface-900 dark:text-white mt-2">
               {l.label}
             </span>
             <span className="text-[11px] text-surface-500 dark:text-surface-400 leading-snug">
               {l.description}
             </span>
-            {!selectable && (
-              <span className="absolute top-2 right-2 px-1.5 py-0.5 rounded text-[9px] font-bold bg-surface-200 dark:bg-surface-700 text-surface-500 dark:text-surface-400 uppercase tracking-wider">
-                Soon
-              </span>
-            )}
           </button>
         );
       })}
     </div>
   );
+}
+
+/**
+ * Tiny schematic thumbnail so users can see at a glance what each
+ * layout looks like before committing. Pure CSS — no screenshots to keep
+ * in sync, and the preview tracks the active accent colour.
+ */
+function NavLayoutPreview({ layout, active }: { layout: NavLayout; active: boolean }) {
+  const primary = active
+    ? 'bg-primary-500'
+    : 'bg-surface-300 dark:bg-surface-600';
+  const secondary = 'bg-surface-200 dark:bg-surface-700';
+  const frame = 'rounded bg-surface-100 dark:bg-surface-800 border border-surface-200 dark:border-surface-700';
+
+  switch (layout) {
+    case 'classic':
+      return (
+        <div className={`relative flex w-full h-20 p-1 gap-1 ${frame}`}>
+          <div className="w-1/4 flex flex-col gap-0.5 p-0.5">
+            <span className={`block h-1 w-full rounded-sm ${primary}`} />
+            <span className={`block h-1 w-3/4 rounded-sm ${secondary}`} />
+            <span className={`block h-1 w-3/4 rounded-sm ${secondary}`} />
+            <span className={`block h-1 w-3/4 rounded-sm ${secondary}`} />
+          </div>
+          <div className="flex-1 flex flex-col gap-0.5 p-0.5">
+            <span className={`block h-2 w-3/4 rounded-sm ${secondary}`} />
+            <span className={`block h-4 w-full rounded-sm ${secondary}`} />
+          </div>
+        </div>
+      );
+    case 'rail':
+      return (
+        <div className={`relative flex w-full h-20 p-1 gap-1 ${frame}`}>
+          <div className="w-2 flex flex-col items-center gap-0.5 py-0.5">
+            <span className={`block w-1.5 h-1.5 rounded-sm ${primary}`} />
+            <span className={`block w-1.5 h-1.5 rounded-sm ${secondary}`} />
+            <span className={`block w-1.5 h-1.5 rounded-sm ${secondary}`} />
+          </div>
+          <div className="flex-1 flex flex-col gap-0.5 p-0.5">
+            <span className={`block h-2 w-3/4 rounded-sm ${secondary}`} />
+            <span className={`block h-4 w-full rounded-sm ${secondary}`} />
+          </div>
+        </div>
+      );
+    case 'top':
+      return (
+        <div className={`relative flex flex-col w-full h-20 p-1 gap-1 ${frame}`}>
+          <div className="flex items-center gap-0.5 h-2">
+            <span className={`block h-1 w-4 rounded-sm ${primary}`} />
+            <span className={`block h-1 w-3 rounded-sm ${secondary}`} />
+            <span className={`block h-1 w-3 rounded-sm ${secondary}`} />
+            <span className={`block h-1 w-3 rounded-sm ${secondary}`} />
+          </div>
+          <div className="flex-1 flex flex-col gap-0.5 p-0.5">
+            <span className={`block h-2 w-3/4 rounded-sm ${secondary}`} />
+            <span className={`block h-4 w-full rounded-sm ${secondary}`} />
+          </div>
+        </div>
+      );
+    case 'dock':
+    default:
+      return (
+        <div className={`relative flex flex-col w-full h-20 p-1 ${frame}`}>
+          <div className="flex-1 flex flex-col gap-0.5 p-0.5">
+            <span className={`block h-2 w-3/4 rounded-sm ${secondary}`} />
+            <span className={`block h-4 w-full rounded-sm ${secondary}`} />
+          </div>
+          <div className="flex items-center justify-center gap-0.5 pb-0.5">
+            <span className={`block w-2 h-2 rounded-full ${primary}`} />
+            <span className={`block w-2 h-2 rounded-full ${secondary}`} />
+            <span className={`block w-2 h-2 rounded-full ${secondary}`} />
+            <span className={`block w-2 h-2 rounded-full ${secondary}`} />
+          </div>
+        </div>
+      );
+  }
 }

--- a/parkhub-web/src/hooks/useNavLayout.test.ts
+++ b/parkhub-web/src/hooks/useNavLayout.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+import { useNavLayout, NAV_LAYOUT_KEY } from './useNavLayout';
+
+describe('useNavLayout', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('defaults to classic when nothing is stored', () => {
+    const { result } = renderHook(() => useNavLayout());
+    expect(result.current[0]).toBe('classic');
+  });
+
+  it('reads the stored layout on first render', () => {
+    window.localStorage.setItem(NAV_LAYOUT_KEY, 'rail');
+    const { result } = renderHook(() => useNavLayout());
+    expect(result.current[0]).toBe('rail');
+  });
+
+  it('ignores unknown values and falls back to classic', () => {
+    window.localStorage.setItem(NAV_LAYOUT_KEY, 'martian');
+    const { result } = renderHook(() => useNavLayout());
+    expect(result.current[0]).toBe('classic');
+  });
+
+  it('writes the new value to localStorage when set', () => {
+    const { result } = renderHook(() => useNavLayout());
+    act(() => result.current[1]('dock'));
+    expect(window.localStorage.getItem(NAV_LAYOUT_KEY)).toBe('dock');
+    expect(result.current[0]).toBe('dock');
+  });
+
+  it('rejects unknown values via setLayout', () => {
+    const { result } = renderHook(() => useNavLayout());
+    // @ts-expect-error — intentionally wrong type to verify runtime guard
+    act(() => result.current[1]('not-a-layout'));
+    expect(result.current[0]).toBe('classic');
+  });
+
+  it('propagates same-tab changes to other consumers via custom event', () => {
+    const { result: a } = renderHook(() => useNavLayout());
+    const { result: b } = renderHook(() => useNavLayout());
+    act(() => a.current[1]('top'));
+    expect(a.current[0]).toBe('top');
+    expect(b.current[0]).toBe('top');
+  });
+
+  it('picks up cross-tab storage events', () => {
+    const { result } = renderHook(() => useNavLayout());
+    act(() => {
+      window.dispatchEvent(
+        new StorageEvent('storage', { key: NAV_LAYOUT_KEY, newValue: 'rail' }),
+      );
+    });
+    expect(result.current[0]).toBe('rail');
+  });
+});

--- a/parkhub-web/src/hooks/useNavLayout.test.ts
+++ b/parkhub-web/src/hooks/useNavLayout.test.ts
@@ -48,10 +48,16 @@ describe('useNavLayout', () => {
 
   it('picks up cross-tab storage events', () => {
     const { result } = renderHook(() => useNavLayout());
+    // jsdom's StorageEvent constructor in some CodeQL ruleset versions is
+    // typed as one-arg. Build the event with `new Event` + Object.assign to
+    // sidestep that without changing the dispatched shape our listener
+    // actually reads (e.key / e.newValue).
     act(() => {
-      window.dispatchEvent(
-        new StorageEvent('storage', { key: NAV_LAYOUT_KEY, newValue: 'rail' }),
-      );
+      const ev = Object.assign(new Event('storage'), {
+        key: NAV_LAYOUT_KEY,
+        newValue: 'rail',
+      });
+      window.dispatchEvent(ev);
     });
     expect(result.current[0]).toBe('rail');
   });

--- a/parkhub-web/src/hooks/useNavLayout.ts
+++ b/parkhub-web/src/hooks/useNavLayout.ts
@@ -1,0 +1,71 @@
+import { useCallback, useEffect, useState } from 'react';
+import type { NavLayout } from '../components/ui/SettingsPrimitives';
+
+// Single source of truth for the nav-layout localStorage key. Kept in a
+// shared hook so Settings, Layout, and any future surface (mobile bottom
+// nav, kiosk mode, etc.) all read/write the same slot.
+export const NAV_LAYOUT_KEY = 'parkhub.nav.layout';
+const NAV_LAYOUT_EVENT = 'parkhub:nav-layout';
+
+const ALLOWED: NavLayout[] = ['classic', 'rail', 'top', 'dock'];
+
+function read(fallback: NavLayout = 'classic'): NavLayout {
+  if (typeof window === 'undefined') return fallback;
+  try {
+    const v = window.localStorage.getItem(NAV_LAYOUT_KEY);
+    return ALLOWED.includes(v as NavLayout) ? (v as NavLayout) : fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+function write(value: NavLayout): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(NAV_LAYOUT_KEY, value);
+  } catch {
+    /* quota / private mode — accept silently */
+  }
+}
+
+/**
+ * Reactive accessor for the user's nav-layout choice. Persists to
+ * localStorage, propagates changes to every mounted consumer in the
+ * same tab via a DOM CustomEvent, and picks up cross-tab updates via
+ * the `storage` event — so switching the layout in Settings while
+ * another tab is open reflows that tab too.
+ */
+export function useNavLayout(): readonly [NavLayout, (next: NavLayout) => void] {
+  const [layout, setLayoutState] = useState<NavLayout>(() => read());
+
+  useEffect(() => {
+    function handleCustom(e: Event) {
+      const detail = (e as CustomEvent<NavLayout>).detail;
+      if (detail && ALLOWED.includes(detail)) setLayoutState(detail);
+    }
+    function handleStorage(e: StorageEvent) {
+      if (e.key !== NAV_LAYOUT_KEY || !e.newValue) return;
+      if (ALLOWED.includes(e.newValue as NavLayout)) {
+        setLayoutState(e.newValue as NavLayout);
+      }
+    }
+    window.addEventListener(NAV_LAYOUT_EVENT, handleCustom);
+    window.addEventListener('storage', handleStorage);
+    return () => {
+      window.removeEventListener(NAV_LAYOUT_EVENT, handleCustom);
+      window.removeEventListener('storage', handleStorage);
+    };
+  }, []);
+
+  const setLayout = useCallback((next: NavLayout) => {
+    if (!ALLOWED.includes(next)) return;
+    write(next);
+    setLayoutState(next);
+    // Broadcast within the current tab so Settings ↔ Layout stay in sync
+    // without a full reload (storage events don't fire in the tab that
+    // did the write).
+    window.dispatchEvent(new CustomEvent<NavLayout>(NAV_LAYOUT_EVENT, { detail: next }));
+  }, []);
+
+  return [layout, setLayout] as const;
+}

--- a/parkhub-web/src/lib/appVersion.ts
+++ b/parkhub-web/src/lib/appVersion.ts
@@ -1,0 +1,10 @@
+// App version exposed to the UI. Sourced from the Vite env variable
+// VITE_APP_VERSION (wired in astro.config.mjs from package.json) with a
+// placeholder fallback so dev builds without the env don't break.
+//
+// Previously this lived hardcoded in Layout.tsx ("v4.9.0") and drifted —
+// v4.13.0 and later shipped with a stale footer. One-line source so it
+// stays accurate forever.
+export const APP_VERSION: string =
+  (typeof import.meta !== 'undefined' && (import.meta as { env?: { VITE_APP_VERSION?: string } }).env?.VITE_APP_VERSION)
+  || 'dev';

--- a/parkhub-web/src/views/Settings.tsx
+++ b/parkhub-web/src/views/Settings.tsx
@@ -23,17 +23,16 @@ import {
   SToggle,
   ThemeSwatches,
   NavLayoutGrid,
-  type NavLayout,
   type ThemeSwatch,
 } from '../components/ui/SettingsPrimitives';
 import { useTheme, type DesignThemeId } from '../context/ThemeContext';
+import { useNavLayout } from '../hooks/useNavLayout';
 
 type Scope = 'user' | 'workspace';
 
-// Persist the user's nav-layout choice so it survives reloads. Only
-// "classic" actually renders today (see SettingsPrimitives NavLayoutGrid);
-// the others accept the selection for when T-1842 lands the four variants.
-const NAV_LAYOUT_KEY = 'parkhub.nav.layout';
+// Nav-layout persistence moved to useNavLayout() so every consumer (Layout,
+// Settings, future kiosk shell) reads/writes the same slot and picks up
+// cross-tab + same-tab change events.
 const DENSITY_KEY = 'parkhub.ui.density';
 
 function readStored<T extends string>(key: string, fallback: T): T {
@@ -70,7 +69,7 @@ export function SettingsPage() {
   const { designTheme, setDesignTheme, setTheme, resolved, designThemes } = useTheme();
 
   const [scope, setScope] = useState<Scope>('user');
-  const [navLayout, setNavLayoutState] = useState<NavLayout>(() => readStored<NavLayout>(NAV_LAYOUT_KEY, 'classic'));
+  const [navLayout, setNavLayoutState] = useNavLayout();
   const [density, setDensityState] = useState<'compact' | 'cozy' | 'comfortable'>(() =>
     readStored<'compact' | 'cozy' | 'comfortable'>(DENSITY_KEY, 'cozy'),
   );
@@ -85,7 +84,6 @@ export function SettingsPage() {
     [designThemes],
   );
 
-  useEffect(() => writeStored(NAV_LAYOUT_KEY, navLayout), [navLayout]);
   useEffect(() => writeStored(DENSITY_KEY, density), [density]);
 
   const userSections = [
@@ -205,7 +203,7 @@ export function SettingsPage() {
 
         <SRow
           title={t('settings.navLayout', 'Navigation layout')}
-          description={t('settings.navLayoutDesc', 'Classic sidebar is current. Other variants arrive in an upcoming release.')}
+          description={t('settings.navLayoutDesc', 'Switch instantly — your choice persists across reloads and syncs to open tabs.')}
         >
           <NavLayoutGrid value={navLayout} onChange={setNavLayoutState} />
         </SRow>


### PR DESCRIPTION
## Summary

Completes the claude.ai/design v4 nav-variants bundle. Before this PR only Classic rendered — Rail/Top/Dock accepted the selection but showed 'Soon' badges and fell back to the wide sidebar. **All four layouts are now live**, switch instantly from Settings → Appearance → Navigation layout, and sync across browser tabs.

### New layouts

- **Rail** (72 px icon sidebar, `src/components/nav/RailSidebar.tsx`)
  - Side-popping label tooltips on hover/focus
  - Section dividers (no room for uppercase labels in a rail)
  - Spring-animated left accent indicator shared with Classic via framer-motion `layoutId`

- **FloatingDock** (macOS-style bottom pill, `src/components/nav/FloatingDock.tsx`)
  - Pointer-proximity icon magnification (useMotionValue + useSpring)
  - 8 curated items + grid overflow drawer for the rest
  - Footer gets `pb-24` so it doesn't collide with the dock

- **TopTabs** (horizontal header, `src/components/nav/TopTabs.tsx`)
  - 6 primary items inline, dropdown for overflow, user-menu popover on the right
  - Underline indicator animates between active tabs

### Shared plumbing

- **`hooks/useNavLayout.ts`** — single source of truth for the user's choice. Persists to `localStorage`, broadcasts via `CustomEvent` for same-tab consumers (Settings ↔ Layout), listens to `storage` events for cross-tab sync. Runtime-guards against stray values.
- **`NAV_SECTIONS`** exported from `Layout.tsx` so every variant shares the same source of nav items — adding a route in one place updates all four layouts automatically.

### Settings polish

- `NavLayoutGrid`: unlocked all four options, replaced "Soon" badges with **schematic CSS thumbnails** (classic = wide rail, rail = narrow rail, top = tabs, dock = pills).
- `Settings` view: dropped local `useState` + `localStorage` plumbing in favour of the shared hook. Description updated: *"Switch instantly — your choice persists across reloads and syncs to open tabs."*

### Version-sync footer

- Footer was hardcoded `ParkHub v4.9.0` — had drifted four versions.
- `astro.config.mjs` now parses the workspace Cargo.toml's version at build time and exposes it via `import.meta.env.VITE_APP_VERSION`. Falls back to package.json, then `dev`.
- `src/lib/appVersion.ts` is a one-line module so future surfaces (settings → about, admin dashboards) use the same source.
- Built bundle verified to contain `4.14.2` today.

## Test plan
- [x] `npx vitest run` — **2062 passed** (2055 existing + 7 new `useNavLayout` tests)
- [x] `npm run build` — clean; `grep -o '\"4\\.14\\.2\"' dist/_astro/Layout.*.js` finds the baked-in version
- [ ] CI
- [ ] Manual sanity — switch each layout in Settings, confirm instant reflow