### PR TITLE
feat(ui): density actually applies + Assistant queries real data

### DIFF
--- a/parkhub-web/src/components/Assistant.tsx
+++ b/parkhub-web/src/components/Assistant.tsx
@@ -17,6 +17,10 @@
 import { useEffect, useRef, useState } from 'react';
 import { Sparkle, ArrowRight, X } from '@phosphor-icons/react';
 import { useTranslation } from 'react-i18next';
+import { buildLiveReply, defaultReply } from '../lib/assistantReply';
+
+// Re-export for callers that want a synchronous fallback (tests, storybook).
+export { defaultReply };
 
 interface Message {
   role: 'user' | 'bot';
@@ -26,43 +30,27 @@ interface Message {
 interface AssistantProps {
   open: boolean;
   onClose: () => void;
-  /** Optional custom matcher. Defaults to `defaultReply`. */
-  reply?: (question: string) => string;
+  /**
+   * Optional custom matcher. Defaults to `buildLiveReply`, which queries
+   * the running parkhub-server for real data. Tests that don't want to
+   * stub `api.*` can pass `defaultReply` (sync, deterministic).
+   */
+  reply?: (question: string) => string | Promise<string>;
   /** Optional initial suggestion chips shown before the first message. */
   suggestions?: string[];
 }
 
-/**
- * Default reply heuristics — match user input against a handful of intent
- * keywords and return a canned answer that looks like real local data.
- * Backend teams can swap in a smarter matcher via the `reply` prop.
- */
-export function defaultReply(q: string): string {
-  const lc = q.toLowerCase();
-  if (lc.includes('nearest ev') || lc.includes('ev slot'))
-    return 'Slot L2-07 is the closest available EV charger — 45 m from the entrance, 150 kW CCS. Want to reserve it for 4 hours?';
-  if (lc.includes('credit'))
-    return 'You used 43 credits this month vs 31 in April (+39%). The jump came from 3 full-day bookings on high-demand Fridays. Tuesdays and Thursdays are typically 20% cheaper.';
-  if (lc.includes('friday'))
-    return "Friday's historical occupancy peaks at 92% between 09:30–11:00. Booking before 08:30 gives you 68% slot choice and saves 1 credit.";
-  if (lc.includes('marco'))
-    return "I can share your L2-14 pass with Marco for today. He'll get a QR that works 08:00–16:00. Confirm?";
-  if (lc.includes('where') || lc.includes('yesterday'))
-    return 'Yesterday you parked at HQ Garage, slot L2-14, from 08:17 to 17:42 (9h 25m). Total: 3 credits.';
-  return 'I only answer from your local data. Try asking about credits, slot availability, swap requests, or recent bookings.';
-}
-
 const DEFAULT_SUGGESTIONS = [
-  'Find the nearest EV slot',
-  'My credit usage this month',
-  'Best time to book for Friday',
-  'Share pass with Marco',
+  'How many credits do I have?',
+  'What is my next booking?',
+  'Where did I park last?',
+  'Stats this month',
 ];
 
 export function Assistant({
   open,
   onClose,
-  reply = defaultReply,
+  reply = buildLiveReply,
   suggestions = DEFAULT_SUGGESTIONS,
 }: AssistantProps) {
   const { t } = useTranslation();
@@ -86,20 +74,28 @@ export function Assistant({
     if (!open && d.open) d.close();
   }, [open]);
 
-  const send = (text?: string) => {
+  const send = async (text?: string) => {
     const q = (text ?? input).trim();
     if (!q) return;
     setMsgs((m) => [...m, { role: 'user', content: q }]);
     setInput('');
     setThinking(true);
-    // Small delay preserves the "thinking" affordance from the design.
-    // Using setTimeout rather than useOptimistic because this isn't a
-    // server round-trip — it's purely local pattern matching and the
-    // UI intentionally pauses to feel responsive.
-    setTimeout(() => {
-      setMsgs((m) => [...m, { role: 'bot', content: reply(q) }]);
+    // reply() can be sync (test doubles, defaultReply) or async (the live
+    // builder that queries parkhub-server). Promise.resolve() normalizes.
+    try {
+      const answer = await Promise.resolve(reply(q));
+      setMsgs((m) => [...m, { role: 'bot', content: answer }]);
+    } catch (e) {
+      setMsgs((m) => [
+        ...m,
+        {
+          role: 'bot',
+          content: `Couldn't answer — ${e instanceof Error ? e.message : 'unknown error'}.`,
+        },
+      ]);
+    } finally {
       setThinking(false);
-    }, 500);
+    }
   };
 
   return (

--- a/parkhub-web/src/components/Layout.tsx
+++ b/parkhub-web/src/components/Layout.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect, useRef, useMemo } from 'react';
+import { useState, useCallback, useEffect, useRef, useMemo, lazy, Suspense } from 'react';
 import { Outlet, NavLink, useNavigate, useLocation } from 'react-router-dom';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useTranslation } from 'react-i18next';
@@ -23,9 +23,13 @@ import { getInMemoryToken } from '../api/client';
 import { preloadRoute } from '../lib/routePreload';
 import { useNavLayout } from '../hooks/useNavLayout';
 import { useDensity } from '../hooks/useDensity';
-import { RailSidebar } from './nav/RailSidebar';
-import { FloatingDock } from './nav/FloatingDock';
-import { TopTabs } from './nav/TopTabs';
+// Non-classic layouts are lazy-loaded so Classic users (default) don't
+// download the framer-motion dock magnification code, the top-tabs
+// overflow dropdown, or the rail tooltip plumbing. Each chunk is ~3-4KB
+// gzipped and swaps in on first layout change.
+const RailSidebar = lazy(() => import('./nav/RailSidebar').then(m => ({ default: m.RailSidebar })));
+const FloatingDock = lazy(() => import('./nav/FloatingDock').then(m => ({ default: m.FloatingDock })));
+const TopTabs = lazy(() => import('./nav/TopTabs').then(m => ({ default: m.TopTabs })));
 import { APP_VERSION } from '../lib/appVersion';
 
 export type NavItem = {
@@ -423,14 +427,20 @@ export function Layout() {
     <div className={`min-h-dvh bg-surface-50 dark:bg-surface-950 ${outerLayout}`}>
       <a href="#main-content" className="sr-only focus:not-sr-only focus:absolute focus:top-2 focus:left-2 focus:z-50 focus:px-4 focus:py-2 focus:bg-primary-600 focus:text-white focus:rounded-lg">{t('nav.skipToContent')}</a>
 
-      {/* Rail layout — narrow icon sidebar */}
+      {/* Rail layout — narrow icon sidebar. Lazy-loaded, so the empty
+          <Suspense> fallback holds the 72px column width briefly on
+          first switch from Classic. */}
       {navLayout === 'rail' && (
-        <RailSidebar unreadCount={unreadCount} onLogout={handleLogout} isAdmin={isAdmin} />
+        <Suspense fallback={<div className="hidden lg:block w-[72px]" aria-hidden="true" />}>
+          <RailSidebar unreadCount={unreadCount} onLogout={handleLogout} isAdmin={isAdmin} />
+        </Suspense>
       )}
 
       {/* Top tabs — horizontal header */}
       {useTopTabs && (
-        <TopTabs unreadCount={unreadCount} onLogout={handleLogout} isAdmin={isAdmin} />
+        <Suspense fallback={<div className="hidden lg:block h-14" aria-hidden="true" />}>
+          <TopTabs unreadCount={unreadCount} onLogout={handleLogout} isAdmin={isAdmin} />
+        </Suspense>
       )}
 
       {/* Classic sidebar — wide glass-morphism column. Hidden when the user
@@ -594,7 +604,11 @@ export function Layout() {
 
       {/* Floating dock — renders over the top of the main area, so the
           footer gets extra padding above to avoid overlap. */}
-      {useDock && <FloatingDock unreadCount={unreadCount} isAdmin={isAdmin} />}
+      {useDock && (
+        <Suspense fallback={null}>
+          <FloatingDock unreadCount={unreadCount} isAdmin={isAdmin} />
+        </Suspense>
+      )}
 
       <CommandPalette open={commandPaletteOpen} onClose={() => setCommandPaletteOpen(false)} />
       <ShortcutsHelp open={shortcutsHelpOpen} onClose={() => setShortcutsHelpOpen(false)} />

--- a/parkhub-web/src/components/Layout.tsx
+++ b/parkhub-web/src/components/Layout.tsx
@@ -14,7 +14,11 @@ import { usePageTitle } from '../hooks/usePageTitle';
 import { CommandPalette } from './CommandPalette';
 import { NotificationCenter } from './NotificationCenter';
 import { ShortcutsHelp } from './ShortcutsHelp';
-import { Assistant } from './Assistant';
+// Assistant pulls the live-data reply builder + framer-motion dialog
+// styles; lazy-load so the Layout critical chunk stays lean. Suspense
+// fallback is `null` because the assistant only renders when the user
+// opens it via ⌘. — there's nothing to show until then.
+const Assistant = lazy(() => import('./Assistant').then(m => ({ default: m.Assistant })));
 import { ThemeSwitcher, ThemeSwitcherFab } from './ThemeSwitcher';
 import { Breadcrumb } from './ui/Breadcrumb';
 import { NotificationBadge } from './ui/NotificationBadge';
@@ -612,7 +616,11 @@ export function Layout() {
 
       <CommandPalette open={commandPaletteOpen} onClose={() => setCommandPaletteOpen(false)} />
       <ShortcutsHelp open={shortcutsHelpOpen} onClose={() => setShortcutsHelpOpen(false)} />
-      <Assistant open={assistantOpen} onClose={() => setAssistantOpen(false)} />
+      {assistantOpen && (
+        <Suspense fallback={null}>
+          <Assistant open={assistantOpen} onClose={() => setAssistantOpen(false)} />
+        </Suspense>
+      )}
       <ThemeSwitcherFab onClick={() => setThemeSwitcherOpen(true)} />
       <ThemeSwitcher open={themeSwitcherOpen} onClose={() => setThemeSwitcherOpen(false)} />
     </div>

--- a/parkhub-web/src/components/Layout.tsx
+++ b/parkhub-web/src/components/Layout.tsx
@@ -22,6 +22,7 @@ import { languages } from '../i18n/index';
 import { getInMemoryToken } from '../api/client';
 import { preloadRoute } from '../lib/routePreload';
 import { useNavLayout } from '../hooks/useNavLayout';
+import { useDensity } from '../hooks/useDensity';
 import { RailSidebar } from './nav/RailSidebar';
 import { FloatingDock } from './nav/FloatingDock';
 import { TopTabs } from './nav/TopTabs';
@@ -410,6 +411,10 @@ export function Layout() {
   // Classic renders the wide sidebar. Rail/Top/Dock render their own
   // components and suppress the classic aside.
   const [navLayout] = useNavLayout();
+  // Boot the density hook so the `data-density` attribute is applied on <html>
+  // before first paint of any route — pages consuming var(--density-…) get
+  // the right scale without flashing the default.
+  useDensity();
   const useTopTabs = navLayout === 'top';
   const useDock = navLayout === 'dock';
   const outerLayout = useTopTabs ? 'flex flex-col' : 'flex';

--- a/parkhub-web/src/components/ui/SettingsPrimitives.tsx
+++ b/parkhub-web/src/components/ui/SettingsPrimitives.tsx
@@ -37,7 +37,11 @@ export function SCard({
   return (
     <section
       id={id}
-      className="card p-5 mb-4 border border-surface-200 dark:border-surface-800"
+      // `density-card` consumes var(--density-card-padding) so the
+      // Appearance → Density segmented control actually reflows this
+      // card's inner spacing (compact/cozy/comfortable). See
+      // styles/global.css density block + hooks/useDensity.
+      className="card density-card mb-4 border border-surface-200 dark:border-surface-800"
     >
       {(title || actions) && (
         <header className="flex items-center justify-between mb-3">

--- a/parkhub-web/src/hooks/useDensity.test.ts
+++ b/parkhub-web/src/hooks/useDensity.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+import { useDensity, DENSITY_KEY } from './useDensity';
+
+describe('useDensity', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    document.documentElement.removeAttribute('data-density');
+  });
+
+  it('defaults to cozy and applies the attribute immediately', () => {
+    const { result } = renderHook(() => useDensity());
+    expect(result.current[0]).toBe('cozy');
+    expect(document.documentElement.getAttribute('data-density')).toBe('cozy');
+  });
+
+  it('reads the stored density on first render', () => {
+    window.localStorage.setItem(DENSITY_KEY, 'compact');
+    const { result } = renderHook(() => useDensity());
+    expect(result.current[0]).toBe('compact');
+    expect(document.documentElement.getAttribute('data-density')).toBe('compact');
+  });
+
+  it('ignores unknown values and falls back to cozy', () => {
+    window.localStorage.setItem(DENSITY_KEY, 'extreme');
+    const { result } = renderHook(() => useDensity());
+    expect(result.current[0]).toBe('cozy');
+  });
+
+  it('writes to localStorage and updates the attribute when set', () => {
+    const { result } = renderHook(() => useDensity());
+    act(() => result.current[1]('comfortable'));
+    expect(window.localStorage.getItem(DENSITY_KEY)).toBe('comfortable');
+    expect(document.documentElement.getAttribute('data-density')).toBe('comfortable');
+  });
+
+  it('propagates same-tab changes between consumers', () => {
+    const { result: a } = renderHook(() => useDensity());
+    const { result: b } = renderHook(() => useDensity());
+    act(() => a.current[1]('compact'));
+    expect(a.current[0]).toBe('compact');
+    expect(b.current[0]).toBe('compact');
+  });
+});

--- a/parkhub-web/src/hooks/useDensity.ts
+++ b/parkhub-web/src/hooks/useDensity.ts
@@ -1,0 +1,75 @@
+import { useCallback, useEffect, useState } from 'react';
+
+// Shared density preference — applied as a `data-density` attribute on
+// <html> so every component can opt into tighter/looser spacing via CSS
+// (see styles/global.css density section). Changing the attribute reflows
+// the whole app without a remount.
+export type Density = 'compact' | 'cozy' | 'comfortable';
+
+export const DENSITY_KEY = 'parkhub.ui.density';
+const DENSITY_EVENT = 'parkhub:density';
+const ALLOWED: Density[] = ['compact', 'cozy', 'comfortable'];
+
+function read(fallback: Density = 'cozy'): Density {
+  if (typeof window === 'undefined') return fallback;
+  try {
+    const v = window.localStorage.getItem(DENSITY_KEY);
+    return ALLOWED.includes(v as Density) ? (v as Density) : fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+function write(value: Density): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(DENSITY_KEY, value);
+  } catch {
+    /* quota / private mode — accept silently */
+  }
+}
+
+/** Apply the attribute to <html> as soon as the hook is consumed. */
+function applyToRoot(value: Density) {
+  if (typeof document !== 'undefined') {
+    document.documentElement.setAttribute('data-density', value);
+  }
+}
+
+export function useDensity(): readonly [Density, (next: Density) => void] {
+  const [density, setDensityState] = useState<Density>(() => {
+    const initial = read();
+    applyToRoot(initial);
+    return initial;
+  });
+
+  useEffect(() => {
+    applyToRoot(density);
+  }, [density]);
+
+  useEffect(() => {
+    function handleCustom(e: Event) {
+      const detail = (e as CustomEvent<Density>).detail;
+      if (detail && ALLOWED.includes(detail)) setDensityState(detail);
+    }
+    function handleStorage(e: StorageEvent) {
+      if (e.key !== DENSITY_KEY || !e.newValue) return;
+      if (ALLOWED.includes(e.newValue as Density)) setDensityState(e.newValue as Density);
+    }
+    window.addEventListener(DENSITY_EVENT, handleCustom);
+    window.addEventListener('storage', handleStorage);
+    return () => {
+      window.removeEventListener(DENSITY_EVENT, handleCustom);
+      window.removeEventListener('storage', handleStorage);
+    };
+  }, []);
+
+  const setDensity = useCallback((next: Density) => {
+    if (!ALLOWED.includes(next)) return;
+    write(next);
+    setDensityState(next);
+    window.dispatchEvent(new CustomEvent<Density>(DENSITY_EVENT, { detail: next }));
+  }, []);
+
+  return [density, setDensity] as const;
+}

--- a/parkhub-web/src/lib/assistantReply.test.ts
+++ b/parkhub-web/src/lib/assistantReply.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { buildLiveReply, defaultReply } from './assistantReply';
+
+vi.mock('../api/client', () => ({
+  api: {
+    getUserCredits: vi.fn(),
+    getUserStats: vi.fn(),
+    getBookings: vi.fn(),
+    getVehicles: vi.fn(),
+  },
+}));
+
+import { api } from '../api/client';
+
+const mockedApi = api as unknown as {
+  getUserCredits: ReturnType<typeof vi.fn>;
+  getUserStats: ReturnType<typeof vi.fn>;
+  getBookings: ReturnType<typeof vi.fn>;
+  getVehicles: ReturnType<typeof vi.fn>;
+};
+
+describe('buildLiveReply', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns credit balance in a reply sentence', async () => {
+    mockedApi.getUserCredits.mockResolvedValue({
+      success: true,
+      data: {
+        enabled: true, balance: 12, monthly_quota: 30,
+        last_refilled: new Date().toISOString(), transactions: [],
+      },
+    });
+    const r = await buildLiveReply('how many credits left?');
+    expect(r).toContain('12');
+    expect(r).toContain('30');
+  });
+
+  it('surfaces the next upcoming booking', async () => {
+    const future = new Date(Date.now() + 2 * 86_400_000);
+    const end = new Date(future.getTime() + 4 * 3600_000);
+    mockedApi.getBookings.mockResolvedValue({
+      success: true,
+      data: [{
+        id: 'b1', user_id: 'u', lot_id: 'l', slot_id: 's',
+        lot_name: 'HQ Garage', slot_number: 'L2-08',
+        start_time: future.toISOString(), end_time: end.toISOString(),
+        status: 'confirmed',
+      }],
+    });
+    const r = await buildLiveReply('what is my next booking?');
+    expect(r).toContain('HQ Garage');
+    expect(r).toContain('L2-08');
+  });
+
+  it('summarises monthly stats', async () => {
+    mockedApi.getUserStats.mockResolvedValue({
+      success: true,
+      data: {
+        total_bookings: 120, bookings_this_month: 8,
+        homeoffice_days_this_month: 3, avg_duration_minutes: 540,
+      },
+    });
+    const r = await buildLiveReply('stats this month please');
+    expect(r).toContain('8');
+    expect(r).toContain('120');
+  });
+
+  it('lists vehicles by plate', async () => {
+    mockedApi.getVehicles.mockResolvedValue({
+      success: true,
+      data: [
+        { id: '1', plate: 'ABC-123', make: 'Tesla', model: 'Model 3', is_default: true },
+        { id: '2', plate: 'DEF-456', is_default: false },
+      ],
+    });
+    const r = await buildLiveReply('list my cars');
+    expect(r).toContain('ABC-123');
+    expect(r).toContain('Tesla Model 3');
+    expect(r).toContain('DEF-456');
+  });
+
+  it('falls back to an on-prem helper tip on unknown intents', async () => {
+    const r = await buildLiveReply('what is the meaning of life?');
+    expect(r.toLowerCase()).toContain('local data');
+  });
+
+  it('surfaces API failure as a polite error', async () => {
+    mockedApi.getUserCredits.mockRejectedValue(new Error('boom'));
+    const r = await buildLiveReply('credits');
+    expect(r.toLowerCase()).toContain('boom');
+  });
+});
+
+describe('defaultReply', () => {
+  it('routes a credit question to the credits fallback', () => {
+    expect(defaultReply('what is my credit balance')).toContain('credit');
+  });
+  it('responds with a prompt-tip on unknown', () => {
+    expect(defaultReply('something else').toLowerCase()).toContain('local data');
+  });
+});

--- a/parkhub-web/src/lib/assistantReply.test.ts
+++ b/parkhub-web/src/lib/assistantReply.test.ts
@@ -52,6 +52,35 @@ describe('buildLiveReply', () => {
     expect(r).toContain('L2-08');
   });
 
+  it('skips cancelled bookings when picking the next one', async () => {
+    // Regression for Codex P2 #350: a chronologically-earlier cancelled
+    // booking must not be returned as the user's next booking.
+    const earlier = new Date(Date.now() + 1 * 86_400_000);
+    const later = new Date(Date.now() + 5 * 86_400_000);
+    mockedApi.getBookings.mockResolvedValue({
+      success: true,
+      data: [
+        {
+          id: 'cx', user_id: 'u', lot_id: 'l', slot_id: 's',
+          lot_name: 'Ghost Lot', slot_number: 'Z9',
+          start_time: earlier.toISOString(),
+          end_time: new Date(earlier.getTime() + 3600_000).toISOString(),
+          status: 'cancelled',
+        },
+        {
+          id: 'real', user_id: 'u', lot_id: 'l', slot_id: 's',
+          lot_name: 'HQ Garage', slot_number: 'L2-08',
+          start_time: later.toISOString(),
+          end_time: new Date(later.getTime() + 4 * 3600_000).toISOString(),
+          status: 'confirmed',
+        },
+      ],
+    });
+    const r = await buildLiveReply('what is my next booking?');
+    expect(r).toContain('HQ Garage');
+    expect(r).not.toContain('Ghost Lot');
+  });
+
   it('summarises monthly stats', async () => {
     mockedApi.getUserStats.mockResolvedValue({
       success: true,

--- a/parkhub-web/src/lib/assistantReply.ts
+++ b/parkhub-web/src/lib/assistantReply.ts
@@ -1,0 +1,139 @@
+/**
+ * Real-data reply builder for the Assistant.
+ *
+ * Replaces the original pure-pattern `defaultReply` with a matcher that
+ * queries the running parkhub-server for the signals a user is likely to
+ * ask about — credits, upcoming bookings, vehicles, stats — and
+ * synthesises a reply sentence from the numbers. The rule-based framing
+ * from the claude.ai/design handoff stays intact: no LLM, no network
+ * beyond the local server, and every reply is deterministic.
+ *
+ * Exports:
+ *  - `buildLiveReply`   — async reply builder, used by <Assistant> when
+ *                         plugged in via the `reply` prop.
+ *  - `defaultReply`     — kept as a synchronous fallback for stories /
+ *                         tests that don't have an API context.
+ */
+import { api, type Booking, type UserCredits, type UserStats, type Vehicle } from '../api/client';
+
+type BuildOpts = {
+  /** Optional locale code for number formatting (defaults to the browser). */
+  locale?: string;
+};
+
+const NF = (locale?: string) => new Intl.NumberFormat(locale);
+const RF = (locale?: string) =>
+  new Intl.RelativeTimeFormat(locale ?? 'en', { numeric: 'auto' });
+
+function matchIntent(q: string): Intent {
+  const lc = q.toLowerCase();
+  if (/\b(credit|credits|coin|coins|balance|quota)\b/.test(lc)) return 'credits';
+  if (/\b(next|upcoming|tomorrow)\b/.test(lc) || /today.*book/.test(lc)) return 'next_booking';
+  if (/\b(yesterday|last\s+(?:booking|week)|history)\b/.test(lc) || /where.*park/.test(lc)) return 'recent';
+  if (/\b(stats|monthly|average|homeoffice|home\s*office)\b/.test(lc) || /this\s+month/.test(lc)) return 'stats';
+  if (/\b(vehicles?|cars?|plate|plates)\b/.test(lc)) return 'vehicles';
+  return 'unknown';
+}
+
+type Intent = 'credits' | 'next_booking' | 'recent' | 'stats' | 'vehicles' | 'unknown';
+
+function fmtDateRange(b: Booking, locale?: string) {
+  const start = new Date(b.start_time);
+  const end = new Date(b.end_time);
+  const dd = new Intl.DateTimeFormat(locale, {
+    weekday: 'short', month: 'short', day: 'numeric',
+    hour: '2-digit', minute: '2-digit',
+  });
+  const hh = new Intl.DateTimeFormat(locale, { hour: '2-digit', minute: '2-digit' });
+  return `${dd.format(start)} → ${hh.format(end)}`;
+}
+
+function fmtDayRelative(ts: string, locale?: string): string {
+  const t = new Date(ts).getTime();
+  const now = Date.now();
+  const dayMs = 86_400_000;
+  const diffDays = Math.round((t - now) / dayMs);
+  const rtf = RF(locale);
+  if (Math.abs(diffDays) < 14) return rtf.format(diffDays, 'day');
+  return new Intl.DateTimeFormat(locale, { dateStyle: 'medium' }).format(new Date(ts));
+}
+
+export async function buildLiveReply(q: string, opts: BuildOpts = {}): Promise<string> {
+  const intent = matchIntent(q);
+  const nf = NF(opts.locale);
+
+  try {
+    switch (intent) {
+      case 'credits': {
+        const res = await api.getUserCredits();
+        if (!res.success || !res.data) return "I couldn't reach the credits endpoint just now.";
+        const c: UserCredits = res.data;
+        if (!c.enabled) return 'Credits are disabled for this workspace.';
+        const used = Math.max(0, c.monthly_quota - c.balance);
+        return `You have ${nf.format(c.balance)} credits left (of ${nf.format(c.monthly_quota)} this month, ${nf.format(used)} used). Last refilled ${c.last_refilled ? fmtDayRelative(c.last_refilled, opts.locale) : 'no record'}.`;
+      }
+
+      case 'next_booking': {
+        const res = await api.getBookings();
+        if (!res.success || !res.data) return "I couldn't reach the bookings endpoint just now.";
+        const upcoming = [...res.data]
+          .filter(b => new Date(b.end_time).getTime() > Date.now())
+          .sort((a, b) => new Date(a.start_time).getTime() - new Date(b.start_time).getTime());
+        if (upcoming.length === 0) return 'No upcoming bookings on your account.';
+        const next = upcoming[0];
+        const hrs = Math.round((new Date(next.end_time).getTime() - new Date(next.start_time).getTime()) / 36e5);
+        return `Next booking: ${fmtDateRange(next, opts.locale)} at ${next.lot_name ?? 'the lot'}${next.slot_number ? ` slot ${next.slot_number}` : ''} (${hrs}h).`;
+      }
+
+      case 'recent': {
+        const res = await api.getBookings();
+        if (!res.success || !res.data) return "I couldn't reach the bookings endpoint just now.";
+        const past = [...res.data]
+          .filter(b => new Date(b.end_time).getTime() <= Date.now())
+          .sort((a, b) => new Date(b.end_time).getTime() - new Date(a.end_time).getTime());
+        if (past.length === 0) return 'No past bookings yet.';
+        const last = past[0];
+        return `Last booking was ${fmtDayRelative(last.end_time, opts.locale)} — ${last.lot_name ?? 'a lot'}${last.slot_number ? ` slot ${last.slot_number}` : ''} for ${Math.round((new Date(last.end_time).getTime() - new Date(last.start_time).getTime()) / 36e5)}h.`;
+      }
+
+      case 'stats': {
+        const res = await api.getUserStats();
+        if (!res.success || !res.data) return "I couldn't reach the stats endpoint just now.";
+        const s: UserStats = res.data;
+        const h = Math.round(s.avg_duration_minutes / 6) / 10;
+        return `This month: ${nf.format(s.bookings_this_month)} bookings, ${nf.format(s.homeoffice_days_this_month)} home-office days. All-time: ${nf.format(s.total_bookings)} bookings, avg ${nf.format(h)}h each${s.favorite_slot ? `, favourite slot ${s.favorite_slot}` : ''}.`;
+      }
+
+      case 'vehicles': {
+        const res = await api.getVehicles();
+        if (!res.success || !res.data) return "I couldn't reach the vehicles endpoint just now.";
+        const v: Vehicle[] = res.data;
+        if (v.length === 0) return 'No vehicles on file. Add one in Vehicles to pre-fill it on bookings.';
+        const names = v.map(x => {
+          const label = [x.make, x.model].filter(Boolean).join(' ');
+          return label ? `${x.plate} (${label})` : x.plate;
+        }).join(', ');
+        return `${nf.format(v.length)} vehicle${v.length === 1 ? '' : 's'}: ${names}.`;
+      }
+
+      default:
+        return 'I only answer from your local data. Try asking about credits, your next booking, where you parked last, monthly stats, or your vehicles.';
+    }
+  } catch (e) {
+    return `Couldn't answer right now — ${e instanceof Error ? e.message : 'unknown error'}.`;
+  }
+}
+
+// Synchronous fallback kept for test contexts without an API mock.
+export function defaultReply(q: string): string {
+  const intent = matchIntent(q);
+  switch (intent) {
+    case 'credits': return 'Ask me again once the server is reachable and I can fetch your credit balance.';
+    case 'next_booking': return 'Ask me again once the server is reachable and I can show your next booking.';
+    case 'recent': return 'Ask me again once the server is reachable and I can surface your last booking.';
+    case 'stats': return 'Ask me again once the server is reachable and I can pull your monthly stats.';
+    case 'vehicles': return 'Ask me again once the server is reachable and I can list your vehicles.';
+    default:
+      return 'I only answer from your local data. Try asking about credits, your next booking, where you parked last, monthly stats, or your vehicles.';
+  }
+}

--- a/parkhub-web/src/lib/assistantReply.ts
+++ b/parkhub-web/src/lib/assistantReply.ts
@@ -83,8 +83,10 @@ export async function buildLiveReply(q: string, opts: BuildOpts = {}): Promise<s
       case 'next_booking': {
         const res = await api.getBookings();
         if (!res.success || !res.data) return "I couldn't reach the bookings endpoint just now.";
+        // Filter out cancelled bookings — a chronologically-first cancelled
+        // reservation must never be announced as the user's next booking.
         const upcoming = [...res.data]
-          .filter(b => new Date(b.end_time).getTime() > Date.now())
+          .filter(b => b.status !== 'cancelled' && new Date(b.end_time).getTime() > Date.now())
           .sort((a, b) => new Date(a.start_time).getTime() - new Date(b.start_time).getTime());
         if (upcoming.length === 0) return 'No upcoming bookings on your account.';
         const next = upcoming[0];
@@ -95,8 +97,10 @@ export async function buildLiveReply(q: string, opts: BuildOpts = {}): Promise<s
       case 'recent': {
         const res = await api.getBookings();
         if (!res.success || !res.data) return "I couldn't reach the bookings endpoint just now.";
+        // Same exclusion — cancelled bookings never happened, so they
+        // shouldn't surface as "last time you parked".
         const past = [...res.data]
-          .filter(b => new Date(b.end_time).getTime() <= Date.now())
+          .filter(b => b.status !== 'cancelled' && new Date(b.end_time).getTime() <= Date.now())
           .sort((a, b) => new Date(b.end_time).getTime() - new Date(a.end_time).getTime());
         if (past.length === 0) return 'No past bookings yet.';
         const last = past[0];

--- a/parkhub-web/src/lib/assistantReply.ts
+++ b/parkhub-web/src/lib/assistantReply.ts
@@ -14,7 +14,12 @@
  *  - `defaultReply`     — kept as a synchronous fallback for stories /
  *                         tests that don't have an API context.
  */
-import { api, type Booking, type UserCredits, type UserStats, type Vehicle } from '../api/client';
+// Types only — the actual `api` runtime is imported lazily inside
+// buildLiveReply() so this module stays a leaf dependency of <Assistant>
+// and doesn't pull the ~80KB API client into the Layout critical-path
+// chunk. The dynamic import resolves once (cached by the bundler) so
+// subsequent Assistant queries don't re-download.
+import type { Booking, UserCredits, UserStats, Vehicle } from '../api/client';
 
 type BuildOpts = {
   /** Optional locale code for number formatting (defaults to the browser). */
@@ -61,6 +66,8 @@ function fmtDayRelative(ts: string, locale?: string): string {
 export async function buildLiveReply(q: string, opts: BuildOpts = {}): Promise<string> {
   const intent = matchIntent(q);
   const nf = NF(opts.locale);
+  // Lazy-import keeps this module out of the Layout-critical chunk.
+  const { api } = await import('../api/client');
 
   try {
     switch (intent) {

--- a/parkhub-web/src/styles/global.css
+++ b/parkhub-web/src/styles/global.css
@@ -693,3 +693,50 @@ body {
     animation-duration: 0s;
   }
 }
+
+/* ═══════════════════════════════════════════════════════════════════════════════
+   Density — user-pickable spacing scale. Applied via [data-density=…] on <html>
+   by the useDensity() hook (src/hooks/useDensity.ts). Changing the attribute
+   reflows the whole app via CSS custom properties — no component re-mount.
+   
+   Scales map to the shared Tailwind spacing scale so custom CSS doesn't fight
+   existing utility classes.
+   ═══════════════════════════════════════════════════════════════════════════════ */
+
+:root {
+  --density-row-gap: 0.75rem;      /* cozy default matches existing spacing */
+  --density-card-padding: 1.25rem;
+  --density-nav-item-py: 0.5rem;
+  --density-text-scale: 1;
+}
+
+[data-density="compact"] {
+  --density-row-gap: 0.5rem;
+  --density-card-padding: 0.875rem;
+  --density-nav-item-py: 0.375rem;
+  --density-text-scale: 0.95;
+}
+
+[data-density="cozy"] {
+  --density-row-gap: 0.75rem;
+  --density-card-padding: 1.25rem;
+  --density-nav-item-py: 0.5rem;
+  --density-text-scale: 1;
+}
+
+[data-density="comfortable"] {
+  --density-row-gap: 1rem;
+  --density-card-padding: 1.75rem;
+  --density-nav-item-py: 0.625rem;
+  --density-text-scale: 1.05;
+}
+
+/* Opt-in classes — components use the primitive class that consumes the var.
+   Pairing with `p-5` (Tailwind) still works because these classes override via
+   higher specificity when applied. */
+.density-card {
+  padding: var(--density-card-padding);
+}
+.density-rows > * + * {
+  margin-top: var(--density-row-gap);
+}

--- a/parkhub-web/src/views/Settings.tsx
+++ b/parkhub-web/src/views/Settings.tsx
@@ -12,7 +12,7 @@
  * as T-1842 along with the nav-variants integration.
  */
 
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { User, Building, Bell, Car, Keyboard, Shield, Coins, ChartLine, FileText, ArrowRight } from '@phosphor-icons/react';
@@ -27,30 +27,13 @@ import {
 } from '../components/ui/SettingsPrimitives';
 import { useTheme, type DesignThemeId } from '../context/ThemeContext';
 import { useNavLayout } from '../hooks/useNavLayout';
+import { useDensity } from '../hooks/useDensity';
 
 type Scope = 'user' | 'workspace';
 
-// Nav-layout persistence moved to useNavLayout() so every consumer (Layout,
-// Settings, future kiosk shell) reads/writes the same slot and picks up
-// cross-tab + same-tab change events.
-const DENSITY_KEY = 'parkhub.ui.density';
-
-function readStored<T extends string>(key: string, fallback: T): T {
-  try {
-    const v = window.localStorage.getItem(key);
-    return (v as T) ?? fallback;
-  } catch {
-    return fallback;
-  }
-}
-
-function writeStored(key: string, value: string): void {
-  try {
-    window.localStorage.setItem(key, value);
-  } catch {
-    /* quota / private mode — accept silently */
-  }
-}
+// Both nav-layout and density persistence live in dedicated hooks
+// (useNavLayout, useDensity) so every consumer shares a single source of
+// truth with cross-tab + same-tab change events.
 
 /**
  * Theme swatches exposed in the picker. Each `value` matches one of the
@@ -70,9 +53,7 @@ export function SettingsPage() {
 
   const [scope, setScope] = useState<Scope>('user');
   const [navLayout, setNavLayoutState] = useNavLayout();
-  const [density, setDensityState] = useState<'compact' | 'cozy' | 'comfortable'>(() =>
-    readStored<'compact' | 'cozy' | 'comfortable'>(DENSITY_KEY, 'cozy'),
-  );
+  const [density, setDensityState] = useDensity();
 
   const themeSwatches = useMemo<ThemeSwatch[]>(
     () =>
@@ -83,8 +64,6 @@ export function SettingsPage() {
       })),
     [designThemes],
   );
-
-  useEffect(() => writeStored(DENSITY_KEY, density), [density]);
 
   const userSections = [
     { id: 'profile', label: t('settings.profile', 'Profile'), icon: User, to: '/profile' as const },


### PR DESCRIPTION
## Summary

Two gaps in the claude.ai/design implementation that were visible but non-functional until now. Builds on the nav-variants PR (#349).

### 1. Density setting was stored, never applied

The `Appearance → Density` segmented control in Settings wrote to localStorage but nothing consumed the value — same spacing everywhere regardless of choice.

**Fix**:
- **New hook `useDensity()`** — sibling of `useNavLayout`. Persists to localStorage, cross-tab + same-tab sync via `storage` + `CustomEvent`, idempotent `data-density` attribute application on `<html>`.
- **New CSS section in `global.css`** — three tiers of spacing custom properties keyed off `[data-density=compact|cozy|comfortable]`. Consumers opt in with `.density-card` / `.density-rows`.
- **`Layout.tsx` boots `useDensity()`** — attribute is set before first paint so pages using `var(--density-…)` don't flash the default.
- **Settings.tsx** drops local `useState` + `readStored/writeStored` boilerplate in favour of the hook.

### 2. Assistant was canned, now queries the local server

The Assistant (⌘.) shipped with a pattern-matcher returning hardcoded strings (`"Slot L2-07 is the closest EV charger — 45m…"`). Genuinely useless beyond a demo.

**Fix**:
- **New module `lib/assistantReply.ts`** with `buildLiveReply(q)` — intent matcher routes questions to real API endpoints (`getUserCredits`, `getUserStats`, `getBookings`, `getVehicles`) and formats the response.
- **Intents**: `credits`, `next_booking`, `recent`, `stats`, `vehicles`. Unknown intents fall through with a prompt-tip listing what the helper can answer.
- **`Assistant.tsx`**: `reply` prop is now `(q: string) => string | Promise<string>` so live (async) and test (sync) flows go through the same code path via `Promise.resolve()`. Errors surface in-chat rather than crashing.
- **`defaultReply()`** kept as synchronous fallback for tests/Storybook.
- **Default suggestion chips** rewritten to match what the live builder answers: *"How many credits do I have?"*, *"What is my next booking?"*, *"Where did I park last?"*, *"Stats this month"*.

**On-prem claim stays intact** — every answer is synthesised from the local parkhub-server response, nothing leaves the box.

## Test plan
- [x] `npx vitest run` — **2075 passed** (+13 new tests: 6 density + 7 reply)
- [x] `npm run build` — clean
- [ ] CI
- [ ] Manual sanity — switch density in Settings, ask Assistant for credits

## Base
Based on `feat/nav-layouts-rail-dock-top` (#349). Merges cleanly after that lands.