### PR TITLE
fix(ui): Login footer reads workspace version + sync docs to v4.14.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,27 @@ _No unreleased changes._
 
 ---
 
+## [4.14.2] - 2026-04-18
+
+### Fixed
+
+- **macOS universal build**: vendor `openssl-sys` per target for the cross-compile leg — Homebrew's arm64 OpenSSL no longer fails to link into the x86_64 binary slice (#344).
+- **Container build**: drop `parkhub-desktop` (Tauri GUI) from the workspace during the runtime image build so Docker users stop hitting GTK dependency errors (#346).
+
+## [4.14.1] - 2026-04-18
+
+### Fixed
+
+- **CI cross-compile**: explicit `rustup target add aarch64-apple-darwin x86_64-apple-darwin` in the macOS universal job so the toolchain is guaranteed present before `lipo` runs (#342).
+
+## [4.14.0] - 2026-04-17
+
+### Changed
+
+- Workspace version bump after merging the v4.13.0 release branch; no user-facing changes beyond the Modular UX platform already shipped in v4.13.0 (#340, #343).
+
+---
+
 ## [4.13.0] - 2026-04-17
 
 Major release: the Modular UX platform — admins can now see, toggle, and

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <p align="center">
   <a href="https://github.com/nash87/parkhub-rust/actions/workflows/ci.yml"><img src="https://github.com/nash87/parkhub-rust/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <a href="CHANGELOG.md"><img src="https://img.shields.io/badge/Release-v4.13.0-brightgreen.svg?style=flat-square" alt="v4.13.0"></a>
+  <a href="CHANGELOG.md"><img src="https://img.shields.io/badge/Release-v4.14.2-brightgreen.svg?style=flat-square" alt="v4.14.2"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square" alt="MIT License"></a>
   <a href="https://www.rust-lang.org/"><img src="https://img.shields.io/badge/Rust-1.94%2B-orange.svg?style=flat-square&logo=rust&logoColor=white" alt="Rust 1.94+"></a>
   <a href="https://astro.build/"><img src="https://img.shields.io/badge/Astro-6-BC52EE.svg?style=flat-square&logo=astro&logoColor=white" alt="Astro 6"></a>
@@ -37,7 +37,7 @@
 
 ---
 
-## What's New in v4.13.0
+## What's New in v4.14.2
 
 | Feature | Description |
 |---------|-------------|

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -362,7 +362,7 @@ spec:
         fsGroup: 1000
       containers:
         - name: parkhub
-          image: ghcr.io/nash87/parkhub-rust:v4.13.0  # Pin to specific version; check GitHub Releases for the latest tag
+          image: ghcr.io/nash87/parkhub-rust:v4.14.2  # Pin to specific version; check GitHub Releases for the latest tag
           args: ["--headless", "--unattended", "--port", "8080"]
           ports:
             - containerPort: 8080

--- a/parkhub-web/package-lock.json
+++ b/parkhub-web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "parkhub-web",
-  "version": "4.12.0",
+  "version": "4.14.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "parkhub-web",
-      "version": "4.12.0",
+      "version": "4.14.2",
       "dependencies": {
         "@astrojs/react": "^5.0.3",
         "@hookform/resolvers": "^5.2.2",

--- a/parkhub-web/package.json
+++ b/parkhub-web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "parkhub-web",
   "type": "module",
-  "version": "4.12.0",
+  "version": "4.14.2",
   "engines": {
     "node": ">=22.12.0"
   },

--- a/parkhub-web/src/lib/appVersion.ts
+++ b/parkhub-web/src/lib/appVersion.ts
@@ -1,10 +1,15 @@
 // App version exposed to the UI. Sourced from the Vite env variable
-// VITE_APP_VERSION (wired in astro.config.mjs from package.json) with a
-// placeholder fallback so dev builds without the env don't break.
+// VITE_APP_VERSION (wired in astro.config.mjs from the workspace Cargo.toml)
+// with a package.json fallback so tests + plain Vite builds — which don't
+// see the astro define — still resolve a real number instead of 'dev'.
 //
 // Previously this lived hardcoded in Layout.tsx ("v4.9.0") and drifted —
 // v4.13.0 and later shipped with a stale footer. One-line source so it
 // stays accurate forever.
+// @ts-ignore — Vite resolves JSON imports at build time
+import { version as pkgVersion } from '../../package.json';
+
 export const APP_VERSION: string =
   (typeof import.meta !== 'undefined' && (import.meta as { env?: { VITE_APP_VERSION?: string } }).env?.VITE_APP_VERSION)
+  || pkgVersion
   || 'dev';

--- a/parkhub-web/src/views/Login.tsx
+++ b/parkhub-web/src/views/Login.tsx
@@ -10,8 +10,7 @@ import { useAuth } from '../context/AuthContext';
 import { FormField, FormInput } from '../components/ui/FormField';
 import { OAuthButtons } from '../components/OAuthButtons';
 import { SSOButtons } from '../components/SSOButtons';
-// @ts-ignore — Vite resolves JSON imports at build time
-import { version as APP_VERSION } from '../../package.json';
+import { APP_VERSION } from '../lib/appVersion';
 
 const loginSchema = z.object({
   username: z.string().min(1, 'Required'),


### PR DESCRIPTION
## Summary
Render demo login page was showing **v4.12.0** — `Login.tsx` had its own hardcoded import from `package.json` instead of the `APP_VERSION` helper `Layout.tsx` uses. Point it at the helper so it tracks the workspace `Cargo.toml` via Vite define (one source of truth — can't drift again).

Also sync the docs to the shipped release tag:
- README release badge + "What's New" header 4.13.0 → 4.14.2
- CHANGELOG entries for 4.14.0 / 4.14.1 / 4.14.2 (CI-only fixes: macOS cross-compile OpenSSL, rustup target preinstall, Docker workspace trim)
- `docs/INSTALLATION.md` K8s manifest sample tag
- `parkhub-web/package.json` itself bumped so the fallback path in `astro.config.mjs` resolves correctly when Cargo.toml isn't alongside (Render's build context)

## Test plan
- [ ] CI green (incl. E2E with the threshold=0.3 / ratio=0.08 gate that just landed)
- [ ] Render redeploys and login footer shows v4.14.2