### PR TITLE
ci(deploy): unblock Render demo deploy

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -116,7 +116,6 @@ jobs:
     needs: publish
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    environment: demo
     permissions: {}
     env:
       RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}


### PR DESCRIPTION
Mirrors parkhub-php #327 — the deploy-demo job's 'environment: demo' scope hid repo-level secrets, silently skipping every deploy on main pushes. Dropping it lets repo-level RENDER_API_KEY / RENDER_SERVICE_ID fire the Render deploy.