### PR TITLE
feat(ui): v5 theme-registry parity — Marble default, Void registered

### DIFF
--- a/parkhub-web/src/components/ThemeSwitcher.test.tsx
+++ b/parkhub-web/src/components/ThemeSwitcher.test.tsx
@@ -73,19 +73,17 @@ describe('ThemeSwitcher', () => {
     vi.restoreAllMocks();
   });
 
-  it('renders all 16 theme cards when open', () => {
+  it('renders all 18 theme cards when open (16 legacy + marble + void)', () => {
     render(
       <ThemeProvider>
         <ThemeSwitcher open={true} onClose={() => {}} />
       </ThemeProvider>,
     );
 
-    // Each theme card has an aria-label with theme name
     expect(screen.getByRole('dialog')).toBeTruthy();
     const buttons = screen.getAllByRole('button', { pressed: undefined });
-    // 16 theme cards + close button = 13 buttons
     const themeButtons = buttons.filter(b => b.getAttribute('aria-pressed') !== null);
-    expect(themeButtons).toHaveLength(16);
+    expect(themeButtons).toHaveLength(18);
   });
 
   it('does not render when closed', () => {
@@ -135,13 +133,17 @@ describe('ThemeSwitcher', () => {
       </ThemeProvider>,
     );
 
-    // Find the Neon theme card — it's a button with aria-pressed that contains "Neon" text
+    // Locate by rendered heading text (theme.name falls through the i18n mock)
+    // so this stays order-independent after marble + void were prepended
+    // as v5 flagships. Index-based lookup would silently click the wrong theme.
     const themeButtons = screen.getAllByRole('button').filter(
       b => b.getAttribute('aria-pressed') !== null
     );
-    // Neon is the 5th theme (index 4)
-    const neonCard = themeButtons[4];
-    await user.click(neonCard);
+    const neonCard = themeButtons.find(
+      b => b.querySelector('h3')?.textContent === 'Neon'
+    );
+    expect(neonCard).toBeDefined();
+    await user.click(neonCard!);
 
     expect(localStorageMock.setItem).toHaveBeenCalledWith('parkhub_design_theme', 'neon');
   });

--- a/parkhub-web/src/context/ThemeContext.test.tsx
+++ b/parkhub-web/src/context/ThemeContext.test.tsx
@@ -219,25 +219,25 @@ describe('ThemeContext', () => {
 
   // ── Design Theme Tests ──
 
-  it('defaults design theme to classic', () => {
+  it('defaults design theme to marble (v5 flagship)', () => {
     render(
       <ThemeProvider>
         <ThemeConsumer />
       </ThemeProvider>,
     );
 
-    expect(screen.getByTestId('design-theme').textContent).toBe('classic');
-    expect(screen.getByTestId('design-theme-name').textContent).toBe('Classic');
+    expect(screen.getByTestId('design-theme').textContent).toBe('marble');
+    expect(screen.getByTestId('design-theme-name').textContent).toBe('Marble');
   });
 
-  it('exposes all 16 design themes', () => {
+  it('exposes all 18 design themes (16 legacy + marble + void)', () => {
     render(
       <ThemeProvider>
         <ThemeConsumer />
       </ThemeProvider>,
     );
 
-    expect(screen.getByTestId('design-themes-count').textContent).toBe('16');
+    expect(screen.getByTestId('design-themes-count').textContent).toBe('18');
   });
 
   it('setDesignTheme changes the active design theme', async () => {
@@ -302,14 +302,14 @@ describe('ThemeContext', () => {
       </ThemeProvider>,
     );
 
-    // Initial
-    expect(document.documentElement.dataset.designTheme).toBe('classic');
+    // Initial — v5 flagship
+    expect(document.documentElement.dataset.designTheme).toBe('marble');
 
     await user.click(screen.getByTestId('set-brutalist'));
     expect(document.documentElement.dataset.designTheme).toBe('brutalist');
   });
 
-  it('falls back to classic for invalid localStorage design theme', () => {
+  it('falls back to marble for invalid localStorage design theme', () => {
     localStorageMock.setItem('parkhub_design_theme', 'invalid_theme');
 
     render(
@@ -318,7 +318,7 @@ describe('ThemeContext', () => {
       </ThemeProvider>,
     );
 
-    expect(screen.getByTestId('design-theme').textContent).toBe('classic');
+    expect(screen.getByTestId('design-theme').textContent).toBe('marble');
   });
 
   it('each DESIGN_THEMES entry has required fields', () => {
@@ -332,8 +332,10 @@ describe('ThemeContext', () => {
     }
   });
 
-  it('DESIGN_THEMES contains all 16 themes', () => {
+  it('DESIGN_THEMES contains all 18 themes (16 legacy + marble + void)', () => {
     const ids = DESIGN_THEMES.map(t => t.id);
+    expect(ids).toContain('marble');
+    expect(ids).toContain('void');
     expect(ids).toContain('classic');
     expect(ids).toContain('glass');
     expect(ids).toContain('bento');
@@ -346,10 +348,10 @@ describe('ThemeContext', () => {
     expect(ids).toContain('forest');
     expect(ids).toContain('synthwave');
     expect(ids).toContain('zen');
-    expect(ids).toHaveLength(16);
+    expect(ids).toHaveLength(18);
   });
 
-  it('can switch to all 16 design themes', async () => {
+  it('can switch to all 18 design themes', async () => {
     const user = userEvent.setup();
 
     render(

--- a/parkhub-web/src/context/ThemeContext.tsx
+++ b/parkhub-web/src/context/ThemeContext.tsx
@@ -7,7 +7,7 @@ type ColorMode = 'light' | 'dark' | 'system';
 
 // ── Design Themes ──
 
-export type DesignThemeId = 'classic' | 'glass' | 'bento' | 'brutalist' | 'neon' | 'warm' | 'liquid' | 'mono' | 'ocean' | 'forest' | 'synthwave' | 'zen' | 'aurora' | 'material' | 'sakura' | 'midnight';
+export type DesignThemeId = 'classic' | 'marble' | 'void' | 'glass' | 'bento' | 'brutalist' | 'neon' | 'warm' | 'liquid' | 'mono' | 'ocean' | 'forest' | 'synthwave' | 'zen' | 'aurora' | 'material' | 'sakura' | 'midnight';
 
 export interface DesignThemeInfo {
   id: DesignThemeId;
@@ -22,6 +22,26 @@ export interface DesignThemeInfo {
 }
 
 export const DESIGN_THEMES: DesignThemeInfo[] = [
+  {
+    id: 'marble',
+    name: 'Marble',
+    description: 'Editorial premium surface. Bright stone base, emerald accents, polished cards and spacious product framing.',
+    previewColors: {
+      light: ['#f7f5f1', '#fffdfa', '#14b8a6', '#111827', '#ded7cd'],
+      dark: ['#161a22', '#1f2937', '#34d399', '#f9fafb', '#374151'],
+    },
+    tags: ['editorial', 'premium', 'stone', 'v4'],
+  },
+  {
+    id: 'void',
+    name: 'Void',
+    description: 'Dark ops room. Inky canvas, cyan telemetry, cinematic contrast, and mission-control density.',
+    previewColors: {
+      light: ['#eef6ff', '#ffffff', '#0ea5e9', '#0f172a', '#dbeafe'],
+      dark: ['#020617', '#0f172a', '#22d3ee', '#e2e8f0', '#1e293b'],
+    },
+    tags: ['dark-first', 'ops', 'cinematic', 'v4'],
+  },
   {
     id: 'classic',
     name: 'Classic',
@@ -184,7 +204,9 @@ export const DESIGN_THEMES: DesignThemeInfo[] = [
   },
 ];
 
-const DEFAULT_DESIGN_THEME: DesignThemeId = 'classic';
+// v5 default: Marble is the flagship design (editorial premium surface,
+// OKLCH tokens, bento layouts). Void remains as the dark-first alternative.
+const DEFAULT_DESIGN_THEME: DesignThemeId = 'marble';
 
 // ── Context ──
 

--- a/parkhub-web/src/context/ThemeSwitching.test.tsx
+++ b/parkhub-web/src/context/ThemeSwitching.test.tsx
@@ -58,7 +58,7 @@ vi.mock('../api/client', () => ({
 import { ThemeProvider, useTheme, DESIGN_THEMES, type DesignThemeId } from './ThemeContext';
 
 const ALL_THEME_IDS: DesignThemeId[] = [
-  'classic', 'glass', 'bento', 'brutalist', 'neon', 'warm',
+  'classic', 'marble', 'void', 'glass', 'bento', 'brutalist', 'neon', 'warm',
   'liquid', 'mono', 'ocean', 'forest', 'synthwave', 'zen',
   'aurora', 'material', 'sakura', 'midnight',
 ];
@@ -95,8 +95,8 @@ describe('Theme Switching — Comprehensive Audit', () => {
   });
 
   describe('Design theme catalog integrity', () => {
-    it('exports exactly 16 themes', () => {
-      expect(DESIGN_THEMES).toHaveLength(16);
+    it('exports exactly 18 themes (16 legacy + marble + void v5 flagships)', () => {
+      expect(DESIGN_THEMES).toHaveLength(18);
     });
 
     it('has no duplicate theme IDs', () => {
@@ -244,10 +244,10 @@ describe('Theme Switching — Comprehensive Audit', () => {
       expect(localStorage.getItem('parkhub_design_theme')).toBe('classic');
     });
 
-    it('falls back to classic on corrupted localStorage', () => {
+    it('falls back to marble (v5 flagship default) on corrupted localStorage', () => {
       localStorage.setItem('parkhub_design_theme', 'garbage-not-a-theme');
       const { getState } = renderWithTheme();
-      expect(getState().designTheme).toBe('classic');
+      expect(getState().designTheme).toBe('marble');
     });
 
     it('currentDesignTheme falls back to first entry when designTheme is somehow unknown', () => {

--- a/parkhub-web/src/pages/index.astro
+++ b/parkhub-web/src/pages/index.astro
@@ -48,7 +48,7 @@ import '../styles/global.css';
       // Prevent FOUC: apply theme before React hydrates
       (function() {
         var t = localStorage.getItem('parkhub_theme') || 'system';
-        var d = localStorage.getItem('parkhub_design_theme') || 'classic';
+        var d = localStorage.getItem('parkhub_design_theme') || 'marble';
         var dark = t === 'dark' || (t === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches);
         if (dark) document.documentElement.classList.add('dark');
         document.documentElement.setAttribute('data-design-theme', d);

--- a/parkhub-web/src/styles/themes.css
+++ b/parkhub-web/src/styles/themes.css
@@ -4,6 +4,96 @@
    Themes support both light and dark mode variants.
    ═══════════════════════════════════════════════════════════════════════════════ */
 
+/* ── Theme: Marble (v5 flagship) ─────────────────────────────────────────────
+   Editorial premium surface. Bright stone base, emerald accents, polished
+   cards and spacious product framing. Default for fresh installs.
+   ──────────────────────────────────────────────────────────────────────────── */
+[data-design-theme="marble"] {
+  --dt-bg-primary: #f7f5f1;
+  --dt-bg-secondary: #fffdfa;
+  --dt-bg-card: rgba(255, 253, 250, 0.94);
+  --dt-text-primary: #1f2937;
+  --dt-text-secondary: #6b7280;
+  --dt-border: #ded7cd;
+  --dt-border-subtle: #ece6dd;
+  --dt-card-shadow: 0 20px 54px -36px rgba(17, 24, 39, 0.28);
+  --dt-card-radius: 28px;
+  --dt-sidebar-bg: rgba(255, 253, 250, 0.88);
+  --dt-sidebar-blur: 18px;
+  --dt-sidebar-border: rgba(148, 163, 184, 0.16);
+  --dt-accent-gradient: linear-gradient(135deg, #10b981, #14b8a6);
+  --dt-input-bg: rgba(255, 255, 255, 0.92);
+  --dt-input-border: #d6d3d1;
+  --dt-badge-radius: var(--radius-full);
+  --dt-nav-active-bg: rgba(16, 185, 129, 0.1);
+  --dt-nav-hover-bg: rgba(255, 255, 255, 0.86);
+  --dt-header-bg: rgba(255, 253, 250, 0.86);
+}
+
+[data-design-theme="marble"].dark,
+.dark [data-design-theme="marble"] {
+  --dt-bg-primary: #161a22;
+  --dt-bg-secondary: #1f2937;
+  --dt-bg-card: rgba(17, 24, 39, 0.88);
+  --dt-text-primary: #f9fafb;
+  --dt-text-secondary: #cbd5e1;
+  --dt-border: rgba(148, 163, 184, 0.18);
+  --dt-border-subtle: rgba(148, 163, 184, 0.1);
+  --dt-card-shadow: 0 24px 60px -40px rgba(0, 0, 0, 0.5);
+  --dt-sidebar-bg: rgba(17, 24, 39, 0.8);
+  --dt-sidebar-border: rgba(148, 163, 184, 0.16);
+  --dt-input-bg: rgba(15, 23, 42, 0.78);
+  --dt-input-border: rgba(148, 163, 184, 0.18);
+  --dt-nav-active-bg: rgba(20, 184, 166, 0.16);
+  --dt-nav-hover-bg: rgba(255, 255, 255, 0.04);
+  --dt-header-bg: rgba(17, 24, 39, 0.82);
+}
+
+/* ── Theme: Void ─────────────────────────────────────────────────────────────
+   Dark ops room. Inky canvas, cyan telemetry, cinematic contrast, and
+   mission-control density. Dark-first; light variant kept for parity.
+   ──────────────────────────────────────────────────────────────────────────── */
+[data-design-theme="void"] {
+  --dt-bg-primary: #eef6ff;
+  --dt-bg-secondary: #ffffff;
+  --dt-bg-card: rgba(255, 255, 255, 0.94);
+  --dt-text-primary: #0f172a;
+  --dt-text-secondary: #475569;
+  --dt-border: #dbeafe;
+  --dt-border-subtle: #e0f2fe;
+  --dt-card-shadow: 0 20px 54px -36px rgba(14, 165, 233, 0.22);
+  --dt-card-radius: 28px;
+  --dt-sidebar-bg: rgba(255, 255, 255, 0.82);
+  --dt-sidebar-blur: 20px;
+  --dt-sidebar-border: rgba(56, 189, 248, 0.12);
+  --dt-accent-gradient: linear-gradient(135deg, #0ea5e9, #22d3ee);
+  --dt-input-bg: rgba(255, 255, 255, 0.94);
+  --dt-input-border: #bfdbfe;
+  --dt-badge-radius: var(--radius-full);
+  --dt-nav-active-bg: rgba(14, 165, 233, 0.08);
+  --dt-nav-hover-bg: rgba(224, 242, 254, 0.78);
+  --dt-header-bg: rgba(255, 255, 255, 0.84);
+}
+
+[data-design-theme="void"].dark,
+.dark [data-design-theme="void"] {
+  --dt-bg-primary: #020617;
+  --dt-bg-secondary: #0f172a;
+  --dt-bg-card: rgba(15, 23, 42, 0.86);
+  --dt-text-primary: #e2e8f0;
+  --dt-text-secondary: #94a3b8;
+  --dt-border: rgba(34, 211, 238, 0.16);
+  --dt-border-subtle: rgba(34, 211, 238, 0.08);
+  --dt-card-shadow: 0 24px 72px -42px rgba(8, 47, 73, 0.72);
+  --dt-sidebar-bg: rgba(2, 6, 23, 0.92);
+  --dt-sidebar-border: rgba(34, 211, 238, 0.14);
+  --dt-input-bg: rgba(15, 23, 42, 0.72);
+  --dt-input-border: rgba(34, 211, 238, 0.16);
+  --dt-nav-active-bg: rgba(34, 211, 238, 0.14);
+  --dt-nav-hover-bg: rgba(30, 41, 59, 0.64);
+  --dt-header-bg: rgba(2, 6, 23, 0.9);
+}
+
 /* ── Theme: Classic ──────────────────────────────────────────────────────────
    Clean, professional. The original ParkHub look.
    ──────────────────────────────────────────────────────────────────────────── */


### PR DESCRIPTION
Follow-up to the v5 foundation. Brings parkhub-rust's ThemeContext to parity with parkhub-php so the rust demo actually lands on Marble as the default on fresh visits.

## Changes

- **Register marble + void** in DESIGN_THEMES array and DesignThemeId union (16 → 18 themes)
- **Add CSS blocks** for `[data-design-theme="marble"]` and `[data-design-theme="void"]` in themes.css — byte-identical with parkhub-php so shared surfaces render the same
- **Flip DEFAULT_DESIGN_THEME** from 'classic' to 'marble'
- **Pre-hydration script** in `pages/index.astro` flipped to 'marble' default — no classic flash on first paint

## Tests

2142/2142 pass. Updated expectations in:
- `ThemeContext.test.tsx` — default is marble, count is 18
- `ThemeSwitching.test.tsx` — catalog length 18, corrupt-fallback is marble
- `ThemeSwitcher.test.tsx` — 18 cards; theme-click test locates the target by rendered heading text (order-independent)

## Unblocks

After merge + Render deploy, `parkhub-rust-demo.onrender.com` will serve `parkhub_design_theme') || 'marble'` and the Marble bento shell renders on first load.