### PR TITLE
feat(ui): port Buchungen, Fahrzeuge, Credits to v5 (mirror of parkhub-php)

### DIFF
--- a/parkhub-web/src/design-v5/App.tsx
+++ b/parkhub-web/src/design-v5/App.tsx
@@ -8,6 +8,9 @@ import { V5CommandPalette } from './CommandPalette';
 import { V5AIPanel } from './AIPanel';
 import { breadcrumbFor, byId, type ScreenId } from './nav';
 import { DashboardV5 } from './screens/Dashboard';
+import { BuchungenV5 } from './screens/Buchungen';
+import { FahrzeugeV5 } from './screens/Fahrzeuge';
+import { CreditsV5 } from './screens/Credits';
 import { PlaceholderV5 } from './screens/Placeholder';
 
 import './fonts';
@@ -20,6 +23,9 @@ import './tokens.css';
  */
 const SCREENS: Partial<Record<ScreenId, ComponentType<{ navigate: (id: ScreenId) => void }>>> = {
   dashboard: DashboardV5,
+  buchungen: BuchungenV5,
+  fahrzeuge: FahrzeugeV5,
+  credits: CreditsV5,
 };
 
 const STORAGE_KEY = 'ph-v5-screen';

--- a/parkhub-web/src/design-v5/screens/Buchungen.test.tsx
+++ b/parkhub-web/src/design-v5/screens/Buchungen.test.tsx
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+const mockGetBookings = vi.fn();
+const mockCancelBooking = vi.fn();
+vi.mock('../../api/client', () => ({
+  api: {
+    getBookings: (...a: unknown[]) => mockGetBookings(...a),
+    cancelBooking: (...a: unknown[]) => mockCancelBooking(...a),
+  },
+}));
+
+vi.mock('@number-flow/react', () => ({
+  default: ({ value }: { value: number }) => <span>{value}</span>,
+}));
+
+const mockToast = vi.fn();
+vi.mock('../Toast', () => ({
+  useV5Toast: () => mockToast,
+  V5ToastProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+import { BuchungenV5 } from './Buchungen';
+
+function renderScreen(navigate = vi.fn()) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <BuchungenV5 navigate={navigate} />
+    </QueryClientProvider>
+  );
+}
+
+const BOOKING_ACTIVE = {
+  id: 'b-active-001',
+  user_id: 'u-1',
+  lot_id: 'l-1',
+  slot_id: 's-1',
+  lot_name: 'Parkhaus Nord',
+  slot_number: 'A3',
+  vehicle_plate: 'M-XY 999',
+  start_time: '2026-04-23T08:00:00Z',
+  end_time: '2026-04-23T18:00:00Z',
+  status: 'active' as const,
+};
+
+const BOOKING_CONFIRMED = { ...BOOKING_ACTIVE, id: 'b-conf-001', status: 'confirmed' as const };
+const BOOKING_DONE = { ...BOOKING_ACTIVE, id: 'b-done-001', status: 'completed' as const };
+
+describe('BuchungenV5', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('renders empty state with CTA when no bookings', async () => {
+    mockGetBookings.mockResolvedValue({ success: true, data: [] });
+    renderScreen();
+    await waitFor(() => expect(screen.getByText('Keine Buchungen gefunden')).toBeInTheDocument());
+    expect(screen.getByText('+ Platz buchen')).toBeInTheDocument();
+  });
+
+  it('renders error state when query fails', async () => {
+    mockGetBookings.mockRejectedValue(new Error('network'));
+    renderScreen();
+    await waitFor(() => expect(screen.getByText('Fehler beim Laden')).toBeInTheDocument());
+  });
+
+  it('renders booking rows with lot, plate and status badge', async () => {
+    mockGetBookings.mockResolvedValue({ success: true, data: [BOOKING_ACTIVE] });
+    renderScreen();
+    await waitFor(() => expect(screen.getByText('Parkhaus Nord')).toBeInTheDocument());
+    expect(screen.getByText('M-XY 999')).toBeInTheDocument();
+    // "Aktiv" also appears as a filter chip — check the count matches a badge + chip
+    expect(screen.getAllByText('Aktiv')).toHaveLength(2);
+  });
+
+  it('filters rows by status when a chip is activated', async () => {
+    mockGetBookings.mockResolvedValue({ success: true, data: [BOOKING_ACTIVE, BOOKING_DONE] });
+    renderScreen();
+    await waitFor(() => expect(screen.getAllByTestId('buchungen-row')).toHaveLength(2));
+    fireEvent.click(screen.getByRole('button', { name: 'Abgeschlossen' }));
+    await waitFor(() => expect(screen.getAllByTestId('buchungen-row')).toHaveLength(1));
+    expect(screen.getByRole('button', { name: 'Abgeschlossen' })).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('Storno button calls cancelBooking + toast', async () => {
+    mockGetBookings.mockResolvedValue({ success: true, data: [BOOKING_CONFIRMED] });
+    mockCancelBooking.mockResolvedValue({ success: true, data: null });
+    renderScreen();
+    await waitFor(() => expect(screen.getByText('Storno')).toBeInTheDocument());
+    fireEvent.click(screen.getByText('Storno'));
+    await waitFor(() => {
+      expect(mockCancelBooking).toHaveBeenCalledWith('b-conf-001');
+      expect(mockToast).toHaveBeenCalledWith('Buchung storniert', 'success');
+    });
+  });
+
+  it('Check-in button navigates and emits toast on active booking', async () => {
+    const navigate = vi.fn();
+    mockGetBookings.mockResolvedValue({ success: true, data: [BOOKING_ACTIVE] });
+    renderScreen(navigate);
+    await waitFor(() => expect(screen.getByText('Check-in')).toBeInTheDocument());
+    fireEvent.click(screen.getByText('Check-in'));
+    expect(navigate).toHaveBeenCalledWith('einchecken');
+    expect(mockToast).toHaveBeenCalledWith('Einchecken geöffnet', 'info');
+  });
+});

--- a/parkhub-web/src/design-v5/screens/Buchungen.test.tsx
+++ b/parkhub-web/src/design-v5/screens/Buchungen.test.tsx
@@ -103,4 +103,23 @@ describe('BuchungenV5', () => {
     expect(navigate).toHaveBeenCalledWith('einchecken');
     expect(mockToast).toHaveBeenCalledWith('Einchecken geöffnet', 'info');
   });
+
+  it('surfaces query error when success:false', async () => {
+    mockGetBookings.mockResolvedValue({ success: false, data: null, error: { code: 'FORBIDDEN', message: 'denied' } });
+    renderScreen();
+    await waitFor(() => expect(screen.getByText('Fehler beim Laden')).toBeInTheDocument());
+  });
+
+  it('calls onError (no success toast) when cancel mutation responds success:false', async () => {
+    mockGetBookings.mockResolvedValue({ success: true, data: [BOOKING_CONFIRMED] });
+    mockCancelBooking.mockResolvedValue({ success: false, data: null, error: { code: 'CONFLICT', message: 'already cancelled' } });
+    renderScreen();
+    await waitFor(() => expect(screen.getByText('Storno')).toBeInTheDocument());
+    fireEvent.click(screen.getByText('Storno'));
+    await waitFor(() => {
+      expect(mockCancelBooking).toHaveBeenCalledWith('b-conf-001');
+      expect(mockToast).toHaveBeenCalledWith('Stornierung fehlgeschlagen', 'error');
+    });
+    expect(mockToast).not.toHaveBeenCalledWith('Buchung storniert', 'success');
+  });
 });

--- a/parkhub-web/src/design-v5/screens/Buchungen.tsx
+++ b/parkhub-web/src/design-v5/screens/Buchungen.tsx
@@ -55,6 +55,7 @@ export function BuchungenV5({ navigate }: { navigate: (id: ScreenId) => void }) 
     queryKey: ['buchungen'],
     queryFn: async () => {
       const res = await api.getBookings();
+      if (!res.success) throw new Error(res.error?.message ?? 'Buchungen konnten nicht geladen werden');
       return res.data ?? [];
     },
     staleTime: 30_000,
@@ -62,7 +63,11 @@ export function BuchungenV5({ navigate }: { navigate: (id: ScreenId) => void }) 
   });
 
   const cancelMutation = useMutation({
-    mutationFn: (id: string) => api.cancelBooking(id),
+    mutationFn: async (id: string) => {
+      const res = await api.cancelBooking(id);
+      if (!res.success) throw new Error(res.error?.message ?? 'Stornierung fehlgeschlagen');
+      return res.data;
+    },
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ['buchungen'] });
       toast('Buchung storniert', 'success');

--- a/parkhub-web/src/design-v5/screens/Buchungen.tsx
+++ b/parkhub-web/src/design-v5/screens/Buchungen.tsx
@@ -1,0 +1,257 @@
+import NumberFlow from '@number-flow/react';
+import { useState } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { Badge, Card, V5NamedIcon } from '../primitives';
+import { useV5Toast } from '../Toast';
+import { api, type Booking } from '../../api/client';
+import type { ScreenId } from '../nav';
+
+type FilterKey = 'alle' | 'active' | 'confirmed' | 'completed' | 'cancelled';
+
+const FILTERS: { key: FilterKey; label: string }[] = [
+  { key: 'alle', label: 'Alle' },
+  { key: 'active', label: 'Aktiv' },
+  { key: 'confirmed', label: 'Bestätigt' },
+  { key: 'completed', label: 'Abgeschlossen' },
+  { key: 'cancelled', label: 'Storniert' },
+];
+
+type BadgeVariant = 'primary' | 'success' | 'warning' | 'error' | 'info' | 'gray' | 'ev' | 'purple';
+
+function statusVariant(s: Booking['status']): BadgeVariant {
+  switch (s) {
+    case 'active': return 'success';
+    case 'confirmed': return 'primary';
+    case 'completed': return 'gray';
+    case 'cancelled': return 'error';
+    default: return 'gray';
+  }
+}
+
+const STATUS_LABEL: Record<Booking['status'], string> = {
+  active: 'Aktiv',
+  confirmed: 'Bestätigt',
+  completed: 'Abgeschlossen',
+  cancelled: 'Storniert',
+};
+
+function formatDateTime(iso: string): string {
+  return new Date(iso).toLocaleString('de-DE', {
+    day: '2-digit', month: '2-digit', year: 'numeric',
+    hour: '2-digit', minute: '2-digit',
+  });
+}
+
+function formatTime(iso: string): string {
+  return new Date(iso).toLocaleTimeString('de-DE', { hour: '2-digit', minute: '2-digit' });
+}
+
+export function BuchungenV5({ navigate }: { navigate: (id: ScreenId) => void }) {
+  const toast = useV5Toast();
+  const qc = useQueryClient();
+  const [filter, setFilter] = useState<FilterKey>('alle');
+
+  const { data: bookings = [], isLoading, isError } = useQuery({
+    queryKey: ['buchungen'],
+    queryFn: async () => {
+      const res = await api.getBookings();
+      return res.data ?? [];
+    },
+    staleTime: 30_000,
+    refetchOnWindowFocus: true,
+  });
+
+  const cancelMutation = useMutation({
+    mutationFn: (id: string) => api.cancelBooking(id),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['buchungen'] });
+      toast('Buchung storniert', 'success');
+    },
+    onError: () => toast('Stornierung fehlgeschlagen', 'error'),
+  });
+
+  const filtered = filter === 'alle' ? bookings : bookings.filter((b) => b.status === filter);
+
+  if (isLoading) {
+    return (
+      <div style={{ padding: 16, flex: 1, overflow: 'auto' }}>
+        <div style={{ height: 32, width: 220, borderRadius: 8, background: 'var(--v5-sur2)', marginBottom: 14, animation: 'ph-v5-pulse 1.6s ease infinite' }} />
+        {[0, 1, 2].map((i) => (
+          <div key={i} style={{ height: 60, borderRadius: 12, background: 'var(--v5-sur2)', marginBottom: 8, animation: 'ph-v5-pulse 1.6s ease infinite', animationDelay: `${i * 0.1}s` }} />
+        ))}
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div style={{ padding: 16, flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+        <Card className="v5-ani" style={{ padding: 28, textAlign: 'center', maxWidth: 360 }}>
+          <V5NamedIcon name="x" size={26} color="var(--v5-err)" />
+          <div style={{ marginTop: 10, fontWeight: 600, color: 'var(--v5-txt)' }}>Fehler beim Laden</div>
+          <div style={{ fontSize: 12, color: 'var(--v5-mut)', marginTop: 4 }}>Buchungen konnten nicht geladen werden.</div>
+        </Card>
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ padding: 16, flex: 1, overflow: 'auto', display: 'flex', flexDirection: 'column', gap: 12 }}>
+      <div className="v5-ani" style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <span style={{ fontWeight: 700, fontSize: 15, color: 'var(--v5-txt)' }}>Buchungen</span>
+          <Badge variant="gray"><NumberFlow value={filtered.length} /></Badge>
+        </div>
+        <button
+          type="button"
+          onClick={() => navigate('buchen')}
+          className="v5-btn"
+          style={{ padding: '7px 14px', borderRadius: 9, background: 'var(--v5-acc)', color: 'var(--v5-accent-fg)', border: 'none', fontSize: 11, fontWeight: 600, cursor: 'pointer', display: 'flex', alignItems: 'center', gap: 5 }}
+        >
+          <V5NamedIcon name="plus" size={12} />
+          Platz buchen
+        </button>
+      </div>
+
+      <div
+        className="v5-ani"
+        role="group"
+        aria-label="Status-Filter"
+        style={{ display: 'flex', gap: 6, flexWrap: 'wrap', animationDelay: '0.06s' }}
+      >
+        {FILTERS.map((f) => {
+          const active = filter === f.key;
+          return (
+            <button
+              key={f.key}
+              type="button"
+              aria-pressed={active}
+              onClick={() => setFilter(f.key)}
+              style={{
+                padding: '5px 12px',
+                borderRadius: 999,
+                fontSize: 11,
+                fontWeight: 500,
+                cursor: 'pointer',
+                border: `1.5px solid ${active ? 'var(--v5-acc)' : 'var(--v5-bor)'}`,
+                background: active ? 'var(--v5-acc-muted)' : 'transparent',
+                color: active ? 'var(--v5-acc)' : 'var(--v5-mut)',
+                transition: 'all 0.15s',
+              }}
+            >
+              {f.label}
+            </button>
+          );
+        })}
+      </div>
+
+      {filtered.length === 0 ? (
+        <Card
+          className="v5-ani"
+          style={{ padding: 36, display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 10, animationDelay: '0.12s' }}
+        >
+          <div style={{ width: 48, height: 48, borderRadius: 14, background: 'var(--v5-acc-muted)', border: '1.5px dashed color-mix(in oklch, var(--v5-acc) 50%, transparent)', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+            <V5NamedIcon name="cal" size={20} color="var(--v5-acc)" />
+          </div>
+          <div style={{ textAlign: 'center' }}>
+            <div style={{ fontWeight: 600, color: 'var(--v5-txt)', fontSize: 13 }}>Keine Buchungen gefunden</div>
+            <div style={{ fontSize: 11, color: 'var(--v5-mut)', marginTop: 3 }}>
+              {filter === 'alle' ? 'Reservieren Sie jetzt einen Parkplatz.' : `Keine Buchungen mit Status „${FILTERS.find((f) => f.key === filter)?.label}".`}
+            </div>
+          </div>
+          {filter === 'alle' && (
+            <button type="button" onClick={() => navigate('buchen')} className="v5-btn" style={{ padding: '8px 16px', borderRadius: 9, background: 'var(--v5-acc)', color: 'var(--v5-accent-fg)', border: 'none', fontSize: 11, fontWeight: 600, cursor: 'pointer' }}>
+              + Platz buchen
+            </button>
+          )}
+        </Card>
+      ) : (
+        <Card className="v5-ani" style={{ overflow: 'hidden', animationDelay: '0.12s' }}>
+          <div
+            className="v5-mono"
+            style={{
+              display: 'grid',
+              gridTemplateColumns: '90px 1fr 100px 150px 90px 110px 100px',
+              padding: '8px 16px',
+              fontSize: 9,
+              letterSpacing: 1.2,
+              textTransform: 'uppercase',
+              color: 'var(--v5-mut)',
+              borderBottom: '1px solid var(--v5-bor)',
+            }}
+          >
+            <span>ID</span>
+            <span>Stellplatz</span>
+            <span>Kennz.</span>
+            <span>Datum / Zeit</span>
+            <span>Typ</span>
+            <span>Status</span>
+            <span>Aktionen</span>
+          </div>
+          {filtered.map((b, i) => {
+            const isActive = b.status === 'active';
+            const isCancellable = isActive || b.status === 'confirmed';
+            const isCancellingThis = cancelMutation.isPending && cancelMutation.variables === b.id;
+            return (
+              <div
+                key={b.id}
+                data-testid="buchungen-row"
+                className="v5-row"
+                style={{
+                  display: 'grid',
+                  gridTemplateColumns: '90px 1fr 100px 150px 90px 110px 100px',
+                  padding: '10px 16px',
+                  borderBottom: i < filtered.length - 1 ? '1px solid var(--v5-bor)' : 'none',
+                  alignItems: 'center',
+                  gap: 4,
+                }}
+              >
+                <span className="v5-mono" style={{ fontSize: 10, color: 'var(--v5-mut)' }} title={b.id}>
+                  {b.id.slice(0, 8)}…
+                </span>
+                <div>
+                  <div style={{ fontSize: 12, fontWeight: 500, color: 'var(--v5-txt)' }}>{b.lot_name ?? '—'}</div>
+                  <div style={{ fontSize: 10, color: 'var(--v5-mut)' }}>Platz {b.slot_number ?? '?'}</div>
+                </div>
+                <span className="v5-mono" style={{ fontSize: 11, color: 'var(--v5-txt)', fontWeight: 500 }}>
+                  {b.vehicle_plate ?? '—'}
+                </span>
+                <div>
+                  <div style={{ fontSize: 11, color: 'var(--v5-txt)' }}>{formatDateTime(b.start_time)}</div>
+                  <div style={{ fontSize: 10, color: 'var(--v5-mut)' }}>– {formatTime(b.end_time)}</div>
+                </div>
+                <span style={{ fontSize: 11, color: 'var(--v5-mut)' }}>{b.booking_type ?? 'Standard'}</span>
+                <Badge variant={statusVariant(b.status)} dot>{STATUS_LABEL[b.status] ?? b.status}</Badge>
+                <div style={{ display: 'flex', gap: 5, alignItems: 'center' }}>
+                  {isActive && (
+                    <button
+                      type="button"
+                      onClick={() => {
+                        navigate('einchecken');
+                        toast('Einchecken geöffnet', 'info');
+                      }}
+                      style={{ padding: '3px 8px', borderRadius: 6, background: 'var(--v5-acc-muted)', border: 'none', fontSize: 10, color: 'var(--v5-acc)', cursor: 'pointer', fontWeight: 500 }}
+                    >
+                      Check-in
+                    </button>
+                  )}
+                  {isCancellable && (
+                    <button
+                      type="button"
+                      disabled={isCancellingThis}
+                      aria-label={`Buchung ${b.id} stornieren`}
+                      onClick={() => cancelMutation.mutate(b.id)}
+                      style={{ padding: '3px 8px', borderRadius: 6, background: 'color-mix(in oklch, var(--v5-err) 8%, transparent)', border: 'none', fontSize: 10, color: 'var(--v5-err)', cursor: isCancellingThis ? 'default' : 'pointer', opacity: isCancellingThis ? 0.5 : 1, fontWeight: 500 }}
+                    >
+                      {isCancellingThis ? '…' : 'Storno'}
+                    </button>
+                  )}
+                </div>
+              </div>
+            );
+          })}
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/parkhub-web/src/design-v5/screens/Credits.test.tsx
+++ b/parkhub-web/src/design-v5/screens/Credits.test.tsx
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+const mockGetUserCredits = vi.fn();
+const mockCreateCheckout = vi.fn();
+
+vi.mock('../../api/client', () => ({
+  api: {
+    getUserCredits: (...a: unknown[]) => mockGetUserCredits(...a),
+    createCheckout: (...a: unknown[]) => mockCreateCheckout(...a),
+  },
+}));
+
+vi.mock('@number-flow/react', () => ({
+  default: ({ value }: { value: number }) => <span>{value}</span>,
+}));
+
+const mockToast = vi.fn();
+vi.mock('../Toast', () => ({
+  useV5Toast: () => mockToast,
+  V5ToastProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+import { CreditsV5 } from './Credits';
+
+function renderScreen(navigate = vi.fn()) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <CreditsV5 navigate={navigate} />
+    </QueryClientProvider>
+  );
+}
+
+const CREDITS = {
+  enabled: true,
+  balance: 7,
+  monthly_quota: 10,
+  last_refilled: '2026-04-01T00:00:00Z',
+  transactions: [
+    { id: 'tx-1', amount: 10, type: 'monthly_refill' as const, description: undefined, created_at: '2026-04-01T00:00:00Z' },
+    { id: 'tx-2', amount: -1, type: 'deduction' as const, description: 'Buchung BK-123', created_at: '2026-04-05T00:00:00Z' },
+    { id: 'tx-3', amount: -2, type: 'deduction' as const, description: undefined, created_at: '2026-04-10T00:00:00Z' },
+  ],
+};
+
+describe('CreditsV5', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.defineProperty(window, 'location', { writable: true, value: { href: '' } });
+  });
+
+  it('renders error state when query fails', async () => {
+    mockGetUserCredits.mockRejectedValue(new Error('network'));
+    renderScreen();
+    await waitFor(() => expect(screen.getByText('Fehler beim Laden')).toBeInTheDocument());
+  });
+
+  it('renders hero balance + stat cards', async () => {
+    mockGetUserCredits.mockResolvedValue({ success: true, data: CREDITS });
+    renderScreen();
+    await waitFor(() => expect(screen.getByText('Monatl. Kontingent')).toBeInTheDocument());
+    expect(screen.getByText('Verbraucht')).toBeInTheDocument();
+    expect(screen.getByText('Letzte Aufladung')).toBeInTheDocument();
+  });
+
+  it('renders transactions with correct sign prefix', async () => {
+    mockGetUserCredits.mockResolvedValue({ success: true, data: CREDITS });
+    renderScreen();
+    await waitFor(() => expect(screen.getByText('Monatliche Aufladung')).toBeInTheDocument());
+    expect(screen.getByText('+10')).toBeInTheDocument();
+    expect(screen.getByText('-1')).toBeInTheDocument();
+    expect(screen.getByText('-2')).toBeInTheDocument();
+  });
+
+  it('renders empty transactions state', async () => {
+    mockGetUserCredits.mockResolvedValue({ success: true, data: { ...CREDITS, transactions: [] } });
+    renderScreen();
+    await waitFor(() => expect(screen.getByText('Keine Transaktionen')).toBeInTheDocument());
+  });
+
+  it('buy button triggers createCheckout + redirect', async () => {
+    mockGetUserCredits.mockResolvedValue({ success: true, data: CREDITS });
+    mockCreateCheckout.mockResolvedValue({
+      success: true,
+      data: { id: 'cs_1', checkout_url: 'https://checkout.stripe.com/test', amount: 10, credits: 10, currency: 'EUR' },
+    });
+    renderScreen();
+    await waitFor(() => screen.getByText('+ Credits kaufen'));
+    fireEvent.click(screen.getByText('+ Credits kaufen'));
+    await waitFor(() => {
+      expect(mockCreateCheckout).toHaveBeenCalledWith(10);
+      expect(mockToast).toHaveBeenCalledWith('Weiterleitung zur Kasse…', 'info');
+    });
+  });
+
+  it('meter has ARIA valuenow/valuemin/valuemax', async () => {
+    mockGetUserCredits.mockResolvedValue({ success: true, data: CREDITS });
+    renderScreen();
+    await waitFor(() => {
+      const meter = screen.getByRole('meter');
+      expect(meter).toHaveAttribute('aria-valuenow', '7');
+      expect(meter).toHaveAttribute('aria-valuemin', '0');
+      expect(meter).toHaveAttribute('aria-valuemax', '10');
+    });
+  });
+});

--- a/parkhub-web/src/design-v5/screens/Credits.test.tsx
+++ b/parkhub-web/src/design-v5/screens/Credits.test.tsx
@@ -105,4 +105,24 @@ describe('CreditsV5', () => {
       expect(meter).toHaveAttribute('aria-valuemax', '10');
     });
   });
+
+  it('surfaces query error when success:false', async () => {
+    mockGetUserCredits.mockResolvedValue({ success: false, data: null, error: { code: 'FORBIDDEN', message: 'denied' } });
+    renderScreen();
+    await waitFor(() => expect(screen.getByText('Fehler beim Laden')).toBeInTheDocument());
+  });
+
+  it('calls onError (no redirect) when createCheckout responds success:false', async () => {
+    mockGetUserCredits.mockResolvedValue({ success: true, data: CREDITS });
+    mockCreateCheckout.mockResolvedValue({ success: false, data: null, error: { code: 'STRIPE', message: 'provider down' } });
+    renderScreen();
+    await waitFor(() => screen.getByText('+ Credits kaufen'));
+    fireEvent.click(screen.getByText('+ Credits kaufen'));
+    await waitFor(() => {
+      expect(mockCreateCheckout).toHaveBeenCalledWith(10);
+      expect(mockToast).toHaveBeenCalledWith('Credits kaufen fehlgeschlagen', 'error');
+    });
+    expect(mockToast).not.toHaveBeenCalledWith('Weiterleitung zur Kasse…', 'info');
+    expect(window.location.href).toBe('');
+  });
 });

--- a/parkhub-web/src/design-v5/screens/Credits.tsx
+++ b/parkhub-web/src/design-v5/screens/Credits.tsx
@@ -1,0 +1,186 @@
+import NumberFlow from '@number-flow/react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { Card, Row, SectionLabel, StatCard, V5NamedIcon } from '../primitives';
+import { useV5Toast } from '../Toast';
+import { api, type CreditTransaction } from '../../api/client';
+import type { ScreenId } from '../nav';
+
+const TX_TYPE_LABEL: Record<CreditTransaction['type'], string> = {
+  grant: 'Gutschrift',
+  deduction: 'Abbuchung',
+  refund: 'Rückerstattung',
+  monthly_refill: 'Monatliche Aufladung',
+};
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString('de-DE', { day: '2-digit', month: '2-digit', year: 'numeric' });
+}
+
+export function CreditsV5({ navigate: _navigate }: { navigate: (id: ScreenId) => void }) {
+  const toast = useV5Toast();
+  const qc = useQueryClient();
+
+  const { data: credits, isLoading, isError } = useQuery({
+    queryKey: ['credits'],
+    queryFn: async () => {
+      const res = await api.getUserCredits();
+      return res.data;
+    },
+    staleTime: 30_000,
+    refetchOnWindowFocus: true,
+  });
+
+  const buyMutation = useMutation({
+    mutationFn: () => api.createCheckout(10),
+    onSuccess: (res) => {
+      if (res.data?.checkout_url) {
+        toast('Weiterleitung zur Kasse…', 'info');
+        window.location.href = res.data.checkout_url;
+      } else {
+        toast('Keine Checkout-URL erhalten', 'error');
+      }
+      qc.invalidateQueries({ queryKey: ['credits'] });
+    },
+    onError: () => toast('Credits kaufen fehlgeschlagen', 'error'),
+  });
+
+  if (isLoading) {
+    return (
+      <div style={{ padding: 16, flex: 1, overflow: 'auto', display: 'flex', flexDirection: 'column', gap: 12 }}>
+        {[240, 90, 200].map((h, i) => (
+          <div key={i} style={{ height: h, borderRadius: 14, background: 'var(--v5-sur2)', animation: 'ph-v5-pulse 1.6s ease infinite', animationDelay: `${i * 0.1}s` }} />
+        ))}
+      </div>
+    );
+  }
+
+  if (isError || !credits) {
+    return (
+      <div style={{ padding: 16, flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+        <Card className="v5-ani" style={{ padding: 28, textAlign: 'center', maxWidth: 360 }}>
+          <V5NamedIcon name="x" size={26} color="var(--v5-err)" />
+          <div style={{ marginTop: 10, fontWeight: 600, color: 'var(--v5-txt)' }}>Fehler beim Laden</div>
+          <div style={{ fontSize: 12, color: 'var(--v5-mut)', marginTop: 4 }}>Credits konnten nicht geladen werden.</div>
+        </Card>
+      </div>
+    );
+  }
+
+  const balance = credits.balance;
+  const quota = credits.monthly_quota;
+  const used = Math.max(0, quota - balance);
+  const pct = quota > 0 ? Math.round((balance / quota) * 100) : 0;
+  const txs = credits.transactions ?? [];
+
+  return (
+    <div style={{ padding: 16, flex: 1, overflow: 'auto', display: 'flex', flexDirection: 'column', gap: 12 }}>
+      <Card
+        className="v5-ani"
+        style={{
+          padding: 22,
+          background: 'linear-gradient(145deg, var(--v5-acc-muted), transparent)',
+          border: '1px solid color-mix(in oklch, var(--v5-acc) 30%, transparent)',
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 12,
+        }}
+      >
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: 12 }}>
+          <div>
+            <SectionLabel>Credits</SectionLabel>
+            <div
+              className="v5-mono"
+              style={{ fontSize: 44, fontWeight: 800, color: 'var(--v5-acc)', letterSpacing: -2, lineHeight: 1 }}
+            >
+              <NumberFlow value={balance} />
+            </div>
+            <div style={{ fontSize: 11, color: 'var(--v5-mut)', marginTop: 4 }}>
+              von {quota} · {credits.last_refilled ? `Zuletzt aufgeladen ${formatDate(credits.last_refilled)}` : 'kein Ablauf'}
+            </div>
+          </div>
+          <button
+            type="button"
+            disabled={buyMutation.isPending}
+            onClick={() => buyMutation.mutate()}
+            className="v5-btn"
+            style={{
+              padding: '9px 18px',
+              borderRadius: 10,
+              background: 'var(--v5-acc)',
+              color: 'var(--v5-accent-fg)',
+              border: 'none',
+              fontSize: 12,
+              fontWeight: 600,
+              cursor: buyMutation.isPending ? 'default' : 'pointer',
+              opacity: buyMutation.isPending ? 0.7 : 1,
+              whiteSpace: 'nowrap',
+            }}
+          >
+            {buyMutation.isPending ? 'Weiterleitung…' : '+ Credits kaufen'}
+          </button>
+        </div>
+        <div>
+          <div
+            style={{ height: 4, background: 'color-mix(in oklch, var(--v5-acc) 18%, transparent)', borderRadius: 4 }}
+            aria-label={`${balance} von ${quota} Credits`}
+            role="meter"
+            aria-valuenow={balance}
+            aria-valuemin={0}
+            aria-valuemax={Math.max(quota, balance)}
+          >
+            <div style={{ height: '100%', width: `${Math.min(100, pct)}%`, background: 'var(--v5-acc)', borderRadius: 4, transition: 'width 0.8s ease' }} />
+          </div>
+          <div style={{ display: 'flex', justifyContent: 'space-between', marginTop: 4, fontSize: 10, color: 'var(--v5-mut)' }}>
+            <span>{pct}% verbleibend</span>
+            <span>{used} verwendet</span>
+          </div>
+        </div>
+      </Card>
+
+      <div className="v5-ani" style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 10, animationDelay: '0.06s' }}>
+        <StatCard label="Monatl. Kontingent" value={<NumberFlow value={quota} />} icon="credit" delay={0} />
+        <StatCard label="Verbraucht" value={<NumberFlow value={used} />} icon="trend" delay={0.06} />
+        <StatCard
+          label="Letzte Aufladung"
+          value={credits.last_refilled ? formatDate(credits.last_refilled) : '—'}
+          icon="cal"
+          delay={0.12}
+        />
+      </div>
+
+      <Card className="v5-ani" style={{ overflow: 'hidden', animationDelay: '0.12s' }}>
+        <div style={{ padding: '12px 18px 8px' }}>
+          <SectionLabel>Transaktionen</SectionLabel>
+        </div>
+        {txs.length === 0 ? (
+          <div style={{ padding: '28px 18px', display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 8 }}>
+            <V5NamedIcon name="list" size={24} color="var(--v5-mut)" />
+            <div style={{ fontSize: 12, color: 'var(--v5-mut)' }}>Keine Transaktionen</div>
+          </div>
+        ) : (
+          txs.map((tx, i) => {
+            const positive = tx.amount > 0;
+            const label = TX_TYPE_LABEL[tx.type] ?? tx.type;
+            return (
+              <Row
+                key={tx.id}
+                label={label}
+                sub={tx.description ?? formatDate(tx.created_at)}
+                last={i === txs.length - 1}
+              >
+                <div style={{ textAlign: 'right' }}>
+                  <div
+                    className="v5-mono"
+                    style={{ fontSize: 13, fontWeight: 700, color: positive ? 'var(--v5-ok)' : 'var(--v5-err)' }}
+                  >
+                    {positive ? '+' : ''}{tx.amount}
+                  </div>
+                </div>
+              </Row>
+            );
+          })
+        )}
+      </Card>
+    </div>
+  );
+}

--- a/parkhub-web/src/design-v5/screens/Credits.tsx
+++ b/parkhub-web/src/design-v5/screens/Credits.tsx
@@ -24,6 +24,7 @@ export function CreditsV5({ navigate: _navigate }: { navigate: (id: ScreenId) =>
     queryKey: ['credits'],
     queryFn: async () => {
       const res = await api.getUserCredits();
+      if (!res.success) throw new Error(res.error?.message ?? 'Credits konnten nicht geladen werden');
       return res.data;
     },
     staleTime: 30_000,
@@ -31,11 +32,15 @@ export function CreditsV5({ navigate: _navigate }: { navigate: (id: ScreenId) =>
   });
 
   const buyMutation = useMutation({
-    mutationFn: () => api.createCheckout(10),
-    onSuccess: (res) => {
-      if (res.data?.checkout_url) {
+    mutationFn: async () => {
+      const res = await api.createCheckout(10);
+      if (!res.success) throw new Error(res.error?.message ?? 'Credits kaufen fehlgeschlagen');
+      return res.data;
+    },
+    onSuccess: (data) => {
+      if (data?.checkout_url) {
         toast('Weiterleitung zur Kasse…', 'info');
-        window.location.href = res.data.checkout_url;
+        window.location.href = data.checkout_url;
       } else {
         toast('Keine Checkout-URL erhalten', 'error');
       }

--- a/parkhub-web/src/design-v5/screens/Fahrzeuge.test.tsx
+++ b/parkhub-web/src/design-v5/screens/Fahrzeuge.test.tsx
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+const mockGetVehicles = vi.fn();
+const mockCreateVehicle = vi.fn();
+const mockDeleteVehicle = vi.fn();
+
+vi.mock('../../api/client', () => ({
+  api: {
+    getVehicles: (...a: unknown[]) => mockGetVehicles(...a),
+    createVehicle: (...a: unknown[]) => mockCreateVehicle(...a),
+    deleteVehicle: (...a: unknown[]) => mockDeleteVehicle(...a),
+  },
+}));
+
+const mockToast = vi.fn();
+vi.mock('../Toast', () => ({
+  useV5Toast: () => mockToast,
+  V5ToastProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+import { FahrzeugeV5 } from './Fahrzeuge';
+
+function renderScreen(navigate = vi.fn()) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <FahrzeugeV5 navigate={navigate} />
+    </QueryClientProvider>
+  );
+}
+
+const VEHICLE_BMW = {
+  id: 'v-001',
+  plate: 'M-AB 123',
+  make: 'BMW',
+  model: '3er',
+  color: 'blue',
+  is_default: true,
+};
+const VEHICLE_EV = {
+  id: 'v-002',
+  plate: 'M-EV 001',
+  make: 'Tesla',
+  model: 'Model 3',
+  color: 'white',
+  is_default: false,
+};
+
+describe('FahrzeugeV5', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('renders empty state with CTA', async () => {
+    mockGetVehicles.mockResolvedValue({ success: true, data: [] });
+    renderScreen();
+    await waitFor(() => expect(screen.getByText('Noch keine Fahrzeuge')).toBeInTheDocument());
+    expect(screen.getByText('+ Fahrzeug hinzufügen')).toBeInTheDocument();
+  });
+
+  it('renders vehicle card with Standard badge', async () => {
+    mockGetVehicles.mockResolvedValue({ success: true, data: [VEHICLE_BMW] });
+    renderScreen();
+    await waitFor(() => expect(screen.getByText('M-AB 123')).toBeInTheDocument());
+    expect(screen.getByText('BMW 3er')).toBeInTheDocument();
+    expect(screen.getByText('Standard')).toBeInTheDocument();
+  });
+
+  it('renders EV badge for Tesla vehicles', async () => {
+    mockGetVehicles.mockResolvedValue({ success: true, data: [VEHICLE_EV] });
+    renderScreen();
+    await waitFor(() => expect(screen.getByText('M-EV 001')).toBeInTheDocument());
+    expect(screen.getByText('EV')).toBeInTheDocument();
+  });
+
+  it('opens add modal on Hinzufügen click', async () => {
+    mockGetVehicles.mockResolvedValue({ success: true, data: [] });
+    renderScreen();
+    await waitFor(() => screen.getByText('Noch keine Fahrzeuge'));
+    fireEvent.click(screen.getAllByText(/Hinzufügen|hinzufügen/).pop()!);
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+  });
+
+  it('createVehicle fires on Speichern with plate + toast success', async () => {
+    mockGetVehicles.mockResolvedValue({ success: true, data: [] });
+    mockCreateVehicle.mockResolvedValue({ success: true, data: VEHICLE_BMW });
+    renderScreen();
+    await waitFor(() => screen.getByText('Noch keine Fahrzeuge'));
+    fireEvent.click(screen.getAllByText(/Hinzufügen|hinzufügen/).pop()!);
+    fireEvent.change(screen.getByPlaceholderText('M-AB 1234'), { target: { value: 'M-AB 123' } });
+    fireEvent.click(screen.getByText('Speichern'));
+    await waitFor(() => {
+      expect(mockCreateVehicle).toHaveBeenCalledWith(expect.objectContaining({ plate: 'M-AB 123' }));
+      expect(mockToast).toHaveBeenCalledWith('Fahrzeug hinzugefügt', 'success');
+    });
+  });
+
+  it('deleteVehicle fires + toast on delete click', async () => {
+    mockGetVehicles.mockResolvedValue({ success: true, data: [VEHICLE_BMW] });
+    mockDeleteVehicle.mockResolvedValue({ success: true, data: null });
+    renderScreen();
+    await waitFor(() => screen.getByText('M-AB 123'));
+    fireEvent.click(screen.getByLabelText('Fahrzeug M-AB 123 löschen'));
+    await waitFor(() => {
+      expect(mockDeleteVehicle).toHaveBeenCalledWith('v-001');
+      expect(mockToast).toHaveBeenCalledWith('Fahrzeug entfernt', 'success');
+    });
+  });
+});

--- a/parkhub-web/src/design-v5/screens/Fahrzeuge.test.tsx
+++ b/parkhub-web/src/design-v5/screens/Fahrzeuge.test.tsx
@@ -106,4 +106,38 @@ describe('FahrzeugeV5', () => {
       expect(mockToast).toHaveBeenCalledWith('Fahrzeug entfernt', 'success');
     });
   });
+
+  it('surfaces query error when success:false', async () => {
+    mockGetVehicles.mockResolvedValue({ success: false, data: null, error: { code: 'FORBIDDEN', message: 'denied' } });
+    renderScreen();
+    await waitFor(() => expect(screen.getByText('Fehler beim Laden')).toBeInTheDocument());
+  });
+
+  it('calls onError (no success toast) when createVehicle responds success:false', async () => {
+    mockGetVehicles.mockResolvedValue({ success: true, data: [] });
+    mockCreateVehicle.mockResolvedValue({ success: false, data: null, error: { code: 'VALIDATION', message: 'invalid plate' } });
+    renderScreen();
+    await waitFor(() => screen.getByText('Noch keine Fahrzeuge'));
+    fireEvent.click(screen.getAllByText(/Hinzufügen|hinzufügen/).pop()!);
+    fireEvent.change(screen.getByPlaceholderText('M-AB 1234'), { target: { value: 'M-AB 123' } });
+    fireEvent.click(screen.getByText('Speichern'));
+    await waitFor(() => {
+      expect(mockCreateVehicle).toHaveBeenCalled();
+      expect(mockToast).toHaveBeenCalledWith('Hinzufügen fehlgeschlagen', 'error');
+    });
+    expect(mockToast).not.toHaveBeenCalledWith('Fahrzeug hinzugefügt', 'success');
+  });
+
+  it('calls onError (no success toast) when deleteVehicle responds success:false', async () => {
+    mockGetVehicles.mockResolvedValue({ success: true, data: [VEHICLE_BMW] });
+    mockDeleteVehicle.mockResolvedValue({ success: false, data: null, error: { code: 'NOT_FOUND', message: 'gone' } });
+    renderScreen();
+    await waitFor(() => screen.getByText('M-AB 123'));
+    fireEvent.click(screen.getByLabelText('Fahrzeug M-AB 123 löschen'));
+    await waitFor(() => {
+      expect(mockDeleteVehicle).toHaveBeenCalledWith('v-001');
+      expect(mockToast).toHaveBeenCalledWith('Löschen fehlgeschlagen', 'error');
+    });
+    expect(mockToast).not.toHaveBeenCalledWith('Fahrzeug entfernt', 'success');
+  });
 });

--- a/parkhub-web/src/design-v5/screens/Fahrzeuge.tsx
+++ b/parkhub-web/src/design-v5/screens/Fahrzeuge.tsx
@@ -1,0 +1,320 @@
+import { useState, type CSSProperties, type ReactNode } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { Badge, Card, V5NamedIcon } from '../primitives';
+import { useV5Toast } from '../Toast';
+import { api, type Vehicle, type CreateVehiclePayload } from '../../api/client';
+import type { ScreenId } from '../nav';
+
+const COLOR_SWATCH: Record<string, string> = {
+  black: 'oklch(0.15 0 0)',
+  white: 'oklch(0.99 0 0)',
+  silver: 'oklch(0.72 0 0)',
+  gray: 'oklch(0.55 0 0)',
+  blue: 'oklch(0.52 0.18 255)',
+  red: 'oklch(0.52 0.22 25)',
+  green: 'oklch(0.55 0.17 160)',
+  brown: 'oklch(0.42 0.10 55)',
+  beige: 'oklch(0.82 0.06 80)',
+  other: 'oklch(0.60 0 0)',
+};
+
+const COLOR_DEFS: { key: string; label: string }[] = [
+  { key: 'black', label: 'Schwarz' },
+  { key: 'white', label: 'Weiß' },
+  { key: 'silver', label: 'Silber' },
+  { key: 'gray', label: 'Grau' },
+  { key: 'blue', label: 'Blau' },
+  { key: 'red', label: 'Rot' },
+  { key: 'green', label: 'Grün' },
+  { key: 'brown', label: 'Braun' },
+  { key: 'beige', label: 'Beige' },
+  { key: 'other', label: 'Sonstiges' },
+];
+
+const EMPTY_FORM: CreateVehiclePayload = { plate: '', make: '', model: '', color: '' };
+
+function isEvVehicle(v: Vehicle): boolean {
+  const mm = `${v.make ?? ''} ${v.model ?? ''}`.toLowerCase();
+  return /tesla|electric|e-tron|ioniq|id\.|taycan|leaf|bolt|ev/.test(mm);
+}
+
+const inputStyle: CSSProperties = {
+  padding: '8px 11px',
+  borderRadius: 9,
+  background: 'var(--v5-sur2)',
+  border: '1px solid var(--v5-bor)',
+  color: 'var(--v5-txt)',
+  fontSize: 12,
+  width: '100%',
+  outline: 'none',
+  boxSizing: 'border-box',
+  fontFamily: 'inherit',
+};
+
+function Field({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+      <label style={{ fontSize: 11, fontWeight: 500, color: 'var(--v5-mut)' }}>{label}</label>
+      {children}
+    </div>
+  );
+}
+
+function AddVehicleModal({
+  onClose,
+  onAdd,
+  isAdding,
+}: {
+  onClose: () => void;
+  onAdd: (payload: CreateVehiclePayload) => void;
+  isAdding: boolean;
+}) {
+  const [form, setForm] = useState<CreateVehiclePayload>(EMPTY_FORM);
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="Fahrzeug hinzufügen"
+      style={{ position: 'fixed', inset: 0, zIndex: 1000, display: 'flex', alignItems: 'center', justifyContent: 'center', padding: 16 }}
+    >
+      <div
+        aria-hidden="true"
+        onClick={onClose}
+        style={{ position: 'absolute', inset: 0, background: 'oklch(0 0 0 / 0.45)', backdropFilter: 'blur(6px)' }}
+      />
+      <Card
+        lift={false}
+        style={{ position: 'relative', width: '100%', maxWidth: 420, padding: 22, display: 'flex', flexDirection: 'column', gap: 14, zIndex: 1 }}
+      >
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+          <div style={{ fontWeight: 700, fontSize: 14, color: 'var(--v5-txt)' }}>Fahrzeug hinzufügen</div>
+          <button
+            type="button"
+            aria-label="Schließen"
+            onClick={onClose}
+            style={{ width: 28, height: 28, borderRadius: 8, background: 'var(--v5-sur2)', border: 'none', cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center' }}
+          >
+            <V5NamedIcon name="x" size={13} color="var(--v5-mut)" />
+          </button>
+        </div>
+        <Field label="Kennzeichen *">
+          <input
+            type="text"
+            value={form.plate}
+            onChange={(e) => setForm({ ...form, plate: e.target.value.toUpperCase() })}
+            placeholder="M-AB 1234"
+            autoFocus
+            style={inputStyle}
+          />
+        </Field>
+        <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 10 }}>
+          <Field label="Marke">
+            <input type="text" value={form.make ?? ''} onChange={(e) => setForm({ ...form, make: e.target.value })} placeholder="BMW" style={inputStyle} />
+          </Field>
+          <Field label="Modell">
+            <input type="text" value={form.model ?? ''} onChange={(e) => setForm({ ...form, model: e.target.value })} placeholder="3er" style={inputStyle} />
+          </Field>
+        </div>
+        <Field label="Farbe">
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: 7, marginTop: 4 }}>
+            {COLOR_DEFS.map((c) => {
+              const selected = form.color === c.key;
+              return (
+                <button
+                  key={c.key}
+                  type="button"
+                  aria-label={c.label}
+                  aria-pressed={selected}
+                  onClick={() => setForm({ ...form, color: selected ? '' : c.key })}
+                  style={{
+                    width: 26,
+                    height: 26,
+                    borderRadius: '50%',
+                    background: COLOR_SWATCH[c.key] ?? 'var(--v5-mut)',
+                    border: selected ? '2.5px solid var(--v5-acc)' : '1.5px solid var(--v5-bor)',
+                    cursor: 'pointer',
+                    transform: selected ? 'scale(1.15)' : 'scale(1)',
+                    transition: 'transform 0.12s, border 0.12s',
+                    outline: 'none',
+                    boxSizing: 'border-box',
+                    padding: 0,
+                  }}
+                />
+              );
+            })}
+          </div>
+        </Field>
+        <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8, paddingTop: 4 }}>
+          <button
+            type="button"
+            onClick={onClose}
+            style={{ padding: '8px 14px', borderRadius: 9, background: 'transparent', border: '1px solid var(--v5-bor)', color: 'var(--v5-mut)', fontSize: 12, cursor: 'pointer' }}
+          >
+            Abbrechen
+          </button>
+          <button
+            type="button"
+            disabled={isAdding || !form.plate.trim()}
+            onClick={() => onAdd(form)}
+            style={{
+              padding: '8px 16px',
+              borderRadius: 9,
+              background: 'var(--v5-acc)',
+              color: 'var(--v5-accent-fg)',
+              border: 'none',
+              fontSize: 12,
+              fontWeight: 600,
+              cursor: isAdding || !form.plate.trim() ? 'default' : 'pointer',
+              opacity: !form.plate.trim() ? 0.5 : 1,
+            }}
+          >
+            {isAdding ? 'Speichern…' : 'Speichern'}
+          </button>
+        </div>
+      </Card>
+    </div>
+  );
+}
+
+export function FahrzeugeV5({ navigate: _navigate }: { navigate: (id: ScreenId) => void }) {
+  const toast = useV5Toast();
+  const qc = useQueryClient();
+  const [showAdd, setShowAdd] = useState(false);
+
+  const { data: vehicles = [], isLoading, isError } = useQuery({
+    queryKey: ['fahrzeuge'],
+    queryFn: async () => {
+      const res = await api.getVehicles();
+      return res.data ?? [];
+    },
+    staleTime: 30_000,
+    refetchOnWindowFocus: true,
+  });
+
+  const addMutation = useMutation({
+    mutationFn: (payload: CreateVehiclePayload) => api.createVehicle(payload),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['fahrzeuge'] });
+      toast('Fahrzeug hinzugefügt', 'success');
+      setShowAdd(false);
+    },
+    onError: () => toast('Hinzufügen fehlgeschlagen', 'error'),
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (id: string) => api.deleteVehicle(id),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['fahrzeuge'] });
+      toast('Fahrzeug entfernt', 'success');
+    },
+    onError: () => toast('Löschen fehlgeschlagen', 'error'),
+  });
+
+  if (isLoading) {
+    return (
+      <div style={{ padding: 16, flex: 1, overflow: 'auto', display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(220px, 1fr))', gap: 10, alignContent: 'start' }}>
+        {[0, 1, 2, 3].map((i) => (
+          <div key={i} style={{ height: 110, borderRadius: 14, background: 'var(--v5-sur2)', animation: 'ph-v5-pulse 1.6s ease infinite', animationDelay: `${i * 0.08}s` }} />
+        ))}
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div style={{ padding: 16, flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+        <Card className="v5-ani" style={{ padding: 28, textAlign: 'center', maxWidth: 360 }}>
+          <V5NamedIcon name="x" size={26} color="var(--v5-err)" />
+          <div style={{ marginTop: 10, fontWeight: 600, color: 'var(--v5-txt)' }}>Fehler beim Laden</div>
+          <div style={{ fontSize: 12, color: 'var(--v5-mut)', marginTop: 4 }}>Fahrzeuge konnten nicht geladen werden.</div>
+        </Card>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <div style={{ padding: 16, flex: 1, overflow: 'auto', display: 'flex', flexDirection: 'column', gap: 12 }}>
+        <div className="v5-ani" style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+          <span style={{ fontWeight: 700, fontSize: 15, color: 'var(--v5-txt)' }}>Meine Fahrzeuge</span>
+          <button
+            type="button"
+            onClick={() => setShowAdd(true)}
+            className="v5-btn"
+            style={{ padding: '7px 14px', borderRadius: 9, background: 'var(--v5-acc)', color: 'var(--v5-accent-fg)', border: 'none', fontSize: 11, fontWeight: 600, cursor: 'pointer', display: 'flex', alignItems: 'center', gap: 5 }}
+          >
+            <V5NamedIcon name="plus" size={12} />
+            Hinzufügen
+          </button>
+        </div>
+        {vehicles.length === 0 ? (
+          <Card className="v5-ani" style={{ padding: 40, display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 12, animationDelay: '0.06s' }}>
+            <div style={{ width: 52, height: 52, borderRadius: 16, background: 'var(--v5-acc-muted)', border: '1.5px dashed color-mix(in oklch, var(--v5-acc) 50%, transparent)', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+              <V5NamedIcon name="car" size={22} color="var(--v5-acc)" />
+            </div>
+            <div style={{ textAlign: 'center' }}>
+              <div style={{ fontWeight: 600, color: 'var(--v5-txt)', fontSize: 13 }}>Noch keine Fahrzeuge</div>
+              <div style={{ fontSize: 11, color: 'var(--v5-mut)', marginTop: 3 }}>Fügen Sie Ihr erstes Fahrzeug hinzu.</div>
+            </div>
+            <button type="button" onClick={() => setShowAdd(true)} className="v5-btn" style={{ padding: '8px 16px', borderRadius: 9, background: 'var(--v5-acc)', color: 'var(--v5-accent-fg)', border: 'none', fontSize: 11, fontWeight: 600, cursor: 'pointer' }}>
+              + Fahrzeug hinzufügen
+            </button>
+          </Card>
+        ) : (
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(220px, 1fr))', gap: 10 }}>
+            {vehicles.map((v, i) => {
+              const ev = isEvVehicle(v);
+              const swatch = v.color ? (COLOR_SWATCH[v.color] ?? 'var(--v5-mut)') : undefined;
+              return (
+                <Card
+                  key={v.id}
+                  data-testid="fahrzeug-card"
+                  className="v5-ani"
+                  style={{ padding: '14px 16px', display: 'flex', flexDirection: 'column', gap: 10, animationDelay: `${i * 0.06}s` }}
+                >
+                  <div style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between' }}>
+                    <div>
+                      <div className="v5-mono" style={{ fontSize: 18, fontWeight: 700, color: 'var(--v5-txt)', letterSpacing: 1 }}>{v.plate}</div>
+                      {(v.make || v.model) && (
+                        <div style={{ fontSize: 11, color: 'var(--v5-mut)', marginTop: 2 }}>
+                          {[v.make, v.model].filter(Boolean).join(' ')}
+                        </div>
+                      )}
+                    </div>
+                    <button
+                      type="button"
+                      aria-label={`Fahrzeug ${v.plate} löschen`}
+                      onClick={() => deleteMutation.mutate(v.id)}
+                      disabled={deleteMutation.isPending}
+                      style={{ width: 28, height: 28, borderRadius: 8, background: 'transparent', border: '1px solid var(--v5-bor)', cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center' }}
+                    >
+                      <V5NamedIcon name="x" size={12} color="var(--v5-err)" />
+                    </button>
+                  </div>
+                  <div style={{ display: 'flex', gap: 6, alignItems: 'center', flexWrap: 'wrap' }}>
+                    {swatch && (
+                      <span
+                        aria-hidden="true"
+                        style={{ width: 12, height: 12, borderRadius: '50%', background: swatch, border: '1px solid var(--v5-bor)', display: 'inline-block', flexShrink: 0 }}
+                      />
+                    )}
+                    {v.color && <span style={{ fontSize: 10, color: 'var(--v5-mut)' }}>{COLOR_DEFS.find((c) => c.key === v.color)?.label ?? v.color}</span>}
+                    {ev && <Badge variant="ev">EV</Badge>}
+                    {v.is_default && <Badge variant="primary">Standard</Badge>}
+                  </div>
+                </Card>
+              );
+            })}
+          </div>
+        )}
+      </div>
+      {showAdd && (
+        <AddVehicleModal
+          onClose={() => setShowAdd(false)}
+          onAdd={(payload) => addMutation.mutate(payload)}
+          isAdding={addMutation.isPending}
+        />
+      )}
+    </>
+  );
+}

--- a/parkhub-web/src/design-v5/screens/Fahrzeuge.tsx
+++ b/parkhub-web/src/design-v5/screens/Fahrzeuge.tsx
@@ -185,6 +185,7 @@ export function FahrzeugeV5({ navigate: _navigate }: { navigate: (id: ScreenId) 
     queryKey: ['fahrzeuge'],
     queryFn: async () => {
       const res = await api.getVehicles();
+      if (!res.success) throw new Error(res.error?.message ?? 'Fahrzeuge konnten nicht geladen werden');
       return res.data ?? [];
     },
     staleTime: 30_000,
@@ -192,7 +193,11 @@ export function FahrzeugeV5({ navigate: _navigate }: { navigate: (id: ScreenId) 
   });
 
   const addMutation = useMutation({
-    mutationFn: (payload: CreateVehiclePayload) => api.createVehicle(payload),
+    mutationFn: async (payload: CreateVehiclePayload) => {
+      const res = await api.createVehicle(payload);
+      if (!res.success) throw new Error(res.error?.message ?? 'Fahrzeug hinzufügen fehlgeschlagen');
+      return res.data;
+    },
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ['fahrzeuge'] });
       toast('Fahrzeug hinzugefügt', 'success');
@@ -202,7 +207,11 @@ export function FahrzeugeV5({ navigate: _navigate }: { navigate: (id: ScreenId) 
   });
 
   const deleteMutation = useMutation({
-    mutationFn: (id: string) => api.deleteVehicle(id),
+    mutationFn: async (id: string) => {
+      const res = await api.deleteVehicle(id);
+      if (!res.success) throw new Error(res.error?.message ?? 'Fahrzeug löschen fehlgeschlagen');
+      return res.data;
+    },
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ['fahrzeuge'] });
       toast('Fahrzeug entfernt', 'success');


### PR DESCRIPTION
Byte-identical mirror of the parkhub-php first-wave screen ports.

Establishes the TanStack Query + v5-primitives pattern every remaining screen port on rust will follow.

- **Buchungen** — filter chips + grid table + Check-in/Storno + toasts
- **Fahrzeuge** — card grid + Add modal + EV badge + delete  
- **Credits** — hero balance + progress meter + transaction list + Stripe redirect

+18 tests across 3 spec files. Total suite: **2160/2160 passing**.