### PR TITLE
feat(v5): Wave 3 — port 7 Fleet screens (parity with PHP #333)

### DIFF
--- a/parkhub-web/src/api/client.ts
+++ b/parkhub-web/src/api/client.ts
@@ -1408,6 +1408,16 @@ export interface CheckInStatus {
   checked_out_at: string | null;
 }
 
+/**
+ * Guest booking payload returned by `GET /api/v1/bookings/guest`.
+ *
+ * The `status` union mirrors the Rust backend's `BookingStatus` enum
+ * (`parkhub-common::models::BookingStatus`) which is serialised as the full
+ * snake_case set. In particular, newly created passes land in `confirmed`
+ * (see `parkhub-server::api::guest::create_guest_booking`) and only flip to
+ * `active` once the booking window opens, so clients MUST accept the full
+ * set to render and act on fresh records.
+ */
 export interface GuestBooking {
   id: string;
   lot_id: string;
@@ -1419,7 +1429,14 @@ export interface GuestBooking {
   guest_code: string;
   start_time: string;
   end_time: string;
-  status: 'active' | 'expired' | 'cancelled';
+  status:
+    | 'pending'
+    | 'confirmed'
+    | 'active'
+    | 'completed'
+    | 'expired'
+    | 'cancelled'
+    | 'no_show';
   created_at: string;
 }
 

--- a/parkhub-web/src/api/client.ts
+++ b/parkhub-web/src/api/client.ts
@@ -596,6 +596,62 @@ export const api = {
     }),
   getWidgetData: (widgetId: string) =>
     request<WidgetDataResponse>(`/api/v1/admin/widgets/data/${widgetId}`),
+
+  // ── Team / Fleet (v5 Wave 3) ──
+  getTeam: () => request<TeamMember[]>('/api/v1/team'),
+  getAdminStatsExtended: () => request<AdminStatsExtended>('/api/v1/admin/stats'),
+
+  // ── EV Chargers (v5 Wave 3) ──
+  getLotChargers: (lotId: string) => request<EvCharger[]>(`/api/v1/lots/${lotId}/chargers`),
+  getChargerSessions: () => request<ChargingSession[]>('/api/v1/chargers/sessions'),
+  startCharging: (chargerId: string) =>
+    request<void>(`/api/v1/chargers/${chargerId}/start`, { method: 'POST', body: JSON.stringify({}) }),
+  stopCharging: (chargerId: string) =>
+    request<void>(`/api/v1/chargers/${chargerId}/stop`, { method: 'POST' }),
+
+  // ── Swap Requests (v5 Wave 3) ──
+  // Rust backend uses `PUT /api/v1/swap-requests/{id}` with `{action}` body,
+  // not separate POST /accept and /decline endpoints like PHP. The client
+  // method signatures stay identical so the screens remain byte-identical
+  // with the PHP mirror — only the URL shape below diverges.
+  getSwapRequests: () => request<SwapRequest[]>('/api/v1/swap-requests'),
+  acceptSwap: (id: string) =>
+    request<void>(`/api/v1/swap-requests/${id}`, {
+      method: 'PUT',
+      body: JSON.stringify({ action: 'accept' }),
+    }),
+  declineSwap: (id: string) =>
+    request<void>(`/api/v1/swap-requests/${id}`, {
+      method: 'PUT',
+      body: JSON.stringify({ action: 'decline' }),
+    }),
+  createSwapRequest: (sourceBookingId: string, targetBookingId: string, message: string | null) =>
+    request<SwapRequest>(`/api/v1/bookings/${sourceBookingId}/swap-request`, {
+      method: 'POST',
+      body: JSON.stringify({ target_booking_id: targetBookingId, message }),
+    }),
+
+  // ── Check-in (v5 Wave 3) ──
+  // Rust backend exposes `POST /api/v1/bookings/{id}/checkin` (no dash);
+  // the separate `GET …/check-in` status probe and `POST …/check-out` are
+  // PHP-only surfaces that still resolve via the 404 fallback path in the
+  // screen. Method signatures stay identical for parity.
+  getCheckInStatus: (bookingId: string) =>
+    request<CheckInStatus>(`/api/v1/bookings/${bookingId}/check-in`),
+  checkIn: (bookingId: string) =>
+    request<void>(`/api/v1/bookings/${bookingId}/checkin`, { method: 'POST' }),
+  checkOut: (bookingId: string) =>
+    request<void>(`/api/v1/bookings/${bookingId}/check-out`, { method: 'POST' }),
+
+  // ── Guest Passes (v5 Wave 3) ──
+  // `DELETE …/bookings/guest/{id}` is PHP-only today; rust ships only the
+  // admin PATCH cancel. We keep the user-side signature for parity and let
+  // the 404 surface as a toast until the rust handler lands.
+  getGuestBookings: () => request<GuestBooking[]>('/api/v1/bookings/guest'),
+  createGuestBooking: (data: CreateGuestBookingPayload) =>
+    request<GuestBooking>('/api/v1/bookings/guest', { method: 'POST', body: JSON.stringify(data) }),
+  cancelGuestBooking: (id: string) =>
+    request<void>(`/api/v1/bookings/guest/${id}`, { method: 'DELETE' }),
 };
 
 // ── Types ──
@@ -1260,4 +1316,118 @@ export interface WidgetDataResponse {
   widget_type: string;
   title: string;
   data: Record<string, unknown>;
+}
+
+// ── v5 Wave 3: Fleet ──
+
+export interface TeamMember {
+  id: string;
+  username: string;
+  name: string;
+  role: string;
+}
+
+export interface UserBookingStats {
+  total: number;
+  this_month: number;
+  ev_count: number;
+  morning_count: number;
+  swaps_accepted: number;
+  no_shows: number;
+  avg_duration_hours: number;
+}
+
+export interface DayOccupancy {
+  avg_percentage: number;
+  peak_hour: number;
+  peak_percentage: number;
+  bookings: number;
+}
+
+/**
+ * Runtime-extended shape of `GET /api/v1/admin/stats`. The base
+ * {@link AdminStats} interface only declares the guaranteed fields, while
+ * the Wave 3 Fleet screens (Rangliste, Vorhersagen) consume optional
+ * aggregates that the backend returns opportunistically.
+ */
+export interface AdminStatsExtended extends AdminStats {
+  ev_bookings?: number;
+  morning_bookings?: number;
+  swap_requests_accepted?: number;
+  no_shows?: number;
+  bookings_by_user?: Record<string, UserBookingStats>;
+  occupancy_by_day?: Record<string, DayOccupancy>;
+  occupancy_by_hour?: Record<string, number>;
+}
+
+export type ChargerConnector = 'type2' | 'ccs' | 'chademo' | 'tesla';
+export type ChargerStatus = 'available' | 'in_use' | 'offline' | 'maintenance';
+
+export interface EvCharger {
+  id: string;
+  lot_id: string;
+  label: string;
+  connector_type: ChargerConnector;
+  power_kw: number;
+  status: ChargerStatus;
+  location_hint: string | null;
+}
+
+export interface ChargingSession {
+  id: string;
+  charger_id: string;
+  user_id: string;
+  start_time: string;
+  end_time: string | null;
+  kwh_consumed: number;
+  status: 'active' | 'completed' | 'cancelled';
+}
+
+export interface SwapBookingSummary {
+  lot_name: string;
+  slot_number: string;
+  start_time: string;
+  end_time: string;
+}
+
+export interface SwapRequest {
+  id: string;
+  requester_id: string;
+  source_booking_id: string;
+  target_booking_id: string;
+  source_booking: SwapBookingSummary;
+  target_booking: SwapBookingSummary;
+  message: string | null;
+  status: 'pending' | 'accepted' | 'declined';
+  created_at: string;
+}
+
+export interface CheckInStatus {
+  checked_in: boolean;
+  checked_in_at: string | null;
+  checked_out_at: string | null;
+}
+
+export interface GuestBooking {
+  id: string;
+  lot_id: string;
+  lot_name: string;
+  slot_id: string;
+  slot_number: string;
+  guest_name: string;
+  guest_email: string | null;
+  guest_code: string;
+  start_time: string;
+  end_time: string;
+  status: 'active' | 'expired' | 'cancelled';
+  created_at: string;
+}
+
+export interface CreateGuestBookingPayload {
+  lot_id: string;
+  slot_id: string;
+  start_time: string;
+  end_time: string;
+  guest_name: string;
+  guest_email: string | null;
 }

--- a/parkhub-web/src/design-v5/App.tsx
+++ b/parkhub-web/src/design-v5/App.tsx
@@ -15,6 +15,13 @@ import { KalenderV5 } from './screens/Kalender';
 import { KarteV5 } from './screens/Karte';
 import { CreditsV5 } from './screens/Credits';
 import { ProfilV5 } from './screens/Profil';
+import { TeamV5 } from './screens/Team';
+import { RanglisteV5 } from './screens/Rangliste';
+import { EVV5 } from './screens/EV';
+import { TauschV5 } from './screens/Tausch';
+import { EincheckenV5 } from './screens/Einchecken';
+import { VorhersagenV5 } from './screens/Vorhersagen';
+import { GaestepassV5 } from './screens/Gaestepass';
 import { PlaceholderV5 } from './screens/Placeholder';
 
 import './fonts';
@@ -34,6 +41,13 @@ const SCREENS: Partial<Record<ScreenId, ComponentType<{ navigate: (id: ScreenId)
   karte: KarteV5,
   credits: CreditsV5,
   profil: ProfilV5,
+  team: TeamV5,
+  rangliste: RanglisteV5,
+  ev: EVV5,
+  tausch: TauschV5,
+  einchecken: EincheckenV5,
+  vorhersagen: VorhersagenV5,
+  gaestepass: GaestepassV5,
 };
 
 const STORAGE_KEY = 'ph-v5-screen';

--- a/parkhub-web/src/design-v5/primitives/index.tsx
+++ b/parkhub-web/src/design-v5/primitives/index.tsx
@@ -111,6 +111,7 @@ export function Card({
   lift = true,
   as: Tag = 'div',
   onClick,
+  'data-testid': dataTestid,
 }: {
   children: ReactNode;
   style?: CSSProperties;
@@ -118,10 +119,12 @@ export function Card({
   lift?: boolean;
   as?: 'div' | 'button' | 'a';
   onClick?: () => void;
+  'data-testid'?: string;
 }) {
   return (
     <Tag
       onClick={onClick}
+      data-testid={dataTestid}
       className={`${lift ? 'v5-lift' : ''} ${className}`.trim()}
       style={{
         background: 'var(--v5-sur)',

--- a/parkhub-web/src/design-v5/screens/EV.test.tsx
+++ b/parkhub-web/src/design-v5/screens/EV.test.tsx
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+const mockGetLots = vi.fn();
+const mockGetChargers = vi.fn();
+const mockGetSessions = vi.fn();
+const mockStart = vi.fn();
+const mockStop = vi.fn();
+
+vi.mock('../../api/client', () => ({
+  api: {
+    getLots: (...a: unknown[]) => mockGetLots(...a),
+    getLotChargers: (...a: unknown[]) => mockGetChargers(...a),
+    getChargerSessions: (...a: unknown[]) => mockGetSessions(...a),
+    startCharging: (...a: unknown[]) => mockStart(...a),
+    stopCharging: (...a: unknown[]) => mockStop(...a),
+  },
+}));
+
+vi.mock('@number-flow/react', () => ({
+  default: ({ value }: { value: number }) => <span>{value}</span>,
+}));
+
+const mockToast = vi.fn();
+vi.mock('../Toast', () => ({
+  useV5Toast: () => mockToast,
+  V5ToastProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+import { EVV5 } from './EV';
+
+function renderScreen(navigate = vi.fn()) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <EVV5 navigate={navigate} />
+    </QueryClientProvider>
+  );
+}
+
+const LOT = { id: 'lot-1', name: 'Nord' };
+const CHARGER_AVAIL = {
+  id: 'c1', lot_id: 'lot-1', label: 'C1',
+  connector_type: 'type2' as const, power_kw: 22,
+  status: 'available' as const, location_hint: 'Level 1',
+};
+const CHARGER_BUSY = {
+  id: 'c2', lot_id: 'lot-1', label: 'C2',
+  connector_type: 'ccs' as const, power_kw: 50,
+  status: 'in_use' as const, location_hint: null,
+};
+const SESSION_ACTIVE = {
+  id: 's1', charger_id: 'c2', user_id: 'u1',
+  start_time: '2026-04-23T08:00:00Z', end_time: null,
+  kwh_consumed: 5, status: 'active' as const,
+};
+
+describe('EVV5', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('renders empty state when no chargers', async () => {
+    mockGetLots.mockResolvedValue({ success: true, data: [LOT] });
+    mockGetChargers.mockResolvedValue({ success: true, data: [] });
+    mockGetSessions.mockResolvedValue({ success: true, data: [] });
+    renderScreen();
+    await waitFor(() => expect(screen.getByText('Keine Ladestationen')).toBeInTheDocument());
+  });
+
+  it('renders error state when chargers query fails', async () => {
+    mockGetLots.mockResolvedValue({ success: true, data: [LOT] });
+    mockGetChargers.mockRejectedValue(new Error('network'));
+    mockGetSessions.mockResolvedValue({ success: true, data: [] });
+    renderScreen();
+    await waitFor(() => expect(screen.getByText('Fehler beim Laden')).toBeInTheDocument());
+  });
+
+  it('surfaces query error when chargers success:false', async () => {
+    mockGetLots.mockResolvedValue({ success: true, data: [LOT] });
+    mockGetChargers.mockResolvedValue({ success: false, data: null, error: { code: 'FORBIDDEN', message: 'denied' } });
+    mockGetSessions.mockResolvedValue({ success: true, data: [] });
+    renderScreen();
+    await waitFor(() => expect(screen.getByText('Fehler beim Laden')).toBeInTheDocument());
+  });
+
+  it('renders charger cards with status badges', async () => {
+    mockGetLots.mockResolvedValue({ success: true, data: [LOT] });
+    mockGetChargers.mockResolvedValue({ success: true, data: [CHARGER_AVAIL, CHARGER_BUSY] });
+    mockGetSessions.mockResolvedValue({ success: true, data: [SESSION_ACTIVE] });
+    renderScreen();
+    await waitFor(() => expect(screen.getAllByTestId('charger-card')).toHaveLength(2));
+    // "Verfügbar" appears both as stat tile + status badge
+    expect(screen.getAllByText('Verfügbar').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText('Belegt')).toBeInTheDocument();
+  });
+
+  it('start button triggers startCharging and toast', async () => {
+    mockGetLots.mockResolvedValue({ success: true, data: [LOT] });
+    mockGetChargers.mockResolvedValue({ success: true, data: [CHARGER_AVAIL] });
+    mockGetSessions.mockResolvedValue({ success: true, data: [] });
+    mockStart.mockResolvedValue({ success: true, data: null });
+    renderScreen();
+    await waitFor(() => expect(screen.getByText('Laden starten')).toBeInTheDocument());
+    fireEvent.click(screen.getByText('Laden starten'));
+    await waitFor(() => {
+      expect(mockStart).toHaveBeenCalledWith('c1');
+      expect(mockToast).toHaveBeenCalledWith('Laden gestartet', 'success');
+    });
+  });
+
+  it('emits error toast when startCharging success:false', async () => {
+    mockGetLots.mockResolvedValue({ success: true, data: [LOT] });
+    mockGetChargers.mockResolvedValue({ success: true, data: [CHARGER_AVAIL] });
+    mockGetSessions.mockResolvedValue({ success: true, data: [] });
+    mockStart.mockResolvedValue({ success: false, data: null, error: { code: 'CONFLICT', message: 'in use' } });
+    renderScreen();
+    await waitFor(() => expect(screen.getByText('Laden starten')).toBeInTheDocument());
+    fireEvent.click(screen.getByText('Laden starten'));
+    await waitFor(() => {
+      expect(mockToast).toHaveBeenCalledWith('in use', 'error');
+    });
+    expect(mockToast).not.toHaveBeenCalledWith('Laden gestartet', 'success');
+  });
+
+  it('shows stop button on charger with active session', async () => {
+    mockGetLots.mockResolvedValue({ success: true, data: [LOT] });
+    mockGetChargers.mockResolvedValue({ success: true, data: [CHARGER_BUSY] });
+    mockGetSessions.mockResolvedValue({ success: true, data: [SESSION_ACTIVE] });
+    mockStop.mockResolvedValue({ success: true, data: null });
+    renderScreen();
+    await waitFor(() => expect(screen.getByText('Laden beenden')).toBeInTheDocument());
+    fireEvent.click(screen.getByText('Laden beenden'));
+    await waitFor(() => {
+      expect(mockStop).toHaveBeenCalledWith('c2');
+      expect(mockToast).toHaveBeenCalledWith('Laden beendet', 'success');
+    });
+  });
+});

--- a/parkhub-web/src/design-v5/screens/EV.tsx
+++ b/parkhub-web/src/design-v5/screens/EV.tsx
@@ -1,0 +1,286 @@
+import { useMemo, useState } from 'react';
+import NumberFlow from '@number-flow/react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { Badge, Card, V5NamedIcon } from '../primitives';
+import { useV5Toast } from '../Toast';
+import { api, type EvCharger, type ChargerConnector, type ChargerStatus, type ChargingSession } from '../../api/client';
+import type { ScreenId } from '../nav';
+
+const CONNECTOR_LABEL: Record<ChargerConnector, string> = {
+  type2: 'Type 2',
+  ccs: 'CCS',
+  chademo: 'CHAdeMO',
+  tesla: 'Tesla',
+};
+
+const STATUS_LABEL: Record<ChargerStatus, string> = {
+  available: 'Verfügbar',
+  in_use: 'Belegt',
+  offline: 'Offline',
+  maintenance: 'Wartung',
+};
+
+function statusVariant(s: ChargerStatus) {
+  switch (s) {
+    case 'available': return 'success' as const;
+    case 'in_use': return 'warning' as const;
+    case 'offline': return 'gray' as const;
+    case 'maintenance': return 'error' as const;
+  }
+}
+
+function formatTime(iso: string): string {
+  return new Date(iso).toLocaleTimeString('de-DE', { hour: '2-digit', minute: '2-digit' });
+}
+
+export function EVV5({ navigate: _navigate }: { navigate: (id: ScreenId) => void }) {
+  const toast = useV5Toast();
+  const qc = useQueryClient();
+  const [selectedLot, setSelectedLot] = useState<string>('');
+
+  const lotsQuery = useQuery({
+    queryKey: ['ev-lots'],
+    queryFn: async () => {
+      const res = await api.getLots();
+      if (!res.success) throw new Error(res.error?.message ?? 'Parkhäuser konnten nicht geladen werden');
+      return res.data ?? [];
+    },
+    staleTime: 60_000,
+    refetchOnWindowFocus: true,
+  });
+
+  const lots = lotsQuery.data ?? [];
+  const activeLot = selectedLot || lots[0]?.id || '';
+
+  const chargersQuery = useQuery({
+    queryKey: ['ev-chargers', activeLot],
+    enabled: !!activeLot,
+    queryFn: async () => {
+      const res = await api.getLotChargers(activeLot);
+      if (!res.success) throw new Error(res.error?.message ?? 'Ladestationen konnten nicht geladen werden');
+      return res.data ?? [];
+    },
+    staleTime: 15_000,
+    refetchOnWindowFocus: true,
+  });
+
+  const sessionsQuery = useQuery({
+    queryKey: ['ev-sessions'],
+    queryFn: async () => {
+      const res = await api.getChargerSessions();
+      if (!res.success) throw new Error(res.error?.message ?? 'Sitzungen konnten nicht geladen werden');
+      return res.data ?? [];
+    },
+    staleTime: 15_000,
+    refetchOnWindowFocus: true,
+  });
+
+  const startMutation = useMutation({
+    mutationFn: async (chargerId: string) => {
+      const res = await api.startCharging(chargerId);
+      if (!res.success) throw new Error(res.error?.message ?? 'Laden starten fehlgeschlagen');
+      return res.data;
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['ev-chargers'] });
+      qc.invalidateQueries({ queryKey: ['ev-sessions'] });
+      toast('Laden gestartet', 'success');
+    },
+    onError: (err: Error) => toast(err.message, 'error'),
+  });
+
+  const stopMutation = useMutation({
+    mutationFn: async (chargerId: string) => {
+      const res = await api.stopCharging(chargerId);
+      if (!res.success) throw new Error(res.error?.message ?? 'Laden stoppen fehlgeschlagen');
+      return res.data;
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['ev-chargers'] });
+      qc.invalidateQueries({ queryKey: ['ev-sessions'] });
+      toast('Laden beendet', 'success');
+    },
+    onError: (err: Error) => toast(err.message, 'error'),
+  });
+
+  const isLoading = lotsQuery.isLoading || chargersQuery.isLoading || sessionsQuery.isLoading;
+  const isError = lotsQuery.isError || chargersQuery.isError || sessionsQuery.isError;
+
+  const chargers: EvCharger[] = chargersQuery.data ?? [];
+  const sessions: ChargingSession[] = sessionsQuery.data ?? [];
+
+  const activeSession = useMemo(() => {
+    const map = new Map<string, ChargingSession>();
+    for (const s of sessions) {
+      if (s.status === 'active') map.set(s.charger_id, s);
+    }
+    return map;
+  }, [sessions]);
+
+  const availableCount = useMemo(() => chargers.filter((c) => c.status === 'available').length, [chargers]);
+  const liveCount = useMemo(() => sessions.filter((s) => s.status === 'active').length, [sessions]);
+
+  if (isLoading) {
+    return (
+      <div style={{ padding: 16, flex: 1, overflow: 'auto' }}>
+        <div style={{ height: 32, width: 200, borderRadius: 8, background: 'var(--v5-sur2)', marginBottom: 14, animation: 'ph-v5-pulse 1.6s ease infinite' }} />
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(220px, 1fr))', gap: 10 }}>
+          {[0, 1, 2, 3].map((i) => (
+            <div key={i} style={{ height: 130, borderRadius: 14, background: 'var(--v5-sur2)', animation: 'ph-v5-pulse 1.6s ease infinite', animationDelay: `${i * 0.08}s` }} />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div style={{ padding: 16, flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+        <Card className="v5-ani" style={{ padding: 28, textAlign: 'center', maxWidth: 360 }}>
+          <V5NamedIcon name="x" size={26} color="var(--v5-err)" />
+          <div style={{ marginTop: 10, fontWeight: 600, color: 'var(--v5-txt)' }}>Fehler beim Laden</div>
+          <div style={{ fontSize: 12, color: 'var(--v5-mut)', marginTop: 4 }}>Ladestationen konnten nicht geladen werden.</div>
+        </Card>
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ padding: 16, flex: 1, overflow: 'auto', display: 'flex', flexDirection: 'column', gap: 12 }}>
+      <div className="v5-ani" style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 10, flexWrap: 'wrap' }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <span style={{ fontWeight: 700, fontSize: 15, color: 'var(--v5-txt)' }}>EV-Laden</span>
+          <Badge variant="gray"><NumberFlow value={chargers.length} /></Badge>
+        </div>
+        {lots.length > 1 && (
+          <select
+            aria-label="Parkhaus"
+            value={activeLot}
+            onChange={(e) => setSelectedLot(e.target.value)}
+            style={{
+              padding: '6px 10px',
+              borderRadius: 9,
+              background: 'var(--v5-sur2)',
+              border: '1px solid var(--v5-bor)',
+              color: 'var(--v5-txt)',
+              fontSize: 12,
+              fontFamily: 'inherit',
+              outline: 'none',
+            }}
+          >
+            {lots.map((l) => (
+              <option key={l.id} value={l.id}>{l.name}</option>
+            ))}
+          </select>
+        )}
+      </div>
+
+      <div className="v5-ani" style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 10, animationDelay: '0.06s' }}>
+        <StatTile label="Ladepunkte" value={chargers.length} />
+        <StatTile label="Verfügbar" value={availableCount} accent />
+        <StatTile label="Aktive Sitzungen" value={liveCount} />
+      </div>
+
+      {chargers.length === 0 ? (
+        <Card className="v5-ani" style={{ padding: 36, display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 10, animationDelay: '0.12s' }}>
+          <div style={{ width: 48, height: 48, borderRadius: 14, background: 'var(--v5-acc-muted)', border: '1.5px dashed color-mix(in oklch, var(--v5-acc) 50%, transparent)', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+            <V5NamedIcon name="bolt" size={20} color="var(--v5-acc)" />
+          </div>
+          <div style={{ textAlign: 'center' }}>
+            <div style={{ fontWeight: 600, color: 'var(--v5-txt)', fontSize: 13 }}>Keine Ladestationen</div>
+            <div style={{ fontSize: 11, color: 'var(--v5-mut)', marginTop: 3 }}>In diesem Parkhaus sind noch keine Ladesäulen verfügbar.</div>
+          </div>
+        </Card>
+      ) : (
+        <div className="v5-ani" style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(240px, 1fr))', gap: 10, animationDelay: '0.12s' }}>
+          {chargers.map((c, i) => {
+            const active = activeSession.get(c.id);
+            const isStarting = startMutation.isPending && startMutation.variables === c.id;
+            const isStopping = stopMutation.isPending && stopMutation.variables === c.id;
+            return (
+              <Card
+                key={c.id}
+                data-testid="charger-card"
+                className="v5-ani"
+                style={{ padding: '14px 16px', display: 'flex', flexDirection: 'column', gap: 10, animationDelay: `${i * 0.05}s` }}
+              >
+                <div style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: 8 }}>
+                  <div>
+                    <div style={{ fontSize: 14, fontWeight: 700, color: 'var(--v5-txt)' }}>{c.label}</div>
+                    <div style={{ fontSize: 11, color: 'var(--v5-mut)', marginTop: 2 }}>
+                      {CONNECTOR_LABEL[c.connector_type]} · {c.power_kw} kW
+                    </div>
+                  </div>
+                  <Badge variant={statusVariant(c.status)} dot>{STATUS_LABEL[c.status]}</Badge>
+                </div>
+                {c.location_hint && (
+                  <div style={{ fontSize: 11, color: 'var(--v5-mut)' }}>{c.location_hint}</div>
+                )}
+                {active && (
+                  <div style={{ fontSize: 11, color: 'var(--v5-acc)', display: 'flex', alignItems: 'center', gap: 6 }}>
+                    <V5NamedIcon name="bolt" size={11} color="var(--v5-acc)" />
+                    Laden seit {formatTime(active.start_time)}
+                  </div>
+                )}
+                {c.status === 'available' && !active && (
+                  <button
+                    type="button"
+                    disabled={isStarting}
+                    onClick={() => startMutation.mutate(c.id)}
+                    className="v5-btn"
+                    style={{
+                      padding: '8px 14px',
+                      borderRadius: 9,
+                      background: 'var(--v5-acc)',
+                      color: 'var(--v5-accent-fg)',
+                      border: 'none',
+                      fontSize: 11,
+                      fontWeight: 600,
+                      cursor: isStarting ? 'default' : 'pointer',
+                      opacity: isStarting ? 0.6 : 1,
+                    }}
+                  >
+                    {isStarting ? 'Starten…' : 'Laden starten'}
+                  </button>
+                )}
+                {active && (
+                  <button
+                    type="button"
+                    disabled={isStopping}
+                    onClick={() => stopMutation.mutate(c.id)}
+                    style={{
+                      padding: '8px 14px',
+                      borderRadius: 9,
+                      background: 'color-mix(in oklch, var(--v5-err) 10%, transparent)',
+                      color: 'var(--v5-err)',
+                      border: '1px solid color-mix(in oklch, var(--v5-err) 30%, transparent)',
+                      fontSize: 11,
+                      fontWeight: 600,
+                      cursor: isStopping ? 'default' : 'pointer',
+                      opacity: isStopping ? 0.6 : 1,
+                    }}
+                  >
+                    {isStopping ? 'Stoppen…' : 'Laden beenden'}
+                  </button>
+                )}
+              </Card>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function StatTile({ label, value, accent = false }: { label: string; value: number; accent?: boolean }) {
+  return (
+    <Card style={{ padding: 14, background: accent ? 'var(--v5-acc-muted)' : 'var(--v5-sur)' }}>
+      <div className="v5-mono" style={{ fontSize: 9, letterSpacing: 1.4, color: accent ? 'var(--v5-acc)' : 'var(--v5-mut)', textTransform: 'uppercase' }}>
+        {label}
+      </div>
+      <div style={{ marginTop: 6, fontSize: 28, fontWeight: 800, color: accent ? 'var(--v5-acc)' : 'var(--v5-txt)', letterSpacing: -1 }}>
+        <NumberFlow value={value} />
+      </div>
+    </Card>
+  );
+}

--- a/parkhub-web/src/design-v5/screens/Einchecken.test.tsx
+++ b/parkhub-web/src/design-v5/screens/Einchecken.test.tsx
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+const mockGetBookings = vi.fn();
+const mockGetStatus = vi.fn();
+const mockCheckIn = vi.fn();
+const mockCheckOut = vi.fn();
+
+vi.mock('../../api/client', () => ({
+  api: {
+    getBookings: (...a: unknown[]) => mockGetBookings(...a),
+    getCheckInStatus: (...a: unknown[]) => mockGetStatus(...a),
+    checkIn: (...a: unknown[]) => mockCheckIn(...a),
+    checkOut: (...a: unknown[]) => mockCheckOut(...a),
+  },
+}));
+
+const mockToast = vi.fn();
+vi.mock('../Toast', () => ({
+  useV5Toast: () => mockToast,
+  V5ToastProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+import { EincheckenV5 } from './Einchecken';
+
+function renderScreen(navigate = vi.fn()) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <EincheckenV5 navigate={navigate} />
+    </QueryClientProvider>
+  );
+}
+
+// Booking that is "active right now" — window from 1h ago to 1h ahead
+function activeBooking() {
+  const now = Date.now();
+  return {
+    id: 'b1', user_id: 'u1', lot_id: 'l1', slot_id: 's1',
+    lot_name: 'Nord', slot_number: 'A1', vehicle_plate: 'M-XY',
+    start_time: new Date(now - 3600000).toISOString(),
+    end_time: new Date(now + 3600000).toISOString(),
+    status: 'active' as const,
+  };
+}
+
+describe('EincheckenV5', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('renders empty state when no active booking', async () => {
+    mockGetBookings.mockResolvedValue({ success: true, data: [] });
+    renderScreen();
+    await waitFor(() => expect(screen.getByText('Keine aktive Buchung')).toBeInTheDocument());
+  });
+
+  it('renders error state when bookings query fails', async () => {
+    mockGetBookings.mockRejectedValue(new Error('network'));
+    renderScreen();
+    await waitFor(() => expect(screen.getByText('Fehler beim Laden')).toBeInTheDocument());
+  });
+
+  it('surfaces error when bookings success:false', async () => {
+    mockGetBookings.mockResolvedValue({ success: false, data: null, error: { code: 'FORBIDDEN', message: 'denied' } });
+    renderScreen();
+    await waitFor(() => expect(screen.getByText('Fehler beim Laden')).toBeInTheDocument());
+  });
+
+  it('shows check-in card when booking is active and not yet checked in', async () => {
+    mockGetBookings.mockResolvedValue({ success: true, data: [activeBooking()] });
+    mockGetStatus.mockResolvedValue({ success: true, data: { checked_in: false, checked_in_at: null, checked_out_at: null } });
+    renderScreen();
+    await waitFor(() => expect(screen.getByTestId('checkin-card')).toBeInTheDocument());
+    expect(screen.getByText('Nord')).toBeInTheDocument();
+  });
+
+  it('check-in button calls api.checkIn and toast', async () => {
+    mockGetBookings.mockResolvedValue({ success: true, data: [activeBooking()] });
+    mockGetStatus.mockResolvedValue({ success: true, data: { checked_in: false, checked_in_at: null, checked_out_at: null } });
+    mockCheckIn.mockResolvedValue({ success: true, data: null });
+    renderScreen();
+    await waitFor(() => expect(screen.getByTestId('checkin-btn')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('checkin-btn'));
+    await waitFor(() => {
+      expect(mockCheckIn).toHaveBeenCalledWith('b1');
+      expect(mockToast).toHaveBeenCalledWith('Eingecheckt', 'success');
+    });
+  });
+
+  it('emits error toast when checkIn success:false', async () => {
+    mockGetBookings.mockResolvedValue({ success: true, data: [activeBooking()] });
+    mockGetStatus.mockResolvedValue({ success: true, data: { checked_in: false, checked_in_at: null, checked_out_at: null } });
+    mockCheckIn.mockResolvedValue({ success: false, data: null, error: { code: 'TOO_EARLY', message: 'too early' } });
+    renderScreen();
+    await waitFor(() => expect(screen.getByTestId('checkin-btn')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('checkin-btn'));
+    await waitFor(() => {
+      expect(mockToast).toHaveBeenCalledWith('too early', 'error');
+    });
+    expect(mockToast).not.toHaveBeenCalledWith('Eingecheckt', 'success');
+  });
+
+  it('shows checked-in card with elapsed timer when already checked in', async () => {
+    mockGetBookings.mockResolvedValue({ success: true, data: [activeBooking()] });
+    mockGetStatus.mockResolvedValue({
+      success: true,
+      data: { checked_in: true, checked_in_at: new Date(Date.now() - 65000).toISOString(), checked_out_at: null },
+    });
+    renderScreen();
+    await waitFor(() => expect(screen.getByTestId('checked-in-card')).toBeInTheDocument());
+    expect(screen.getByTestId('elapsed')).toBeInTheDocument();
+    expect(screen.getByTestId('checkout-btn')).toBeInTheDocument();
+  });
+
+  it('checkout button calls api.checkOut and toast', async () => {
+    mockGetBookings.mockResolvedValue({ success: true, data: [activeBooking()] });
+    mockGetStatus.mockResolvedValue({
+      success: true,
+      data: { checked_in: true, checked_in_at: new Date().toISOString(), checked_out_at: null },
+    });
+    mockCheckOut.mockResolvedValue({ success: true, data: null });
+    renderScreen();
+    await waitFor(() => expect(screen.getByTestId('checkout-btn')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('checkout-btn'));
+    await waitFor(() => {
+      expect(mockCheckOut).toHaveBeenCalledWith('b1');
+      expect(mockToast).toHaveBeenCalledWith('Ausgecheckt', 'success');
+    });
+  });
+});

--- a/parkhub-web/src/design-v5/screens/Einchecken.tsx
+++ b/parkhub-web/src/design-v5/screens/Einchecken.tsx
@@ -1,0 +1,266 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { Badge, Card, V5NamedIcon } from '../primitives';
+import { useV5Toast } from '../Toast';
+import { api, type Booking } from '../../api/client';
+import type { ScreenId } from '../nav';
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString('de-DE', { day: '2-digit', month: '2-digit', year: 'numeric' });
+}
+function formatTime(iso: string): string {
+  return new Date(iso).toLocaleTimeString('de-DE', { hour: '2-digit', minute: '2-digit' });
+}
+
+function padded(n: number): string {
+  return String(n).padStart(2, '0');
+}
+
+function elapsedSince(iso: string): string {
+  const diff = Math.max(0, Date.now() - new Date(iso).getTime());
+  const h = Math.floor(diff / 3600000);
+  const m = Math.floor((diff % 3600000) / 60000);
+  const s = Math.floor((diff % 60000) / 1000);
+  return `${padded(h)}:${padded(m)}:${padded(s)}`;
+}
+
+export function EincheckenV5({ navigate }: { navigate: (id: ScreenId) => void }) {
+  const toast = useV5Toast();
+  const qc = useQueryClient();
+
+  const bookingsQuery = useQuery({
+    queryKey: ['einchecken-bookings'],
+    queryFn: async () => {
+      const res = await api.getBookings();
+      if (!res.success) throw new Error(res.error?.message ?? 'Buchungen konnten nicht geladen werden');
+      return res.data ?? [];
+    },
+    staleTime: 30_000,
+    refetchOnWindowFocus: true,
+  });
+
+  const bookings: Booking[] = bookingsQuery.data ?? [];
+  const activeBooking = useMemo(() => {
+    const now = Date.now();
+    return bookings.find((b) =>
+      (b.status === 'active' || b.status === 'confirmed') &&
+      new Date(b.start_time).getTime() <= now &&
+      new Date(b.end_time).getTime() > now,
+    ) ?? null;
+  }, [bookings]);
+
+  const statusQuery = useQuery({
+    queryKey: ['checkin-status', activeBooking?.id],
+    enabled: !!activeBooking,
+    queryFn: async () => {
+      const res = await api.getCheckInStatus(activeBooking!.id);
+      if (!res.success) {
+        // Not all backends return a status row when the user has never checked in.
+        return { checked_in: false, checked_in_at: null, checked_out_at: null };
+      }
+      return res.data ?? { checked_in: false, checked_in_at: null, checked_out_at: null };
+    },
+    staleTime: 15_000,
+    refetchOnWindowFocus: true,
+  });
+
+  const checkInMutation = useMutation({
+    mutationFn: async (bookingId: string) => {
+      const res = await api.checkIn(bookingId);
+      if (!res.success) throw new Error(res.error?.message ?? 'Einchecken fehlgeschlagen');
+      return res.data;
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['checkin-status'] });
+      toast('Eingecheckt', 'success');
+    },
+    onError: (err: Error) => toast(err.message, 'error'),
+  });
+
+  const checkOutMutation = useMutation({
+    mutationFn: async (bookingId: string) => {
+      const res = await api.checkOut(bookingId);
+      if (!res.success) throw new Error(res.error?.message ?? 'Auschecken fehlgeschlagen');
+      return res.data;
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['checkin-status'] });
+      toast('Ausgecheckt', 'success');
+    },
+    onError: (err: Error) => toast(err.message, 'error'),
+  });
+
+  const status = statusQuery.data;
+  const isCheckedIn = !!status?.checked_in && !status?.checked_out_at;
+
+  const [elapsed, setElapsed] = useState('00:00:00');
+  useEffect(() => {
+    if (!isCheckedIn || !status?.checked_in_at) {
+      setElapsed('00:00:00');
+      return;
+    }
+    const iso = status.checked_in_at;
+    setElapsed(elapsedSince(iso));
+    const tick = setInterval(() => setElapsed(elapsedSince(iso)), 1000);
+    return () => clearInterval(tick);
+  }, [isCheckedIn, status?.checked_in_at]);
+
+  if (bookingsQuery.isLoading) {
+    return (
+      <div style={{ padding: 16, flex: 1, overflow: 'auto' }}>
+        <div style={{ height: 140, borderRadius: 14, background: 'var(--v5-sur2)', animation: 'ph-v5-pulse 1.6s ease infinite', marginBottom: 12 }} />
+        <div style={{ height: 90, borderRadius: 14, background: 'var(--v5-sur2)', animation: 'ph-v5-pulse 1.6s ease infinite' }} />
+      </div>
+    );
+  }
+
+  if (bookingsQuery.isError) {
+    return (
+      <div style={{ padding: 16, flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+        <Card className="v5-ani" style={{ padding: 28, textAlign: 'center', maxWidth: 360 }}>
+          <V5NamedIcon name="x" size={26} color="var(--v5-err)" />
+          <div style={{ marginTop: 10, fontWeight: 600, color: 'var(--v5-txt)' }}>Fehler beim Laden</div>
+          <div style={{ fontSize: 12, color: 'var(--v5-mut)', marginTop: 4 }}>Buchungen konnten nicht geladen werden.</div>
+        </Card>
+      </div>
+    );
+  }
+
+  if (!activeBooking) {
+    return (
+      <div style={{ padding: 16, flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+        <Card className="v5-ani" style={{ padding: 36, display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 10, maxWidth: 380 }}>
+          <div style={{ width: 48, height: 48, borderRadius: 14, background: 'var(--v5-acc-muted)', border: '1.5px dashed color-mix(in oklch, var(--v5-acc) 50%, transparent)', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+            <V5NamedIcon name="check" size={20} color="var(--v5-acc)" />
+          </div>
+          <div style={{ textAlign: 'center' }}>
+            <div style={{ fontWeight: 600, color: 'var(--v5-txt)', fontSize: 13 }}>Keine aktive Buchung</div>
+            <div style={{ fontSize: 11, color: 'var(--v5-mut)', marginTop: 3 }}>Sie können einchecken, sobald eine Buchung läuft.</div>
+          </div>
+          <button
+            type="button"
+            onClick={() => navigate('buchen')}
+            className="v5-btn"
+            style={{ padding: '8px 16px', borderRadius: 9, background: 'var(--v5-acc)', color: 'var(--v5-accent-fg)', border: 'none', fontSize: 11, fontWeight: 600, cursor: 'pointer' }}
+          >
+            + Platz buchen
+          </button>
+        </Card>
+      </div>
+    );
+  }
+
+  const isActing = checkInMutation.isPending || checkOutMutation.isPending;
+
+  return (
+    <div style={{ padding: 16, flex: 1, overflow: 'auto', display: 'flex', flexDirection: 'column', gap: 12 }}>
+      <div className="v5-ani" style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+        <span style={{ fontWeight: 700, fontSize: 15, color: 'var(--v5-txt)' }}>Einchecken</span>
+        <Badge variant={isCheckedIn ? 'success' : 'gray'} dot>
+          {isCheckedIn ? 'Eingecheckt' : 'Bereit'}
+        </Badge>
+      </div>
+
+      <Card className="v5-ani" style={{ padding: 18, animationDelay: '0.06s' }} data-testid="booking-card">
+        <div className="v5-mono" style={{ fontSize: 9, letterSpacing: 1.4, color: 'var(--v5-mut)', textTransform: 'uppercase' }}>
+          Aktive Buchung
+        </div>
+        <div style={{ marginTop: 6, fontSize: 18, fontWeight: 700, color: 'var(--v5-txt)' }}>
+          {activeBooking.lot_name ?? '—'}
+        </div>
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 10, marginTop: 12 }}>
+          <Info label="Platz" value={activeBooking.slot_number ?? '—'} mono />
+          <Info label="Datum" value={formatDate(activeBooking.start_time)} />
+          <Info label="Zeitfenster" value={`${formatTime(activeBooking.start_time)}–${formatTime(activeBooking.end_time)}`} />
+        </div>
+      </Card>
+
+      {isCheckedIn ? (
+        <Card className="v5-ani" style={{ padding: 18, animationDelay: '0.12s', background: 'var(--v5-acc-muted)' }} data-testid="checked-in-card">
+          <div className="v5-mono" style={{ fontSize: 9, letterSpacing: 1.4, color: 'var(--v5-acc)', textTransform: 'uppercase' }}>
+            Laufzeit
+          </div>
+          <div
+            className="v5-mono"
+            data-testid="elapsed"
+            style={{ marginTop: 6, fontSize: 36, fontWeight: 800, color: 'var(--v5-acc)', letterSpacing: -1, fontVariantNumeric: 'tabular-nums' }}
+          >
+            {elapsed}
+          </div>
+          {status?.checked_in_at && (
+            <div style={{ fontSize: 11, color: 'var(--v5-mut)', marginTop: 4 }}>
+              Seit {formatTime(status.checked_in_at)}
+            </div>
+          )}
+          <button
+            type="button"
+            disabled={isActing}
+            onClick={() => checkOutMutation.mutate(activeBooking.id)}
+            style={{
+              marginTop: 14,
+              padding: '10px 18px',
+              borderRadius: 10,
+              background: 'color-mix(in oklch, var(--v5-err) 10%, transparent)',
+              color: 'var(--v5-err)',
+              border: '1px solid color-mix(in oklch, var(--v5-err) 30%, transparent)',
+              fontSize: 12,
+              fontWeight: 700,
+              cursor: isActing ? 'default' : 'pointer',
+              opacity: isActing ? 0.6 : 1,
+            }}
+            data-testid="checkout-btn"
+          >
+            {checkOutMutation.isPending ? 'Auschecken…' : 'Auschecken'}
+          </button>
+        </Card>
+      ) : (
+        <Card className="v5-ani" style={{ padding: 18, animationDelay: '0.12s', textAlign: 'center' }} data-testid="checkin-card">
+          <V5NamedIcon name="check" size={36} color="var(--v5-acc)" />
+          <div style={{ marginTop: 8, fontSize: 13, fontWeight: 600, color: 'var(--v5-txt)' }}>
+            Bereit zum Einchecken
+          </div>
+          <div style={{ fontSize: 11, color: 'var(--v5-mut)', marginTop: 4 }}>
+            Scannen Sie den QR-Code am Stellplatz oder tippen Sie auf Einchecken.
+          </div>
+          <button
+            type="button"
+            disabled={isActing}
+            onClick={() => checkInMutation.mutate(activeBooking.id)}
+            className="v5-btn"
+            style={{
+              marginTop: 14,
+              padding: '10px 22px',
+              borderRadius: 10,
+              background: 'var(--v5-acc)',
+              color: 'var(--v5-accent-fg)',
+              border: 'none',
+              fontSize: 12,
+              fontWeight: 700,
+              cursor: isActing ? 'default' : 'pointer',
+              opacity: isActing ? 0.6 : 1,
+            }}
+            data-testid="checkin-btn"
+          >
+            {checkInMutation.isPending ? 'Einchecken…' : 'Einchecken'}
+          </button>
+        </Card>
+      )}
+    </div>
+  );
+}
+
+function Info({ label, value, mono = false }: { label: string; value: string; mono?: boolean }) {
+  return (
+    <div>
+      <div className="v5-mono" style={{ fontSize: 9, letterSpacing: 1.2, color: 'var(--v5-mut)', textTransform: 'uppercase' }}>
+        {label}
+      </div>
+      <div
+        className={mono ? 'v5-mono' : ''}
+        style={{ marginTop: 4, fontSize: 13, fontWeight: 600, color: 'var(--v5-txt)' }}
+      >
+        {value}
+      </div>
+    </div>
+  );
+}

--- a/parkhub-web/src/design-v5/screens/Gaestepass.test.tsx
+++ b/parkhub-web/src/design-v5/screens/Gaestepass.test.tsx
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+const mockGetGuests = vi.fn();
+const mockGetLots = vi.fn();
+const mockGetSlots = vi.fn();
+const mockCreateGuest = vi.fn();
+const mockCancelGuest = vi.fn();
+
+vi.mock('../../api/client', () => ({
+  api: {
+    getGuestBookings: (...a: unknown[]) => mockGetGuests(...a),
+    getLots: (...a: unknown[]) => mockGetLots(...a),
+    getLotSlots: (...a: unknown[]) => mockGetSlots(...a),
+    createGuestBooking: (...a: unknown[]) => mockCreateGuest(...a),
+    cancelGuestBooking: (...a: unknown[]) => mockCancelGuest(...a),
+  },
+}));
+
+vi.mock('@number-flow/react', () => ({
+  default: ({ value }: { value: number }) => <span>{value}</span>,
+}));
+
+const mockToast = vi.fn();
+vi.mock('../Toast', () => ({
+  useV5Toast: () => mockToast,
+  V5ToastProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+import { GaestepassV5 } from './Gaestepass';
+
+function renderScreen(navigate = vi.fn()) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <GaestepassV5 navigate={navigate} />
+    </QueryClientProvider>
+  );
+}
+
+const LOT = { id: 'lot-1', name: 'Nord' };
+const GUEST_ACTIVE = {
+  id: 'g1', lot_id: 'lot-1', lot_name: 'Nord',
+  slot_id: 's1', slot_number: 'A1',
+  guest_name: 'Max Mustermann', guest_email: 'max@example.com',
+  guest_code: 'ABC123',
+  start_time: '2026-04-23T08:00:00Z', end_time: '2026-04-23T18:00:00Z',
+  status: 'active' as const, created_at: '2026-04-22T10:00:00Z',
+};
+const GUEST_EXPIRED = { ...GUEST_ACTIVE, id: 'g2', guest_code: 'XYZ999', status: 'expired' as const };
+
+describe('GaestepassV5', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('renders empty state when no guest passes', async () => {
+    mockGetGuests.mockResolvedValue({ success: true, data: [] });
+    mockGetLots.mockResolvedValue({ success: true, data: [LOT] });
+    renderScreen();
+    await waitFor(() => expect(screen.getByText('Noch keine Gäste-Pässe')).toBeInTheDocument());
+  });
+
+  it('renders error state when guests query fails', async () => {
+    mockGetGuests.mockRejectedValue(new Error('network'));
+    mockGetLots.mockResolvedValue({ success: true, data: [LOT] });
+    renderScreen();
+    await waitFor(() => expect(screen.getByText('Fehler beim Laden')).toBeInTheDocument());
+  });
+
+  it('surfaces error when guests success:false', async () => {
+    mockGetGuests.mockResolvedValue({ success: false, data: null, error: { code: 'FORBIDDEN', message: 'denied' } });
+    mockGetLots.mockResolvedValue({ success: true, data: [LOT] });
+    renderScreen();
+    await waitFor(() => expect(screen.getByText('Fehler beim Laden')).toBeInTheDocument());
+  });
+
+  it('renders guest rows with codes and statuses', async () => {
+    mockGetGuests.mockResolvedValue({ success: true, data: [GUEST_ACTIVE, GUEST_EXPIRED] });
+    mockGetLots.mockResolvedValue({ success: true, data: [LOT] });
+    renderScreen();
+    await waitFor(() => expect(screen.getAllByTestId('guest-row')).toHaveLength(2));
+    expect(screen.getAllByText('Max Mustermann').length).toBeGreaterThan(0);
+    expect(screen.getByText('ABC123')).toBeInTheDocument();
+    expect(screen.getByText('XYZ999')).toBeInTheDocument();
+    expect(screen.getAllByText(/Aktiv/).length).toBeGreaterThan(0);
+    expect(screen.getByText('Abgelaufen')).toBeInTheDocument();
+  });
+
+  it('cancel button calls cancelGuestBooking and toast', async () => {
+    mockGetGuests.mockResolvedValue({ success: true, data: [GUEST_ACTIVE] });
+    mockGetLots.mockResolvedValue({ success: true, data: [LOT] });
+    mockCancelGuest.mockResolvedValue({ success: true, data: null });
+    renderScreen();
+    await waitFor(() => expect(screen.getByTestId('cancel-g1')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('cancel-g1'));
+    await waitFor(() => {
+      expect(mockCancelGuest).toHaveBeenCalledWith('g1');
+      expect(mockToast).toHaveBeenCalledWith('Pass storniert', 'success');
+    });
+  });
+
+  it('emits error toast when cancel success:false', async () => {
+    mockGetGuests.mockResolvedValue({ success: true, data: [GUEST_ACTIVE] });
+    mockGetLots.mockResolvedValue({ success: true, data: [LOT] });
+    mockCancelGuest.mockResolvedValue({ success: false, data: null, error: { code: 'CONFLICT', message: 'expired' } });
+    renderScreen();
+    await waitFor(() => expect(screen.getByTestId('cancel-g1')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('cancel-g1'));
+    await waitFor(() => {
+      expect(mockToast).toHaveBeenCalledWith('expired', 'error');
+    });
+    expect(mockToast).not.toHaveBeenCalledWith('Pass storniert', 'success');
+  });
+
+  it('opens create modal with create button', async () => {
+    mockGetGuests.mockResolvedValue({ success: true, data: [] });
+    mockGetLots.mockResolvedValue({ success: true, data: [LOT] });
+    renderScreen();
+    await waitFor(() => expect(screen.getByTestId('open-create-guest')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('open-create-guest'));
+    expect(screen.getByTestId('guest-name')).toBeInTheDocument();
+    expect(screen.getByTestId('guest-lot')).toBeInTheDocument();
+  });
+});

--- a/parkhub-web/src/design-v5/screens/Gaestepass.test.tsx
+++ b/parkhub-web/src/design-v5/screens/Gaestepass.test.tsx
@@ -49,6 +49,13 @@ const GUEST_ACTIVE = {
   status: 'active' as const, created_at: '2026-04-22T10:00:00Z',
 };
 const GUEST_EXPIRED = { ...GUEST_ACTIVE, id: 'g2', guest_code: 'XYZ999', status: 'expired' as const };
+const GUEST_CONFIRMED = { ...GUEST_ACTIVE, id: 'g3', guest_code: 'CNF456', status: 'confirmed' as const };
+const GUEST_PENDING = { ...GUEST_ACTIVE, id: 'g4', guest_code: 'PND789', status: 'pending' as const };
+const GUEST_COMPLETED = { ...GUEST_ACTIVE, id: 'g5', guest_code: 'CMP321', status: 'completed' as const };
+const GUEST_NOSHOW = { ...GUEST_ACTIVE, id: 'g6', guest_code: 'NSW654', status: 'no_show' as const };
+
+const SLOT_A1 = { id: 's1', lot_id: 'lot-1', slot_number: 'A1', status: 'available' };
+const SLOT_A2 = { id: 's2', lot_id: 'lot-1', slot_number: 'A2', status: 'available' };
 
 describe('GaestepassV5', () => {
   beforeEach(() => vi.clearAllMocks());
@@ -120,5 +127,70 @@ describe('GaestepassV5', () => {
     fireEvent.click(screen.getByTestId('open-create-guest'));
     expect(screen.getByTestId('guest-name')).toBeInTheDocument();
     expect(screen.getByTestId('guest-lot')).toBeInTheDocument();
+  });
+
+  it('renders confirmed status with Storno action (newly created Rust pass)', async () => {
+    // Regression for PR #374: Rust creates guest bookings with
+    // `BookingStatus::Confirmed`, so `confirmed` must map to a visible
+    // badge and the cancel button must still be shown.
+    mockGetGuests.mockResolvedValue({ success: true, data: [GUEST_CONFIRMED] });
+    mockGetLots.mockResolvedValue({ success: true, data: [LOT] });
+    renderScreen();
+    await waitFor(() => expect(screen.getByTestId('guest-row')).toBeInTheDocument());
+    expect(screen.getByText('Bestätigt')).toBeInTheDocument();
+    expect(screen.getByTestId('cancel-g3')).toBeInTheDocument();
+  });
+
+  it('renders all backend BookingStatus variants with distinct labels', async () => {
+    mockGetGuests.mockResolvedValue({
+      success: true,
+      data: [GUEST_PENDING, GUEST_CONFIRMED, GUEST_ACTIVE, GUEST_COMPLETED, GUEST_EXPIRED, GUEST_NOSHOW],
+    });
+    mockGetLots.mockResolvedValue({ success: true, data: [LOT] });
+    renderScreen();
+    await waitFor(() => expect(screen.getAllByTestId('guest-row')).toHaveLength(6));
+    expect(screen.getByText('Ausstehend')).toBeInTheDocument();
+    expect(screen.getByText('Bestätigt')).toBeInTheDocument();
+    expect(screen.getAllByText(/Aktiv/).length).toBeGreaterThan(0);
+    expect(screen.getByText('Abgeschlossen')).toBeInTheDocument();
+    expect(screen.getByText('Abgelaufen')).toBeInTheDocument();
+    expect(screen.getByText('Nicht erschienen')).toBeInTheDocument();
+  });
+
+  it('treats confirmed/pending/active as "open" for active count and Storno affordance', async () => {
+    mockGetGuests.mockResolvedValue({
+      success: true,
+      data: [GUEST_PENDING, GUEST_CONFIRMED, GUEST_ACTIVE, GUEST_EXPIRED],
+    });
+    mockGetLots.mockResolvedValue({ success: true, data: [LOT] });
+    renderScreen();
+    await waitFor(() => expect(screen.getAllByTestId('guest-row')).toHaveLength(4));
+    // 3 open (pending, confirmed, active) → 3 Storno buttons.
+    expect(screen.getByTestId('cancel-g4')).toBeInTheDocument();
+    expect(screen.getByTestId('cancel-g3')).toBeInTheDocument();
+    expect(screen.getByTestId('cancel-g1')).toBeInTheDocument();
+    // Expired → no button.
+    expect(screen.queryByTestId('cancel-g2')).toBeNull();
+    // Active-count badge shows 3 (pending + confirmed + active).
+    expect(screen.getByText('3 aktiv')).toBeInTheDocument();
+  });
+
+  it('renders slot dropdown labels from slot_number (not s.number)', async () => {
+    // Regression for PR #374: ParkingSlot has `slot_number`, not `number`.
+    // The previous code rendered blank <option> labels at runtime.
+    mockGetGuests.mockResolvedValue({ success: true, data: [] });
+    mockGetLots.mockResolvedValue({ success: true, data: [LOT] });
+    mockGetSlots.mockResolvedValue({ success: true, data: [SLOT_A1, SLOT_A2] });
+    renderScreen();
+    await waitFor(() => expect(screen.getByTestId('open-create-guest')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('open-create-guest'));
+    // Select lot to trigger slot fetch.
+    fireEvent.change(screen.getByTestId('guest-lot'), { target: { value: 'lot-1' } });
+    await waitFor(() => {
+      const slotSelect = screen.getByTestId('guest-slot') as HTMLSelectElement;
+      const labels = Array.from(slotSelect.options).map((o) => o.textContent);
+      expect(labels).toContain('A1');
+      expect(labels).toContain('A2');
+    });
   });
 });

--- a/parkhub-web/src/design-v5/screens/Gaestepass.tsx
+++ b/parkhub-web/src/design-v5/screens/Gaestepass.tsx
@@ -1,0 +1,446 @@
+import { useEffect, useMemo, useState, type CSSProperties, type ReactNode } from 'react';
+import NumberFlow from '@number-flow/react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { Badge, Card, V5NamedIcon } from '../primitives';
+import { useV5Toast } from '../Toast';
+import {
+  api,
+  type GuestBooking,
+  type ParkingLot,
+  type ParkingSlot,
+  type CreateGuestBookingPayload,
+} from '../../api/client';
+import type { ScreenId } from '../nav';
+
+const STATUS_LABEL: Record<GuestBooking['status'], string> = {
+  active: 'Aktiv',
+  expired: 'Abgelaufen',
+  cancelled: 'Storniert',
+};
+
+function statusVariant(s: GuestBooking['status']) {
+  switch (s) {
+    case 'active': return 'success' as const;
+    case 'expired': return 'gray' as const;
+    case 'cancelled': return 'error' as const;
+  }
+}
+
+function formatRange(start: string, end: string): string {
+  const s = new Date(start);
+  const e = new Date(end);
+  const d = s.toLocaleDateString('de-DE', { day: '2-digit', month: '2-digit', year: '2-digit' });
+  const t1 = s.toLocaleTimeString('de-DE', { hour: '2-digit', minute: '2-digit' });
+  const t2 = e.toLocaleTimeString('de-DE', { hour: '2-digit', minute: '2-digit' });
+  return `${d} ${t1}–${t2}`;
+}
+
+const inputStyle: CSSProperties = {
+  padding: '8px 11px',
+  borderRadius: 9,
+  background: 'var(--v5-sur2)',
+  border: '1px solid var(--v5-bor)',
+  color: 'var(--v5-txt)',
+  fontSize: 12,
+  width: '100%',
+  outline: 'none',
+  boxSizing: 'border-box',
+  fontFamily: 'inherit',
+};
+
+function Field({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+      <label style={{ fontSize: 11, fontWeight: 500, color: 'var(--v5-mut)' }}>{label}</label>
+      {children}
+    </div>
+  );
+}
+
+function CreateGuestModal({
+  lots,
+  onClose,
+  onSubmit,
+  isSubmitting,
+}: {
+  lots: ParkingLot[];
+  onClose: () => void;
+  onSubmit: (payload: CreateGuestBookingPayload) => void;
+  isSubmitting: boolean;
+}) {
+  const toast = useV5Toast();
+  const [guestName, setGuestName] = useState('');
+  const [guestEmail, setGuestEmail] = useState('');
+  const [lotId, setLotId] = useState('');
+  const [slotId, setSlotId] = useState('');
+  const [start, setStart] = useState('');
+  const [end, setEnd] = useState('');
+
+  const slotsQuery = useQuery({
+    queryKey: ['guest-slots', lotId],
+    enabled: !!lotId,
+    queryFn: async () => {
+      const res = await api.getLotSlots(lotId);
+      if (!res.success) throw new Error(res.error?.message ?? 'Stellplätze konnten nicht geladen werden');
+      return res.data ?? [];
+    },
+    staleTime: 30_000,
+  });
+  const slots: ParkingSlot[] = slotsQuery.data ?? [];
+  const availableSlots = useMemo(() => slots.filter((s) => s.status === 'available'), [slots]);
+
+  function submit() {
+    if (!guestName.trim() || !lotId || !slotId || !start || !end) {
+      toast('Bitte alle Pflichtfelder ausfüllen', 'error');
+      return;
+    }
+    onSubmit({
+      lot_id: lotId,
+      slot_id: slotId,
+      start_time: new Date(start).toISOString(),
+      end_time: new Date(end).toISOString(),
+      guest_name: guestName.trim(),
+      guest_email: guestEmail.trim() || null,
+    });
+  }
+
+  const disabled = isSubmitting || !guestName.trim() || !lotId || !slotId || !start || !end;
+
+  return (
+    <div role="dialog" aria-modal="true" aria-label="Gäste-Pass erstellen" style={{ position: 'fixed', inset: 0, zIndex: 1000, display: 'flex', alignItems: 'center', justifyContent: 'center', padding: 16 }}>
+      <div aria-hidden="true" onClick={onClose} style={{ position: 'absolute', inset: 0, background: 'oklch(0 0 0 / 0.45)', backdropFilter: 'blur(6px)' }} />
+      <Card lift={false} style={{ position: 'relative', width: '100%', maxWidth: 460, padding: 22, display: 'flex', flexDirection: 'column', gap: 12, zIndex: 1 }}>
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+          <div style={{ fontWeight: 700, fontSize: 14, color: 'var(--v5-txt)' }}>Gäste-Pass erstellen</div>
+          <button type="button" aria-label="Schließen" onClick={onClose} style={{ width: 28, height: 28, borderRadius: 8, background: 'var(--v5-sur2)', border: 'none', cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+            <V5NamedIcon name="x" size={13} color="var(--v5-mut)" />
+          </button>
+        </div>
+        <Field label="Gast-Name *">
+          <input type="text" value={guestName} onChange={(e) => setGuestName(e.target.value)} autoFocus style={inputStyle} data-testid="guest-name" />
+        </Field>
+        <Field label="Gast-E-Mail">
+          <input type="email" value={guestEmail} onChange={(e) => setGuestEmail(e.target.value)} style={inputStyle} data-testid="guest-email" />
+        </Field>
+        <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 10 }}>
+          <Field label="Parkhaus *">
+            <select value={lotId} onChange={(e) => { setLotId(e.target.value); setSlotId(''); }} style={inputStyle} data-testid="guest-lot">
+              <option value="">Bitte wählen…</option>
+              {lots.map((l) => (
+                <option key={l.id} value={l.id}>{l.name}</option>
+              ))}
+            </select>
+          </Field>
+          <Field label="Stellplatz *">
+            <select value={slotId} onChange={(e) => setSlotId(e.target.value)} disabled={!lotId} style={inputStyle} data-testid="guest-slot">
+              <option value="">{lotId ? 'Bitte wählen…' : 'Erst Parkhaus wählen'}</option>
+              {availableSlots.map((s) => (
+                <option key={s.id} value={s.id}>{s.number}</option>
+              ))}
+            </select>
+          </Field>
+        </div>
+        <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 10 }}>
+          <Field label="Start *">
+            <input type="datetime-local" value={start} onChange={(e) => setStart(e.target.value)} style={inputStyle} data-testid="guest-start" />
+          </Field>
+          <Field label="Ende *">
+            <input type="datetime-local" value={end} onChange={(e) => setEnd(e.target.value)} style={inputStyle} data-testid="guest-end" />
+          </Field>
+        </div>
+        <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8, paddingTop: 4 }}>
+          <button type="button" onClick={onClose} style={{ padding: '8px 14px', borderRadius: 9, background: 'transparent', border: '1px solid var(--v5-bor)', color: 'var(--v5-mut)', fontSize: 12, cursor: 'pointer' }}>
+            Abbrechen
+          </button>
+          <button
+            type="button"
+            disabled={disabled}
+            onClick={submit}
+            style={{
+              padding: '8px 16px',
+              borderRadius: 9,
+              background: 'var(--v5-acc)',
+              color: 'var(--v5-accent-fg)',
+              border: 'none',
+              fontSize: 12,
+              fontWeight: 600,
+              cursor: disabled ? 'default' : 'pointer',
+              opacity: disabled ? 0.5 : 1,
+            }}
+            data-testid="guest-submit"
+          >
+            {isSubmitting ? 'Erstellen…' : 'Pass erstellen'}
+          </button>
+        </div>
+      </Card>
+    </div>
+  );
+}
+
+export function GaestepassV5({ navigate: _navigate }: { navigate: (id: ScreenId) => void }) {
+  const toast = useV5Toast();
+  const qc = useQueryClient();
+  const [showCreate, setShowCreate] = useState(false);
+  const [createdCode, setCreatedCode] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  const bookingsQuery = useQuery({
+    queryKey: ['guest-bookings'],
+    queryFn: async () => {
+      const res = await api.getGuestBookings();
+      if (!res.success) throw new Error(res.error?.message ?? 'Gäste-Pässe konnten nicht geladen werden');
+      return res.data ?? [];
+    },
+    staleTime: 30_000,
+    refetchOnWindowFocus: true,
+  });
+
+  const lotsQuery = useQuery({
+    queryKey: ['guest-lots'],
+    queryFn: async () => {
+      const res = await api.getLots();
+      if (!res.success) throw new Error(res.error?.message ?? 'Parkhäuser konnten nicht geladen werden');
+      return res.data ?? [];
+    },
+    staleTime: 60_000,
+  });
+
+  const createMutation = useMutation({
+    mutationFn: async (payload: CreateGuestBookingPayload) => {
+      const res = await api.createGuestBooking(payload);
+      if (!res.success) throw new Error(res.error?.message ?? 'Gäste-Pass erstellen fehlgeschlagen');
+      return res.data;
+    },
+    onSuccess: (data) => {
+      qc.invalidateQueries({ queryKey: ['guest-bookings'] });
+      toast('Gäste-Pass erstellt', 'success');
+      setShowCreate(false);
+      if (data?.guest_code) setCreatedCode(data.guest_code);
+    },
+    onError: (err: Error) => toast(err.message, 'error'),
+  });
+
+  const cancelMutation = useMutation({
+    mutationFn: async (id: string) => {
+      const res = await api.cancelGuestBooking(id);
+      if (!res.success) throw new Error(res.error?.message ?? 'Stornierung fehlgeschlagen');
+      return res.data;
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['guest-bookings'] });
+      toast('Pass storniert', 'success');
+    },
+    onError: (err: Error) => toast(err.message, 'error'),
+  });
+
+  useEffect(() => {
+    if (copied) {
+      const timer = setTimeout(() => setCopied(false), 2000);
+      return () => clearTimeout(timer);
+    }
+  }, [copied]);
+
+  const bookings: GuestBooking[] = bookingsQuery.data ?? [];
+  const lots: ParkingLot[] = lotsQuery.data ?? [];
+  const activeCount = useMemo(() => bookings.filter((b) => b.status === 'active').length, [bookings]);
+
+  function copyCode(code: string) {
+    if (typeof navigator !== 'undefined' && navigator.clipboard) {
+      void navigator.clipboard.writeText(code).then(
+        () => {
+          setCopied(true);
+          toast('Code kopiert', 'info');
+        },
+        () => toast('Kopieren fehlgeschlagen', 'error'),
+      );
+    }
+  }
+
+  if (bookingsQuery.isLoading || lotsQuery.isLoading) {
+    return (
+      <div style={{ padding: 16, flex: 1, overflow: 'auto' }}>
+        <div style={{ height: 32, width: 220, borderRadius: 8, background: 'var(--v5-sur2)', marginBottom: 14, animation: 'ph-v5-pulse 1.6s ease infinite' }} />
+        {[0, 1, 2].map((i) => (
+          <div key={i} style={{ height: 70, borderRadius: 12, background: 'var(--v5-sur2)', marginBottom: 8, animation: 'ph-v5-pulse 1.6s ease infinite', animationDelay: `${i * 0.1}s` }} />
+        ))}
+      </div>
+    );
+  }
+
+  if (bookingsQuery.isError || lotsQuery.isError) {
+    return (
+      <div style={{ padding: 16, flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+        <Card className="v5-ani" style={{ padding: 28, textAlign: 'center', maxWidth: 360 }}>
+          <V5NamedIcon name="x" size={26} color="var(--v5-err)" />
+          <div style={{ marginTop: 10, fontWeight: 600, color: 'var(--v5-txt)' }}>Fehler beim Laden</div>
+          <div style={{ fontSize: 12, color: 'var(--v5-mut)', marginTop: 4 }}>Gäste-Pässe konnten nicht geladen werden.</div>
+        </Card>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <div style={{ padding: 16, flex: 1, overflow: 'auto', display: 'flex', flexDirection: 'column', gap: 12 }}>
+        <div className="v5-ani" style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+            <span style={{ fontWeight: 700, fontSize: 15, color: 'var(--v5-txt)' }}>Gäste-Pass</span>
+            <Badge variant="gray"><NumberFlow value={bookings.length} /></Badge>
+            {activeCount > 0 && <Badge variant="success" dot>{activeCount} aktiv</Badge>}
+          </div>
+          <button
+            type="button"
+            onClick={() => { setShowCreate(true); setCreatedCode(null); }}
+            className="v5-btn"
+            style={{ padding: '7px 14px', borderRadius: 9, background: 'var(--v5-acc)', color: 'var(--v5-accent-fg)', border: 'none', fontSize: 11, fontWeight: 600, cursor: 'pointer', display: 'flex', alignItems: 'center', gap: 5 }}
+            data-testid="open-create-guest"
+          >
+            <V5NamedIcon name="plus" size={12} />
+            Neuer Pass
+          </button>
+        </div>
+
+        {createdCode && (
+          <Card className="v5-ani" style={{ padding: 16, background: 'var(--v5-acc-muted)', border: '1px solid color-mix(in oklch, var(--v5-acc) 30%, transparent)' }} data-testid="created-code">
+            <div className="v5-mono" style={{ fontSize: 9, letterSpacing: 1.4, color: 'var(--v5-acc)', textTransform: 'uppercase' }}>
+              Neuer Code
+            </div>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginTop: 6 }}>
+              <code
+                className="v5-mono"
+                style={{ fontSize: 22, fontWeight: 800, color: 'var(--v5-acc)', letterSpacing: 2, background: 'var(--v5-sur)', padding: '6px 12px', borderRadius: 8 }}
+              >
+                {createdCode}
+              </code>
+              <button
+                type="button"
+                onClick={() => copyCode(createdCode)}
+                style={{ padding: '6px 12px', borderRadius: 8, background: 'var(--v5-sur)', border: '1px solid var(--v5-bor)', color: 'var(--v5-txt)', fontSize: 11, fontWeight: 600, cursor: 'pointer' }}
+                data-testid="copy-created-code"
+              >
+                {copied ? 'Kopiert' : 'Kopieren'}
+              </button>
+            </div>
+            <div style={{ fontSize: 11, color: 'var(--v5-mut)', marginTop: 6 }}>
+              Teilen Sie diesen Code mit Ihrem Gast, um den Stellplatz freizuschalten.
+            </div>
+          </Card>
+        )}
+
+        {bookings.length === 0 ? (
+          <Card className="v5-ani" style={{ padding: 36, display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 10, animationDelay: '0.06s' }}>
+            <div style={{ width: 48, height: 48, borderRadius: 14, background: 'var(--v5-acc-muted)', border: '1.5px dashed color-mix(in oklch, var(--v5-acc) 50%, transparent)', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+              <V5NamedIcon name="guest" size={20} color="var(--v5-acc)" />
+            </div>
+            <div style={{ textAlign: 'center' }}>
+              <div style={{ fontWeight: 600, color: 'var(--v5-txt)', fontSize: 13 }}>Noch keine Gäste-Pässe</div>
+              <div style={{ fontSize: 11, color: 'var(--v5-mut)', marginTop: 3 }}>Erstellen Sie einen temporären Zugang für Besucher.</div>
+            </div>
+            <button
+              type="button"
+              onClick={() => { setShowCreate(true); setCreatedCode(null); }}
+              className="v5-btn"
+              style={{ padding: '8px 16px', borderRadius: 9, background: 'var(--v5-acc)', color: 'var(--v5-accent-fg)', border: 'none', fontSize: 11, fontWeight: 600, cursor: 'pointer' }}
+            >
+              + Pass erstellen
+            </button>
+          </Card>
+        ) : (
+          <Card className="v5-ani" style={{ overflow: 'hidden', animationDelay: '0.12s' }}>
+            <div
+              className="v5-mono"
+              style={{
+                display: 'grid',
+                gridTemplateColumns: '1fr 110px 1fr 180px 90px',
+                padding: '8px 16px',
+                fontSize: 9,
+                letterSpacing: 1.2,
+                textTransform: 'uppercase',
+                color: 'var(--v5-mut)',
+                borderBottom: '1px solid var(--v5-bor)',
+              }}
+            >
+              <span>Gast</span>
+              <span>Code</span>
+              <span>Parkhaus / Platz</span>
+              <span>Zeitraum</span>
+              <span>Aktion</span>
+            </div>
+            {bookings.map((b, i) => {
+              const isCancelling = cancelMutation.isPending && cancelMutation.variables === b.id;
+              return (
+                <div
+                  key={b.id}
+                  data-testid="guest-row"
+                  className="v5-row"
+                  style={{
+                    display: 'grid',
+                    gridTemplateColumns: '1fr 110px 1fr 180px 90px',
+                    padding: '10px 16px',
+                    borderBottom: i < bookings.length - 1 ? '1px solid var(--v5-bor)' : 'none',
+                    alignItems: 'center',
+                    gap: 6,
+                  }}
+                >
+                  <div>
+                    <div style={{ fontSize: 12, fontWeight: 500, color: 'var(--v5-txt)' }}>{b.guest_name}</div>
+                    <div style={{ fontSize: 10, color: 'var(--v5-mut)' }}>
+                      {b.guest_email ?? 'Keine E-Mail'}
+                    </div>
+                  </div>
+                  <code
+                    className="v5-mono"
+                    style={{ fontSize: 11, fontWeight: 700, color: 'var(--v5-acc)', letterSpacing: 1, cursor: 'pointer' }}
+                    onClick={() => copyCode(b.guest_code)}
+                    title="Klicken zum Kopieren"
+                  >
+                    {b.guest_code}
+                  </code>
+                  <div>
+                    <div style={{ fontSize: 11, color: 'var(--v5-txt)' }}>{b.lot_name}</div>
+                    <div style={{ fontSize: 10, color: 'var(--v5-mut)' }}>Platz {b.slot_number}</div>
+                  </div>
+                  <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+                    <Badge variant={statusVariant(b.status)} dot>{STATUS_LABEL[b.status]}</Badge>
+                    <span style={{ fontSize: 10, color: 'var(--v5-mut)' }}>{formatRange(b.start_time, b.end_time)}</span>
+                  </div>
+                  {b.status === 'active' ? (
+                    <button
+                      type="button"
+                      disabled={isCancelling}
+                      onClick={() => cancelMutation.mutate(b.id)}
+                      style={{
+                        padding: '4px 10px',
+                        borderRadius: 7,
+                        background: 'color-mix(in oklch, var(--v5-err) 8%, transparent)',
+                        border: 'none',
+                        fontSize: 10,
+                        color: 'var(--v5-err)',
+                        cursor: isCancelling ? 'default' : 'pointer',
+                        opacity: isCancelling ? 0.5 : 1,
+                        fontWeight: 500,
+                      }}
+                      data-testid={`cancel-${b.id}`}
+                    >
+                      {isCancelling ? '…' : 'Storno'}
+                    </button>
+                  ) : (
+                    <span style={{ fontSize: 10, color: 'var(--v5-mut)' }}>—</span>
+                  )}
+                </div>
+              );
+            })}
+          </Card>
+        )}
+      </div>
+      {showCreate && (
+        <CreateGuestModal
+          lots={lots}
+          onClose={() => setShowCreate(false)}
+          onSubmit={(payload) => createMutation.mutate(payload)}
+          isSubmitting={createMutation.isPending}
+        />
+      )}
+    </>
+  );
+}

--- a/parkhub-web/src/design-v5/screens/Gaestepass.tsx
+++ b/parkhub-web/src/design-v5/screens/Gaestepass.tsx
@@ -12,18 +12,39 @@ import {
 } from '../../api/client';
 import type { ScreenId } from '../nav';
 
+// Backend (Rust `BookingStatus`, PHP `Booking::STATUS_*`) can return the full
+// booking status enum for guest passes. Rust creates fresh guest bookings with
+// `BookingStatus::Confirmed`, so `confirmed` is the most common newly-created
+// status. `pending`, `completed` and `no_show` are rare but legal, and we map
+// them to sensible visual fallbacks so the row is never blank.
 const STATUS_LABEL: Record<GuestBooking['status'], string> = {
+  pending: 'Ausstehend',
+  confirmed: 'Bestätigt',
   active: 'Aktiv',
+  completed: 'Abgeschlossen',
   expired: 'Abgelaufen',
   cancelled: 'Storniert',
+  no_show: 'Nicht erschienen',
 };
 
 function statusVariant(s: GuestBooking['status']) {
   switch (s) {
+    case 'pending': return 'warning' as const;
+    case 'confirmed': return 'info' as const;
     case 'active': return 'success' as const;
+    case 'completed': return 'gray' as const;
     case 'expired': return 'gray' as const;
     case 'cancelled': return 'error' as const;
+    case 'no_show': return 'error' as const;
   }
+}
+
+// A guest pass is "open" (pre-use or in-use) when it is still actionable from
+// the user's perspective — fresh passes land in `confirmed`, then flip to
+// `active` while the time window is open. Both states should count as active
+// and expose the Storno action.
+function isOpenStatus(s: GuestBooking['status']): boolean {
+  return s === 'confirmed' || s === 'active' || s === 'pending';
 }
 
 function formatRange(start: string, end: string): string {
@@ -135,7 +156,7 @@ function CreateGuestModal({
             <select value={slotId} onChange={(e) => setSlotId(e.target.value)} disabled={!lotId} style={inputStyle} data-testid="guest-slot">
               <option value="">{lotId ? 'Bitte wählen…' : 'Erst Parkhaus wählen'}</option>
               {availableSlots.map((s) => (
-                <option key={s.id} value={s.id}>{s.number}</option>
+                <option key={s.id} value={s.id}>{s.slot_number}</option>
               ))}
             </select>
           </Field>
@@ -242,7 +263,7 @@ export function GaestepassV5({ navigate: _navigate }: { navigate: (id: ScreenId)
 
   const bookings: GuestBooking[] = bookingsQuery.data ?? [];
   const lots: ParkingLot[] = lotsQuery.data ?? [];
-  const activeCount = useMemo(() => bookings.filter((b) => b.status === 'active').length, [bookings]);
+  const activeCount = useMemo(() => bookings.filter((b) => isOpenStatus(b.status)).length, [bookings]);
 
   function copyCode(code: string) {
     if (typeof navigator !== 'undefined' && navigator.clipboard) {
@@ -404,7 +425,7 @@ export function GaestepassV5({ navigate: _navigate }: { navigate: (id: ScreenId)
                     <Badge variant={statusVariant(b.status)} dot>{STATUS_LABEL[b.status]}</Badge>
                     <span style={{ fontSize: 10, color: 'var(--v5-mut)' }}>{formatRange(b.start_time, b.end_time)}</span>
                   </div>
-                  {b.status === 'active' ? (
+                  {isOpenStatus(b.status) ? (
                     <button
                       type="button"
                       disabled={isCancelling}

--- a/parkhub-web/src/design-v5/screens/Rangliste.test.tsx
+++ b/parkhub-web/src/design-v5/screens/Rangliste.test.tsx
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+const mockGetTeam = vi.fn();
+const mockGetAdminStats = vi.fn();
+vi.mock('../../api/client', () => ({
+  api: {
+    getTeam: (...a: unknown[]) => mockGetTeam(...a),
+    getAdminStatsExtended: (...a: unknown[]) => mockGetAdminStats(...a),
+  },
+}));
+
+vi.mock('@number-flow/react', () => ({
+  default: ({ value }: { value: number }) => <span>{value}</span>,
+}));
+
+const mockToast = vi.fn();
+vi.mock('../Toast', () => ({
+  useV5Toast: () => mockToast,
+  V5ToastProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+import { RanglisteV5 } from './Rangliste';
+
+function renderScreen(navigate = vi.fn()) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <RanglisteV5 navigate={navigate} />
+    </QueryClientProvider>
+  );
+}
+
+const TEAM_ALICE = { id: 'u1', username: 'alice', name: 'Alice', role: 'user' };
+const TEAM_BOB = { id: 'u2', username: 'bob', name: 'Bob', role: 'user' };
+
+const STATS_BASE = {
+  total_users: 2,
+  total_lots: 1,
+  total_bookings: 20,
+  active_bookings: 5,
+};
+
+const STATS_WITH_USERS = {
+  ...STATS_BASE,
+  bookings_by_user: {
+    u1: { total: 20, this_month: 12, ev_count: 10, morning_count: 8, swaps_accepted: 3, no_shows: 0, avg_duration_hours: 4 },
+    u2: { total: 10, this_month: 3, ev_count: 0, morning_count: 0, swaps_accepted: 0, no_shows: 2, avg_duration_hours: 2 },
+  },
+};
+
+describe('RanglisteV5', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('renders empty state when no members', async () => {
+    mockGetTeam.mockResolvedValue({ success: true, data: [] });
+    mockGetAdminStats.mockResolvedValue({ success: true, data: STATS_BASE });
+    renderScreen();
+    await waitFor(() => expect(screen.getByText('Keine Rangliste verfügbar')).toBeInTheDocument());
+  });
+
+  it('renders error when team query fails', async () => {
+    mockGetTeam.mockRejectedValue(new Error('network'));
+    mockGetAdminStats.mockResolvedValue({ success: true, data: STATS_BASE });
+    renderScreen();
+    await waitFor(() => expect(screen.getByText('Fehler beim Laden')).toBeInTheDocument());
+  });
+
+  it('surfaces error when team success:false', async () => {
+    mockGetTeam.mockResolvedValue({ success: false, data: null, error: { code: 'FORBIDDEN', message: 'denied' } });
+    mockGetAdminStats.mockResolvedValue({ success: true, data: STATS_BASE });
+    renderScreen();
+    await waitFor(() => expect(screen.getByText('Fehler beim Laden')).toBeInTheDocument());
+  });
+
+  it('surfaces error when stats success:false', async () => {
+    mockGetTeam.mockResolvedValue({ success: true, data: [TEAM_ALICE] });
+    mockGetAdminStats.mockResolvedValue({ success: false, data: null, error: { code: 'FORBIDDEN', message: 'denied' } });
+    renderScreen();
+    await waitFor(() => expect(screen.getByText('Fehler beim Laden')).toBeInTheDocument());
+  });
+
+  it('renders leaderboard rows sorted by eco score', async () => {
+    mockGetTeam.mockResolvedValue({ success: true, data: [TEAM_BOB, TEAM_ALICE] });
+    mockGetAdminStats.mockResolvedValue({ success: true, data: STATS_WITH_USERS });
+    renderScreen();
+    await waitFor(() => expect(screen.getAllByTestId('rank-row')).toHaveLength(2));
+    const rows = screen.getAllByTestId('rank-row');
+    // Alice has higher eco score due to EV + bookings
+    expect(rows[0]).toHaveTextContent('Alice');
+    expect(rows[1]).toHaveTextContent('Bob');
+  });
+
+  it('renders badges for EV / early / team / frequent stats', async () => {
+    mockGetTeam.mockResolvedValue({ success: true, data: [TEAM_ALICE] });
+    mockGetAdminStats.mockResolvedValue({ success: true, data: STATS_WITH_USERS });
+    renderScreen();
+    await waitFor(() => expect(screen.getByTestId('rank-row')).toBeInTheDocument());
+    expect(screen.getByText('EV')).toBeInTheDocument();
+    expect(screen.getByText('Früh')).toBeInTheDocument();
+    expect(screen.getByText('Teamplayer')).toBeInTheDocument();
+    expect(screen.getByText('Vielparker')).toBeInTheDocument();
+  });
+
+  it('shows highlight cards for aktivster / grünster / zuverlässigster', async () => {
+    mockGetTeam.mockResolvedValue({ success: true, data: [TEAM_ALICE, TEAM_BOB] });
+    mockGetAdminStats.mockResolvedValue({ success: true, data: STATS_WITH_USERS });
+    renderScreen();
+    await waitFor(() => expect(screen.getByTestId('highlights')).toBeInTheDocument());
+    expect(screen.getByText('Aktivster')).toBeInTheDocument();
+    expect(screen.getByText('Grünster')).toBeInTheDocument();
+    expect(screen.getByText('Zuverlässigster')).toBeInTheDocument();
+  });
+});

--- a/parkhub-web/src/design-v5/screens/Rangliste.test.tsx
+++ b/parkhub-web/src/design-v5/screens/Rangliste.test.tsx
@@ -74,9 +74,32 @@ describe('RanglisteV5', () => {
     await waitFor(() => expect(screen.getByText('Fehler beim Laden')).toBeInTheDocument());
   });
 
-  it('surfaces error when stats success:false', async () => {
-    mockGetTeam.mockResolvedValue({ success: true, data: [TEAM_ALICE] });
+  it('renders leaderboard with empty stats when admin stats are forbidden (non-admin)', async () => {
+    // Regression for PR #374: `/api/v1/admin/stats` is admin-gated in the Rust
+    // backend (`check_admin`), but /rangliste is reachable by normal users.
+    // FORBIDDEN must degrade gracefully, not hard-fail the screen.
+    mockGetTeam.mockResolvedValue({ success: true, data: [TEAM_ALICE, TEAM_BOB] });
     mockGetAdminStats.mockResolvedValue({ success: false, data: null, error: { code: 'FORBIDDEN', message: 'denied' } });
+    renderScreen();
+    await waitFor(() => expect(screen.getAllByTestId('rank-row')).toHaveLength(2));
+    expect(screen.queryByText('Fehler beim Laden')).toBeNull();
+    // Alice/Bob names may appear both in the highlight cards and the leaderboard
+    // rows, so assert on presence via getAllByText.
+    expect(screen.getAllByText('Alice').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Bob').length).toBeGreaterThan(0);
+  });
+
+  it('also degrades on HTTP_403 error code from admin stats', async () => {
+    mockGetTeam.mockResolvedValue({ success: true, data: [TEAM_ALICE] });
+    mockGetAdminStats.mockResolvedValue({ success: false, data: null, error: { code: 'HTTP_403', message: 'forbidden' } });
+    renderScreen();
+    await waitFor(() => expect(screen.getAllByTestId('rank-row')).toHaveLength(1));
+    expect(screen.queryByText('Fehler beim Laden')).toBeNull();
+  });
+
+  it('still surfaces error when stats fail with non-auth error', async () => {
+    mockGetTeam.mockResolvedValue({ success: true, data: [TEAM_ALICE] });
+    mockGetAdminStats.mockResolvedValue({ success: false, data: null, error: { code: 'HTTP_500', message: 'server error' } });
     renderScreen();
     await waitFor(() => expect(screen.getByText('Fehler beim Laden')).toBeInTheDocument());
   });

--- a/parkhub-web/src/design-v5/screens/Rangliste.tsx
+++ b/parkhub-web/src/design-v5/screens/Rangliste.tsx
@@ -1,0 +1,251 @@
+import { useMemo } from 'react';
+import NumberFlow from '@number-flow/react';
+import { useQuery } from '@tanstack/react-query';
+import { Badge, Card, V5NamedIcon } from '../primitives';
+import { api, type TeamMember, type UserBookingStats } from '../../api/client';
+import type { ScreenId } from '../nav';
+
+interface BadgeDef {
+  key: string;
+  label: string;
+  variant: 'primary' | 'success' | 'warning' | 'info' | 'purple';
+}
+
+interface LeaderboardEntry {
+  id: string;
+  name: string;
+  username: string;
+  ecoScore: number;
+  bookingsThisMonth: number;
+  evPercentage: number;
+  badges: BadgeDef[];
+  noShows: number;
+}
+
+function computeEcoScore(stats: UserBookingStats): number {
+  const bookingScore = Math.min(stats.this_month * 5, 40);
+  const evScore = stats.total > 0 ? (stats.ev_count / stats.total) * 30 : 0;
+  const durationScore = Math.min(stats.avg_duration_hours * 3, 20);
+  const reliabilityScore = stats.no_shows === 0 ? 10 : Math.max(0, 10 - stats.no_shows * 3);
+  return Math.round(bookingScore + evScore + durationScore + reliabilityScore);
+}
+
+function computeBadges(stats: UserBookingStats): BadgeDef[] {
+  const badges: BadgeDef[] = [];
+  if (stats.ev_count > 0) badges.push({ key: 'ev', label: 'EV', variant: 'success' });
+  if (stats.morning_count > 0) badges.push({ key: 'early', label: 'Früh', variant: 'warning' });
+  if (stats.swaps_accepted > 0) badges.push({ key: 'team', label: 'Teamplayer', variant: 'info' });
+  if (stats.this_month >= 10) badges.push({ key: 'frequent', label: 'Vielparker', variant: 'purple' });
+  return badges;
+}
+
+const EMPTY_STATS: UserBookingStats = {
+  total: 0, this_month: 0, ev_count: 0, morning_count: 0,
+  swaps_accepted: 0, no_shows: 0, avg_duration_hours: 0,
+};
+
+const MEDAL_COLOR = ['oklch(0.82 0.16 85)', 'oklch(0.72 0 0)', 'oklch(0.55 0.1 55)'];
+
+export function RanglisteV5({ navigate: _navigate }: { navigate: (id: ScreenId) => void }) {
+  const teamQuery = useQuery({
+    queryKey: ['team-members'],
+    queryFn: async () => {
+      const res = await api.getTeam();
+      if (!res.success) throw new Error(res.error?.message ?? 'Rangliste konnte nicht geladen werden');
+      return res.data ?? [];
+    },
+    staleTime: 30_000,
+    refetchOnWindowFocus: true,
+  });
+
+  const statsQuery = useQuery({
+    queryKey: ['admin-stats-extended'],
+    queryFn: async () => {
+      const res = await api.getAdminStatsExtended();
+      if (!res.success) throw new Error(res.error?.message ?? 'Statistiken konnten nicht geladen werden');
+      return res.data;
+    },
+    staleTime: 30_000,
+    refetchOnWindowFocus: true,
+  });
+
+  const isLoading = teamQuery.isLoading || statsQuery.isLoading;
+  const isError = teamQuery.isError || statsQuery.isError;
+  const members: TeamMember[] = teamQuery.data ?? [];
+  const stats = statsQuery.data;
+
+  const leaderboard = useMemo<LeaderboardEntry[]>(() => {
+    if (!members.length) return [];
+    const byUser = stats?.bookings_by_user ?? {};
+    return members
+      .map((m) => {
+        const s: UserBookingStats = byUser[m.id] ?? EMPTY_STATS;
+        return {
+          id: m.id,
+          name: m.name || m.username,
+          username: m.username,
+          ecoScore: computeEcoScore(s),
+          bookingsThisMonth: s.this_month,
+          evPercentage: s.total > 0 ? Math.round((s.ev_count / s.total) * 100) : 0,
+          badges: computeBadges(s),
+          noShows: s.no_shows,
+        };
+      })
+      .sort((a, b) => b.ecoScore - a.ecoScore);
+  }, [members, stats]);
+
+  const maxBookings = useMemo(
+    () => Math.max(1, ...leaderboard.map((e) => e.bookingsThisMonth)),
+    [leaderboard],
+  );
+
+  if (isLoading) {
+    return (
+      <div style={{ padding: 16, flex: 1, overflow: 'auto' }}>
+        <div style={{ height: 32, width: 220, borderRadius: 8, background: 'var(--v5-sur2)', marginBottom: 14, animation: 'ph-v5-pulse 1.6s ease infinite' }} />
+        {[0, 1, 2, 3].map((i) => (
+          <div key={i} style={{ height: 60, borderRadius: 12, background: 'var(--v5-sur2)', marginBottom: 8, animation: 'ph-v5-pulse 1.6s ease infinite', animationDelay: `${i * 0.1}s` }} />
+        ))}
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div style={{ padding: 16, flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+        <Card className="v5-ani" style={{ padding: 28, textAlign: 'center', maxWidth: 360 }}>
+          <V5NamedIcon name="x" size={26} color="var(--v5-err)" />
+          <div style={{ marginTop: 10, fontWeight: 600, color: 'var(--v5-txt)' }}>Fehler beim Laden</div>
+          <div style={{ fontSize: 12, color: 'var(--v5-mut)', marginTop: 4 }}>Rangliste konnte nicht geladen werden.</div>
+        </Card>
+      </div>
+    );
+  }
+
+  if (leaderboard.length === 0) {
+    return (
+      <div style={{ padding: 16, flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+        <Card className="v5-ani" style={{ padding: 36, display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 10, maxWidth: 380 }}>
+          <div style={{ width: 48, height: 48, borderRadius: 14, background: 'var(--v5-acc-muted)', border: '1.5px dashed color-mix(in oklch, var(--v5-acc) 50%, transparent)', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+            <V5NamedIcon name="rank" size={20} color="var(--v5-acc)" />
+          </div>
+          <div style={{ textAlign: 'center' }}>
+            <div style={{ fontWeight: 600, color: 'var(--v5-txt)', fontSize: 13 }}>Keine Rangliste verfügbar</div>
+            <div style={{ fontSize: 11, color: 'var(--v5-mut)', marginTop: 3 }}>Sobald Teammitglieder Buchungen haben, erscheint die Rangliste hier.</div>
+          </div>
+        </Card>
+      </div>
+    );
+  }
+
+  const highlights = [
+    {
+      label: 'Aktivster',
+      value: [...leaderboard].sort((a, b) => b.bookingsThisMonth - a.bookingsThisMonth)[0],
+      suffix: (e: LeaderboardEntry) => `${e.bookingsThisMonth} Buchungen`,
+    },
+    {
+      label: 'Grünster',
+      value: [...leaderboard].sort((a, b) => b.evPercentage - a.evPercentage)[0],
+      suffix: (e: LeaderboardEntry) => `${e.evPercentage}% EV`,
+    },
+    {
+      label: 'Zuverlässigster',
+      value: [...leaderboard].sort((a, b) => a.noShows - b.noShows || b.ecoScore - a.ecoScore)[0],
+      suffix: (e: LeaderboardEntry) => `${e.noShows} Ausfälle`,
+    },
+  ];
+
+  return (
+    <div style={{ padding: 16, flex: 1, overflow: 'auto', display: 'flex', flexDirection: 'column', gap: 12 }}>
+      <div className="v5-ani" style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <span style={{ fontWeight: 700, fontSize: 15, color: 'var(--v5-txt)' }}>Rangliste</span>
+          <Badge variant="gray"><NumberFlow value={leaderboard.length} /></Badge>
+        </div>
+      </div>
+
+      <div className="v5-ani" style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 10, animationDelay: '0.06s' }} data-testid="highlights">
+        {highlights.map((h) => (
+          <Card key={h.label} style={{ padding: 14 }}>
+            <div className="v5-mono" style={{ fontSize: 9, letterSpacing: 1.4, color: 'var(--v5-mut)', textTransform: 'uppercase' }}>
+              {h.label}
+            </div>
+            <div style={{ marginTop: 6, fontSize: 14, fontWeight: 700, color: 'var(--v5-txt)' }}>{h.value.name}</div>
+            <div style={{ fontSize: 11, color: 'var(--v5-mut)', marginTop: 2 }}>{h.suffix(h.value)}</div>
+          </Card>
+        ))}
+      </div>
+
+      <Card className="v5-ani" style={{ overflow: 'hidden', animationDelay: '0.12s' }} data-testid="leaderboard">
+        <div
+          className="v5-mono"
+          style={{
+            display: 'grid',
+            gridTemplateColumns: '36px 1fr 110px 60px 120px',
+            padding: '8px 16px',
+            fontSize: 9,
+            letterSpacing: 1.2,
+            textTransform: 'uppercase',
+            color: 'var(--v5-mut)',
+            borderBottom: '1px solid var(--v5-bor)',
+          }}
+        >
+          <span>Rang</span>
+          <span>Name</span>
+          <span>Abzeichen</span>
+          <span>Score</span>
+          <span>Buchungen</span>
+        </div>
+        {leaderboard.map((entry, idx) => (
+          <div
+            key={entry.id}
+            data-testid="rank-row"
+            className="v5-row"
+            style={{
+              display: 'grid',
+              gridTemplateColumns: '36px 1fr 110px 60px 120px',
+              padding: '10px 16px',
+              borderBottom: idx < leaderboard.length - 1 ? '1px solid var(--v5-bor)' : 'none',
+              alignItems: 'center',
+              gap: 6,
+            }}
+          >
+            {idx < 3 ? (
+              <V5NamedIcon name="rank" size={18} color={MEDAL_COLOR[idx]} />
+            ) : (
+              <span className="v5-mono" style={{ fontSize: 12, color: 'var(--v5-mut)', fontWeight: 600 }}>{idx + 1}</span>
+            )}
+            <div style={{ minWidth: 0 }}>
+              <div style={{ fontSize: 12, fontWeight: 500, color: 'var(--v5-txt)', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{entry.name}</div>
+              <div style={{ fontSize: 10, color: 'var(--v5-mut)' }}>@{entry.username}</div>
+            </div>
+            <div style={{ display: 'flex', flexWrap: 'wrap', gap: 4 }}>
+              {entry.badges.map((b) => (
+                <Badge key={b.key} variant={b.variant}>{b.label}</Badge>
+              ))}
+            </div>
+            <span className="v5-mono" style={{ fontSize: 14, fontWeight: 700, color: 'var(--v5-acc)', fontVariantNumeric: 'tabular-nums' }}>
+              {entry.ecoScore}
+            </span>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+              <div style={{ flex: 1, height: 6, background: 'var(--v5-sur2)', borderRadius: 999, overflow: 'hidden' }}>
+                <div
+                  style={{
+                    height: '100%',
+                    width: `${Math.min(100, (entry.bookingsThisMonth / maxBookings) * 100)}%`,
+                    background: 'var(--v5-acc)',
+                    borderRadius: 999,
+                  }}
+                />
+              </div>
+              <span className="v5-mono" style={{ fontSize: 10, color: 'var(--v5-mut)', minWidth: 18, textAlign: 'right', fontVariantNumeric: 'tabular-nums' }}>
+                {entry.bookingsThisMonth}
+              </span>
+            </div>
+          </div>
+        ))}
+      </Card>
+    </div>
+  );
+}

--- a/parkhub-web/src/design-v5/screens/Rangliste.tsx
+++ b/parkhub-web/src/design-v5/screens/Rangliste.tsx
@@ -58,11 +58,23 @@ export function RanglisteV5({ navigate: _navigate }: { navigate: (id: ScreenId) 
     refetchOnWindowFocus: true,
   });
 
+  // Admin stats are optional decoration on the leaderboard — `/api/v1/admin/stats`
+  // is admin-gated on both the Rust (`check_admin`) and PHP (admin middleware)
+  // backends, so non-admin users predictably receive FORBIDDEN. We degrade
+  // gracefully: the leaderboard still renders with team data only, every
+  // entry falling through to EMPTY_STATS (no badges, score = 0). Network or
+  // other non-auth failures continue to be treated as hard errors so they
+  // surface in the UI.
   const statsQuery = useQuery({
     queryKey: ['admin-stats-extended'],
     queryFn: async () => {
       const res = await api.getAdminStatsExtended();
-      if (!res.success) throw new Error(res.error?.message ?? 'Statistiken konnten nicht geladen werden');
+      if (!res.success) {
+        if (res.error?.code === 'FORBIDDEN' || res.error?.code === 'HTTP_403') {
+          return null;
+        }
+        throw new Error(res.error?.message ?? 'Statistiken konnten nicht geladen werden');
+      }
       return res.data;
     },
     staleTime: 30_000,

--- a/parkhub-web/src/design-v5/screens/Tausch.test.tsx
+++ b/parkhub-web/src/design-v5/screens/Tausch.test.tsx
@@ -1,0 +1,148 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+const mockGetSwaps = vi.fn();
+const mockGetBookings = vi.fn();
+const mockAccept = vi.fn();
+const mockDecline = vi.fn();
+const mockCreate = vi.fn();
+
+vi.mock('../../api/client', () => ({
+  api: {
+    getSwapRequests: (...a: unknown[]) => mockGetSwaps(...a),
+    getBookings: (...a: unknown[]) => mockGetBookings(...a),
+    acceptSwap: (...a: unknown[]) => mockAccept(...a),
+    declineSwap: (...a: unknown[]) => mockDecline(...a),
+    createSwapRequest: (...a: unknown[]) => mockCreate(...a),
+  },
+}));
+
+vi.mock('@number-flow/react', () => ({
+  default: ({ value }: { value: number }) => <span>{value}</span>,
+}));
+
+const mockToast = vi.fn();
+vi.mock('../Toast', () => ({
+  useV5Toast: () => mockToast,
+  V5ToastProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+import { TauschV5 } from './Tausch';
+
+function renderScreen(navigate = vi.fn()) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <TauschV5 navigate={navigate} />
+    </QueryClientProvider>
+  );
+}
+
+const SWAP_PENDING = {
+  id: 'sw1', requester_id: 'u1',
+  source_booking_id: 'b1', target_booking_id: 'b2',
+  source_booking: { lot_name: 'Nord', slot_number: 'A1', start_time: '2026-04-23T08:00:00Z', end_time: '2026-04-23T18:00:00Z' },
+  target_booking: { lot_name: 'Süd', slot_number: 'B2', start_time: '2026-04-23T08:00:00Z', end_time: '2026-04-23T18:00:00Z' },
+  message: 'Kurztausch',
+  status: 'pending' as const,
+  created_at: '2026-04-22T10:00:00Z',
+};
+const SWAP_ACCEPTED = { ...SWAP_PENDING, id: 'sw2', status: 'accepted' as const, message: null };
+
+const BOOKING_ACTIVE = {
+  id: 'b1', user_id: 'u1', lot_id: 'l1', slot_id: 's1',
+  lot_name: 'Nord', slot_number: 'A1', vehicle_plate: 'M-XY',
+  start_time: '2026-04-23T08:00:00Z', end_time: '2026-04-23T18:00:00Z',
+  status: 'active' as const,
+};
+
+describe('TauschV5', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('renders empty state when no swap requests', async () => {
+    mockGetSwaps.mockResolvedValue({ success: true, data: [] });
+    mockGetBookings.mockResolvedValue({ success: true, data: [] });
+    renderScreen();
+    await waitFor(() => expect(screen.getByText('Keine Tauschanfragen')).toBeInTheDocument());
+  });
+
+  it('renders error state when query fails', async () => {
+    mockGetSwaps.mockRejectedValue(new Error('network'));
+    mockGetBookings.mockResolvedValue({ success: true, data: [] });
+    renderScreen();
+    await waitFor(() => expect(screen.getByText('Fehler beim Laden')).toBeInTheDocument());
+  });
+
+  it('surfaces query error when success:false', async () => {
+    mockGetSwaps.mockResolvedValue({ success: false, data: null, error: { code: 'FORBIDDEN', message: 'denied' } });
+    mockGetBookings.mockResolvedValue({ success: true, data: [] });
+    renderScreen();
+    await waitFor(() => expect(screen.getByText('Fehler beim Laden')).toBeInTheDocument());
+  });
+
+  it('renders swap rows with status badges', async () => {
+    mockGetSwaps.mockResolvedValue({ success: true, data: [SWAP_PENDING, SWAP_ACCEPTED] });
+    mockGetBookings.mockResolvedValue({ success: true, data: [] });
+    renderScreen();
+    await waitFor(() => expect(screen.getAllByTestId('swap-row')).toHaveLength(2));
+    expect(screen.getByText('Offen')).toBeInTheDocument();
+    expect(screen.getByText('Angenommen')).toBeInTheDocument();
+  });
+
+  it('accept button calls acceptSwap and toast', async () => {
+    mockGetSwaps.mockResolvedValue({ success: true, data: [SWAP_PENDING] });
+    mockGetBookings.mockResolvedValue({ success: true, data: [] });
+    mockAccept.mockResolvedValue({ success: true, data: null });
+    renderScreen();
+    await waitFor(() => expect(screen.getByText('Annehmen')).toBeInTheDocument());
+    fireEvent.click(screen.getByText('Annehmen'));
+    await waitFor(() => {
+      expect(mockAccept).toHaveBeenCalledWith('sw1');
+      expect(mockToast).toHaveBeenCalledWith('Tausch angenommen', 'success');
+    });
+  });
+
+  it('emits error toast when acceptSwap success:false', async () => {
+    mockGetSwaps.mockResolvedValue({ success: true, data: [SWAP_PENDING] });
+    mockGetBookings.mockResolvedValue({ success: true, data: [] });
+    mockAccept.mockResolvedValue({ success: false, data: null, error: { code: 'CONFLICT', message: 'expired' } });
+    renderScreen();
+    await waitFor(() => expect(screen.getByText('Annehmen')).toBeInTheDocument());
+    fireEvent.click(screen.getByText('Annehmen'));
+    await waitFor(() => {
+      expect(mockToast).toHaveBeenCalledWith('expired', 'error');
+    });
+    expect(mockToast).not.toHaveBeenCalledWith('Tausch angenommen', 'success');
+  });
+
+  it('decline button calls declineSwap and toast', async () => {
+    mockGetSwaps.mockResolvedValue({ success: true, data: [SWAP_PENDING] });
+    mockGetBookings.mockResolvedValue({ success: true, data: [] });
+    mockDecline.mockResolvedValue({ success: true, data: null });
+    renderScreen();
+    await waitFor(() => expect(screen.getByText('Ablehnen')).toBeInTheDocument());
+    fireEvent.click(screen.getByText('Ablehnen'));
+    await waitFor(() => {
+      expect(mockDecline).toHaveBeenCalledWith('sw1');
+      expect(mockToast).toHaveBeenCalledWith('Tausch abgelehnt', 'success');
+    });
+  });
+
+  it('can open create modal and submit when active bookings exist', async () => {
+    mockGetSwaps.mockResolvedValue({ success: true, data: [] });
+    mockGetBookings.mockResolvedValue({ success: true, data: [BOOKING_ACTIVE] });
+    mockCreate.mockResolvedValue({ success: true, data: null });
+    renderScreen();
+    await waitFor(() => expect(screen.getByTestId('open-create-swap')).not.toBeDisabled());
+    fireEvent.click(screen.getByTestId('open-create-swap'));
+    expect(screen.getByTestId('swap-source')).toBeInTheDocument();
+    fireEvent.change(screen.getByTestId('swap-source'), { target: { value: 'b1' } });
+    fireEvent.change(screen.getByTestId('swap-target'), { target: { value: 'b2' } });
+    fireEvent.click(screen.getByTestId('swap-submit'));
+    await waitFor(() => {
+      expect(mockCreate).toHaveBeenCalledWith('b1', 'b2', null);
+      expect(mockToast).toHaveBeenCalledWith('Tauschanfrage gesendet', 'success');
+    });
+  });
+});

--- a/parkhub-web/src/design-v5/screens/Tausch.tsx
+++ b/parkhub-web/src/design-v5/screens/Tausch.tsx
@@ -1,0 +1,370 @@
+import { useMemo, useState, type CSSProperties, type ReactNode } from 'react';
+import NumberFlow from '@number-flow/react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { Badge, Card, V5NamedIcon } from '../primitives';
+import { useV5Toast } from '../Toast';
+import { api, type Booking, type SwapRequest } from '../../api/client';
+import type { ScreenId } from '../nav';
+
+const STATUS_LABEL: Record<SwapRequest['status'], string> = {
+  pending: 'Offen',
+  accepted: 'Angenommen',
+  declined: 'Abgelehnt',
+};
+
+function statusVariant(s: SwapRequest['status']) {
+  switch (s) {
+    case 'pending': return 'warning' as const;
+    case 'accepted': return 'success' as const;
+    case 'declined': return 'error' as const;
+  }
+}
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString('de-DE', { day: '2-digit', month: '2-digit', year: '2-digit' });
+}
+function formatTime(iso: string): string {
+  return new Date(iso).toLocaleTimeString('de-DE', { hour: '2-digit', minute: '2-digit' });
+}
+
+const inputStyle: CSSProperties = {
+  padding: '8px 11px',
+  borderRadius: 9,
+  background: 'var(--v5-sur2)',
+  border: '1px solid var(--v5-bor)',
+  color: 'var(--v5-txt)',
+  fontSize: 12,
+  width: '100%',
+  outline: 'none',
+  boxSizing: 'border-box',
+  fontFamily: 'inherit',
+};
+
+function Field({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+      <label style={{ fontSize: 11, fontWeight: 500, color: 'var(--v5-mut)' }}>{label}</label>
+      {children}
+    </div>
+  );
+}
+
+function CreateSwapModal({
+  bookings,
+  onClose,
+  onSubmit,
+  isSubmitting,
+}: {
+  bookings: Booking[];
+  onClose: () => void;
+  onSubmit: (sourceId: string, targetId: string, message: string | null) => void;
+  isSubmitting: boolean;
+}) {
+  const [sourceId, setSourceId] = useState('');
+  const [targetId, setTargetId] = useState('');
+  const [message, setMessage] = useState('');
+  const disabled = !sourceId || !targetId || isSubmitting;
+  return (
+    <div role="dialog" aria-modal="true" aria-label="Tausch anfragen" style={{ position: 'fixed', inset: 0, zIndex: 1000, display: 'flex', alignItems: 'center', justifyContent: 'center', padding: 16 }}>
+      <div aria-hidden="true" onClick={onClose} style={{ position: 'absolute', inset: 0, background: 'oklch(0 0 0 / 0.45)', backdropFilter: 'blur(6px)' }} />
+      <Card lift={false} style={{ position: 'relative', width: '100%', maxWidth: 440, padding: 22, display: 'flex', flexDirection: 'column', gap: 14, zIndex: 1 }}>
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+          <div style={{ fontWeight: 700, fontSize: 14, color: 'var(--v5-txt)' }}>Tausch anfragen</div>
+          <button type="button" aria-label="Schließen" onClick={onClose} style={{ width: 28, height: 28, borderRadius: 8, background: 'var(--v5-sur2)', border: 'none', cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+            <V5NamedIcon name="x" size={13} color="var(--v5-mut)" />
+          </button>
+        </div>
+        <Field label="Ihre Buchung *">
+          <select value={sourceId} onChange={(e) => setSourceId(e.target.value)} style={inputStyle} data-testid="swap-source">
+            <option value="">Bitte wählen…</option>
+            {bookings.map((b) => (
+              <option key={b.id} value={b.id}>
+                {b.lot_name} · Platz {b.slot_number} ({formatDate(b.start_time)} {formatTime(b.start_time)})
+              </option>
+            ))}
+          </select>
+        </Field>
+        <Field label="Ziel-Buchungs-ID *">
+          <input type="text" value={targetId} onChange={(e) => setTargetId(e.target.value)} placeholder="b-…" style={inputStyle} data-testid="swap-target" />
+        </Field>
+        <Field label="Nachricht (optional)">
+          <textarea value={message} onChange={(e) => setMessage(e.target.value)} rows={3} style={{ ...inputStyle, resize: 'vertical' }} data-testid="swap-message" />
+        </Field>
+        <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8, paddingTop: 4 }}>
+          <button type="button" onClick={onClose} style={{ padding: '8px 14px', borderRadius: 9, background: 'transparent', border: '1px solid var(--v5-bor)', color: 'var(--v5-mut)', fontSize: 12, cursor: 'pointer' }}>
+            Abbrechen
+          </button>
+          <button
+            type="button"
+            disabled={disabled}
+            onClick={() => onSubmit(sourceId, targetId, message.trim() || null)}
+            style={{
+              padding: '8px 16px',
+              borderRadius: 9,
+              background: 'var(--v5-acc)',
+              color: 'var(--v5-accent-fg)',
+              border: 'none',
+              fontSize: 12,
+              fontWeight: 600,
+              cursor: disabled ? 'default' : 'pointer',
+              opacity: disabled ? 0.5 : 1,
+            }}
+            data-testid="swap-submit"
+          >
+            {isSubmitting ? 'Senden…' : 'Anfrage senden'}
+          </button>
+        </div>
+      </Card>
+    </div>
+  );
+}
+
+export function TauschV5({ navigate: _navigate }: { navigate: (id: ScreenId) => void }) {
+  const toast = useV5Toast();
+  const qc = useQueryClient();
+  const [showCreate, setShowCreate] = useState(false);
+
+  const requestsQuery = useQuery({
+    queryKey: ['swap-requests'],
+    queryFn: async () => {
+      const res = await api.getSwapRequests();
+      if (!res.success) throw new Error(res.error?.message ?? 'Tauschanfragen konnten nicht geladen werden');
+      return res.data ?? [];
+    },
+    staleTime: 30_000,
+    refetchOnWindowFocus: true,
+  });
+
+  const bookingsQuery = useQuery({
+    queryKey: ['swap-bookings'],
+    queryFn: async () => {
+      const res = await api.getBookings();
+      if (!res.success) throw new Error(res.error?.message ?? 'Buchungen konnten nicht geladen werden');
+      return res.data ?? [];
+    },
+    staleTime: 30_000,
+    refetchOnWindowFocus: true,
+  });
+
+  const acceptMutation = useMutation({
+    mutationFn: async (id: string) => {
+      const res = await api.acceptSwap(id);
+      if (!res.success) throw new Error(res.error?.message ?? 'Annahme fehlgeschlagen');
+      return res.data;
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['swap-requests'] });
+      toast('Tausch angenommen', 'success');
+    },
+    onError: (err: Error) => toast(err.message, 'error'),
+  });
+
+  const declineMutation = useMutation({
+    mutationFn: async (id: string) => {
+      const res = await api.declineSwap(id);
+      if (!res.success) throw new Error(res.error?.message ?? 'Ablehnung fehlgeschlagen');
+      return res.data;
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['swap-requests'] });
+      toast('Tausch abgelehnt', 'success');
+    },
+    onError: (err: Error) => toast(err.message, 'error'),
+  });
+
+  const createMutation = useMutation({
+    mutationFn: async (vars: { source: string; target: string; message: string | null }) => {
+      const res = await api.createSwapRequest(vars.source, vars.target, vars.message);
+      if (!res.success) throw new Error(res.error?.message ?? 'Anfrage senden fehlgeschlagen');
+      return res.data;
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['swap-requests'] });
+      toast('Tauschanfrage gesendet', 'success');
+      setShowCreate(false);
+    },
+    onError: (err: Error) => toast(err.message, 'error'),
+  });
+
+  const isLoading = requestsQuery.isLoading || bookingsQuery.isLoading;
+  const isError = requestsQuery.isError || bookingsQuery.isError;
+
+  const requests: SwapRequest[] = requestsQuery.data ?? [];
+  const bookings: Booking[] = bookingsQuery.data ?? [];
+  const activeBookings = useMemo(
+    () => bookings.filter((b) => b.status === 'active' || b.status === 'confirmed'),
+    [bookings],
+  );
+  const pendingCount = useMemo(() => requests.filter((r) => r.status === 'pending').length, [requests]);
+
+  if (isLoading) {
+    return (
+      <div style={{ padding: 16, flex: 1, overflow: 'auto' }}>
+        <div style={{ height: 32, width: 200, borderRadius: 8, background: 'var(--v5-sur2)', marginBottom: 14, animation: 'ph-v5-pulse 1.6s ease infinite' }} />
+        {[0, 1, 2].map((i) => (
+          <div key={i} style={{ height: 90, borderRadius: 12, background: 'var(--v5-sur2)', marginBottom: 8, animation: 'ph-v5-pulse 1.6s ease infinite', animationDelay: `${i * 0.1}s` }} />
+        ))}
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div style={{ padding: 16, flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+        <Card className="v5-ani" style={{ padding: 28, textAlign: 'center', maxWidth: 360 }}>
+          <V5NamedIcon name="x" size={26} color="var(--v5-err)" />
+          <div style={{ marginTop: 10, fontWeight: 600, color: 'var(--v5-txt)' }}>Fehler beim Laden</div>
+          <div style={{ fontSize: 12, color: 'var(--v5-mut)', marginTop: 4 }}>Tauschanfragen konnten nicht geladen werden.</div>
+        </Card>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <div style={{ padding: 16, flex: 1, overflow: 'auto', display: 'flex', flexDirection: 'column', gap: 12 }}>
+        <div className="v5-ani" style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+            <span style={{ fontWeight: 700, fontSize: 15, color: 'var(--v5-txt)' }}>Tausch</span>
+            <Badge variant="gray"><NumberFlow value={requests.length} /></Badge>
+            {pendingCount > 0 && <Badge variant="warning" dot>{pendingCount} offen</Badge>}
+          </div>
+          <button
+            type="button"
+            onClick={() => setShowCreate(true)}
+            className="v5-btn"
+            disabled={activeBookings.length === 0}
+            style={{
+              padding: '7px 14px',
+              borderRadius: 9,
+              background: 'var(--v5-acc)',
+              color: 'var(--v5-accent-fg)',
+              border: 'none',
+              fontSize: 11,
+              fontWeight: 600,
+              cursor: activeBookings.length === 0 ? 'default' : 'pointer',
+              opacity: activeBookings.length === 0 ? 0.5 : 1,
+              display: 'flex', alignItems: 'center', gap: 5,
+            }}
+            data-testid="open-create-swap"
+          >
+            <V5NamedIcon name="swap" size={12} />
+            Neue Anfrage
+          </button>
+        </div>
+
+        {requests.length === 0 ? (
+          <Card className="v5-ani" style={{ padding: 36, display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 10, animationDelay: '0.06s' }}>
+            <div style={{ width: 48, height: 48, borderRadius: 14, background: 'var(--v5-acc-muted)', border: '1.5px dashed color-mix(in oklch, var(--v5-acc) 50%, transparent)', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+              <V5NamedIcon name="swap" size={20} color="var(--v5-acc)" />
+            </div>
+            <div style={{ textAlign: 'center' }}>
+              <div style={{ fontWeight: 600, color: 'var(--v5-txt)', fontSize: 13 }}>Keine Tauschanfragen</div>
+              <div style={{ fontSize: 11, color: 'var(--v5-mut)', marginTop: 3 }}>Tauschen Sie Ihren Stellplatz mit einem Teammitglied.</div>
+            </div>
+          </Card>
+        ) : (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+            {requests.map((r, i) => {
+              const isAccepting = acceptMutation.isPending && acceptMutation.variables === r.id;
+              const isDeclining = declineMutation.isPending && declineMutation.variables === r.id;
+              return (
+                <Card
+                  key={r.id}
+                  data-testid="swap-row"
+                  className="v5-ani"
+                  style={{ padding: 14, animationDelay: `${i * 0.05}s` }}
+                >
+                  <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 10 }}>
+                    <div style={{ display: 'flex', alignItems: 'center', gap: 8, minWidth: 0 }}>
+                      <V5NamedIcon name="swap" size={14} color="var(--v5-acc)" />
+                      <span style={{ fontSize: 12, fontWeight: 600, color: 'var(--v5-txt)' }}>
+                        {r.source_booking.lot_name}
+                      </span>
+                      <span style={{ color: 'var(--v5-mut)' }}>→</span>
+                      <span style={{ fontSize: 12, fontWeight: 600, color: 'var(--v5-txt)' }}>
+                        {r.target_booking.lot_name}
+                      </span>
+                    </div>
+                    <Badge variant={statusVariant(r.status)} dot>{STATUS_LABEL[r.status]}</Badge>
+                  </div>
+                  <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 10, marginBottom: 10 }}>
+                    <SlotPanel label="Ihr Platz" lot={r.source_booking.lot_name} slot={r.source_booking.slot_number} start={r.source_booking.start_time} end={r.source_booking.end_time} />
+                    <SlotPanel label="Ziel" lot={r.target_booking.lot_name} slot={r.target_booking.slot_number} start={r.target_booking.start_time} end={r.target_booking.end_time} />
+                  </div>
+                  {r.message && (
+                    <div style={{ fontSize: 11, color: 'var(--v5-mut)', fontStyle: 'italic', marginBottom: 10 }}>
+                      „{r.message}"
+                    </div>
+                  )}
+                  {r.status === 'pending' && (
+                    <div style={{ display: 'flex', gap: 6 }}>
+                      <button
+                        type="button"
+                        disabled={isAccepting || isDeclining}
+                        onClick={() => acceptMutation.mutate(r.id)}
+                        style={{
+                          padding: '6px 12px',
+                          borderRadius: 8,
+                          background: 'var(--v5-acc)',
+                          color: 'var(--v5-accent-fg)',
+                          border: 'none',
+                          fontSize: 11,
+                          fontWeight: 600,
+                          cursor: isAccepting ? 'default' : 'pointer',
+                          opacity: isAccepting ? 0.6 : 1,
+                        }}
+                        data-testid={`accept-${r.id}`}
+                      >
+                        {isAccepting ? '…' : 'Annehmen'}
+                      </button>
+                      <button
+                        type="button"
+                        disabled={isAccepting || isDeclining}
+                        onClick={() => declineMutation.mutate(r.id)}
+                        style={{
+                          padding: '6px 12px',
+                          borderRadius: 8,
+                          background: 'color-mix(in oklch, var(--v5-err) 10%, transparent)',
+                          color: 'var(--v5-err)',
+                          border: '1px solid color-mix(in oklch, var(--v5-err) 30%, transparent)',
+                          fontSize: 11,
+                          fontWeight: 600,
+                          cursor: isDeclining ? 'default' : 'pointer',
+                          opacity: isDeclining ? 0.6 : 1,
+                        }}
+                        data-testid={`decline-${r.id}`}
+                      >
+                        {isDeclining ? '…' : 'Ablehnen'}
+                      </button>
+                    </div>
+                  )}
+                </Card>
+              );
+            })}
+          </div>
+        )}
+      </div>
+      {showCreate && (
+        <CreateSwapModal
+          bookings={activeBookings}
+          onClose={() => setShowCreate(false)}
+          onSubmit={(source, target, message) => createMutation.mutate({ source, target, message })}
+          isSubmitting={createMutation.isPending}
+        />
+      )}
+    </>
+  );
+}
+
+function SlotPanel({ label, lot, slot, start, end }: { label: string; lot: string; slot: string; start: string; end: string }) {
+  return (
+    <div style={{ padding: 10, borderRadius: 10, background: 'var(--v5-sur2)', border: '1px solid var(--v5-bor)' }}>
+      <div className="v5-mono" style={{ fontSize: 9, letterSpacing: 1.2, color: 'var(--v5-mut)', textTransform: 'uppercase', marginBottom: 4 }}>{label}</div>
+      <div style={{ fontSize: 12, fontWeight: 500, color: 'var(--v5-txt)' }}>{lot}</div>
+      <div style={{ fontSize: 10, color: 'var(--v5-mut)', marginTop: 2 }}>
+        Platz {slot} · {formatDate(start)} {formatTime(start)}–{formatTime(end)}
+      </div>
+    </div>
+  );
+}

--- a/parkhub-web/src/design-v5/screens/Team.test.tsx
+++ b/parkhub-web/src/design-v5/screens/Team.test.tsx
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+const mockTeamAbsences = vi.fn();
+vi.mock('../../api/client', () => ({
+  api: {
+    teamAbsences: (...a: unknown[]) => mockTeamAbsences(...a),
+  },
+}));
+
+vi.mock('@number-flow/react', () => ({
+  default: ({ value }: { value: number }) => <span>{value}</span>,
+}));
+
+const mockToast = vi.fn();
+vi.mock('../Toast', () => ({
+  useV5Toast: () => mockToast,
+  V5ToastProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+import { TeamV5 } from './Team';
+
+function renderScreen(navigate = vi.fn()) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <TeamV5 navigate={navigate} />
+    </QueryClientProvider>
+  );
+}
+
+const TODAY = new Date().toISOString().slice(0, 10);
+const FAR_FUTURE = '2099-01-01';
+const PAST = '2000-01-01';
+
+const ABSENCE_TODAY = { user_name: 'Alice', absence_type: 'vacation', start_date: TODAY, end_date: TODAY };
+const ABSENCE_HOMEOFFICE_TODAY = { user_name: 'Bob', absence_type: 'homeoffice', start_date: TODAY, end_date: TODAY };
+const ABSENCE_UPCOMING = { user_name: 'Bob', absence_type: 'homeoffice', start_date: FAR_FUTURE, end_date: FAR_FUTURE };
+const ABSENCE_PAST = { user_name: 'Carol', absence_type: 'sick', start_date: PAST, end_date: PAST };
+
+describe('TeamV5', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('renders empty state when no members', async () => {
+    mockTeamAbsences.mockResolvedValue({ success: true, data: [] });
+    renderScreen();
+    await waitFor(() => expect(screen.getByText('Noch keine Teamdaten')).toBeInTheDocument());
+  });
+
+  it('renders error state when query fails', async () => {
+    mockTeamAbsences.mockRejectedValue(new Error('network'));
+    renderScreen();
+    await waitFor(() => expect(screen.getByText('Fehler beim Laden')).toBeInTheDocument());
+  });
+
+  it('surfaces query error when success:false', async () => {
+    mockTeamAbsences.mockResolvedValue({ success: false, data: null, error: { code: 'FORBIDDEN', message: 'denied' } });
+    renderScreen();
+    await waitFor(() => expect(screen.getByText('Fehler beim Laden')).toBeInTheDocument());
+  });
+
+  it('renders team rows with name and status badge', async () => {
+    mockTeamAbsences.mockResolvedValue({ success: true, data: [ABSENCE_TODAY, ABSENCE_HOMEOFFICE_TODAY] });
+    renderScreen();
+    await waitFor(() => expect(screen.getAllByTestId('team-row')).toHaveLength(2));
+    // Alice appears in roster row + today-absences panel, so allow multiple matches
+    expect(screen.getAllByText('Alice').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText('Bob').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText('Abwesend')).toBeInTheDocument();
+    expect(screen.getByText('Home Office')).toBeInTheDocument();
+  });
+
+  it('shows today absence panel when someone is out today', async () => {
+    mockTeamAbsences.mockResolvedValue({ success: true, data: [ABSENCE_TODAY] });
+    renderScreen();
+    await waitFor(() => expect(screen.getByTestId('today-absences')).toBeInTheDocument());
+    // "Heute abwesend" appears in the stat tile + panel heading, both are fine
+    expect(screen.getAllByText(/Heute abwesend/).length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText('Urlaub')).toBeInTheDocument();
+  });
+
+  it('derives "Gebucht" status for members without today/past absences active', async () => {
+    mockTeamAbsences.mockResolvedValue({ success: true, data: [ABSENCE_PAST] });
+    renderScreen();
+    await waitFor(() => expect(screen.getByText('Carol')).toBeInTheDocument());
+    expect(screen.getByText('Gebucht')).toBeInTheDocument();
+  });
+
+  it('renders correctly with mixed absence types', async () => {
+    mockTeamAbsences.mockResolvedValue({
+      success: true,
+      data: [ABSENCE_TODAY, ABSENCE_UPCOMING, ABSENCE_PAST],
+    });
+    renderScreen();
+    await waitFor(() => expect(screen.getAllByTestId('team-row')).toHaveLength(3));
+    // members sorted alphabetically: Alice, Bob, Carol
+    const rows = screen.getAllByTestId('team-row');
+    expect(rows[0]).toHaveTextContent('Alice');
+    expect(rows[1]).toHaveTextContent('Bob');
+    expect(rows[2]).toHaveTextContent('Carol');
+  });
+});

--- a/parkhub-web/src/design-v5/screens/Team.tsx
+++ b/parkhub-web/src/design-v5/screens/Team.tsx
@@ -1,0 +1,260 @@
+import { useMemo } from 'react';
+import NumberFlow from '@number-flow/react';
+import { useQuery } from '@tanstack/react-query';
+import { Badge, Card, V5NamedIcon } from '../primitives';
+import { api, type TeamAbsenceEntry } from '../../api/client';
+import type { ScreenId } from '../nav';
+
+type TeamMemberStatus = 'booked' | 'absent' | 'available' | 'home';
+
+interface TeamMemberRow {
+  name: string;
+  department: string;
+  status: TeamMemberStatus;
+  statusLabel: string;
+  slot: string;
+  since: string;
+  entries: TeamAbsenceEntry[];
+}
+
+function inferStatus(absenceType?: string): TeamMemberStatus {
+  if (!absenceType) return 'booked';
+  if (absenceType === 'homeoffice') return 'home';
+  if (absenceType === 'vacation' || absenceType === 'sick' || absenceType === 'other') return 'absent';
+  return 'available';
+}
+
+function statusLabelFor(status: TeamMemberStatus): string {
+  switch (status) {
+    case 'booked': return 'Gebucht';
+    case 'absent': return 'Abwesend';
+    case 'home': return 'Home Office';
+    default: return 'Verfügbar';
+  }
+}
+
+function statusVariant(s: TeamMemberStatus) {
+  switch (s) {
+    case 'booked': return 'success' as const;
+    case 'absent': return 'error' as const;
+    case 'home': return 'info' as const;
+    default: return 'primary' as const;
+  }
+}
+
+function groupByUser(list: TeamAbsenceEntry[]): Record<string, TeamAbsenceEntry[]> {
+  const groups: Record<string, TeamAbsenceEntry[]> = {};
+  for (const entry of list) {
+    if (!groups[entry.user_name]) groups[entry.user_name] = [];
+    groups[entry.user_name].push(entry);
+  }
+  return groups;
+}
+
+function formatMonthYear(value: string): string {
+  return new Date(`${value}T00:00:00`).toLocaleDateString('de-DE', { month: 'short', year: '2-digit' });
+}
+
+function formatDate(value: string): string {
+  return new Date(`${value}T00:00:00`).toLocaleDateString('de-DE', { day: 'numeric', month: 'short' });
+}
+
+function absenceLabel(type: string): string {
+  if (type === 'homeoffice') return 'Homeoffice';
+  if (type === 'vacation') return 'Urlaub';
+  if (type === 'sick') return 'Krank';
+  if (type === 'other') return 'Sonstiges';
+  return type;
+}
+
+export function TeamV5({ navigate: _navigate }: { navigate: (id: ScreenId) => void }) {
+  const { data: entries = [], isLoading, isError } = useQuery({
+    queryKey: ['team-absences'],
+    queryFn: async () => {
+      const res = await api.teamAbsences();
+      if (!res.success) throw new Error(res.error?.message ?? 'Team konnte nicht geladen werden');
+      return res.data ?? [];
+    },
+    staleTime: 30_000,
+    refetchOnWindowFocus: true,
+  });
+
+  const todayStr = useMemo(() => new Date().toISOString().slice(0, 10), []);
+
+  const todayEntries = useMemo(
+    () => entries.filter((e) => e.start_date <= todayStr && e.end_date >= todayStr),
+    [entries, todayStr],
+  );
+
+  const upcomingEntries = useMemo(
+    () => entries.filter((e) => e.start_date > todayStr).sort((a, b) => a.start_date.localeCompare(b.start_date)),
+    [entries, todayStr],
+  );
+
+  const members = useMemo<TeamMemberRow[]>(() => {
+    const byUser = groupByUser(entries);
+    return Object.entries(byUser)
+      .map(([name, userEntries], index) => {
+        const current = userEntries.find((e) => e.start_date <= todayStr && e.end_date >= todayStr);
+        const next = [...userEntries].sort((a, b) => a.start_date.localeCompare(b.start_date))[0];
+        const status = inferStatus(current?.absence_type);
+        return {
+          name,
+          department: `Team ${index + 1}`,
+          status,
+          statusLabel: statusLabelFor(status),
+          slot: status === 'booked' ? `A-0${(index % 8) + 1}` : '—',
+          since: next ? formatMonthYear(next.start_date) : '—',
+          entries: userEntries,
+        };
+      })
+      .sort((a, b) => a.name.localeCompare(b.name));
+  }, [entries, todayStr]);
+
+  if (isLoading) {
+    return (
+      <div style={{ padding: 16, flex: 1, overflow: 'auto' }}>
+        <div style={{ height: 32, width: 200, borderRadius: 8, background: 'var(--v5-sur2)', marginBottom: 14, animation: 'ph-v5-pulse 1.6s ease infinite' }} />
+        {[0, 1, 2].map((i) => (
+          <div key={i} style={{ height: 70, borderRadius: 12, background: 'var(--v5-sur2)', marginBottom: 8, animation: 'ph-v5-pulse 1.6s ease infinite', animationDelay: `${i * 0.1}s` }} />
+        ))}
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div style={{ padding: 16, flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+        <Card className="v5-ani" style={{ padding: 28, textAlign: 'center', maxWidth: 360 }}>
+          <V5NamedIcon name="x" size={26} color="var(--v5-err)" />
+          <div style={{ marginTop: 10, fontWeight: 600, color: 'var(--v5-txt)' }}>Fehler beim Laden</div>
+          <div style={{ fontSize: 12, color: 'var(--v5-mut)', marginTop: 4 }}>Team konnte nicht geladen werden.</div>
+        </Card>
+      </div>
+    );
+  }
+
+  if (members.length === 0) {
+    return (
+      <div style={{ padding: 16, flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+        <Card className="v5-ani" style={{ padding: 36, display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 10, maxWidth: 380 }}>
+          <div style={{ width: 48, height: 48, borderRadius: 14, background: 'var(--v5-acc-muted)', border: '1.5px dashed color-mix(in oklch, var(--v5-acc) 50%, transparent)', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+            <V5NamedIcon name="users" size={20} color="var(--v5-acc)" />
+          </div>
+          <div style={{ textAlign: 'center' }}>
+            <div style={{ fontWeight: 600, color: 'var(--v5-txt)', fontSize: 13 }}>Noch keine Teamdaten</div>
+            <div style={{ fontSize: 11, color: 'var(--v5-mut)', marginTop: 3 }}>Sobald Kollegen Abwesenheiten eintragen, erscheinen sie hier.</div>
+          </div>
+        </Card>
+      </div>
+    );
+  }
+
+  const presentCount = Math.max(0, members.length - todayEntries.length);
+
+  return (
+    <div style={{ padding: 16, flex: 1, overflow: 'auto', display: 'flex', flexDirection: 'column', gap: 12 }}>
+      <div className="v5-ani" style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <span style={{ fontWeight: 700, fontSize: 15, color: 'var(--v5-txt)' }}>Team</span>
+          <Badge variant="gray"><NumberFlow value={members.length} /></Badge>
+        </div>
+      </div>
+
+      <div className="v5-ani" style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 10, animationDelay: '0.06s' }}>
+        <StatTile label="Heute anwesend" value={presentCount} accent />
+        <StatTile label="Heute abwesend" value={todayEntries.length} />
+        <StatTile label="Kommende Abwesenheiten" value={upcomingEntries.length} />
+      </div>
+
+      <Card className="v5-ani" style={{ overflow: 'hidden', animationDelay: '0.12s' }} data-testid="team-roster">
+        <div
+          className="v5-mono"
+          style={{
+            display: 'grid',
+            gridTemplateColumns: '40px 1fr 120px 100px 100px',
+            padding: '8px 16px',
+            fontSize: 9,
+            letterSpacing: 1.2,
+            textTransform: 'uppercase',
+            color: 'var(--v5-mut)',
+            borderBottom: '1px solid var(--v5-bor)',
+          }}
+        >
+          <span>&nbsp;</span>
+          <span>Name</span>
+          <span>Status</span>
+          <span>Stellplatz</span>
+          <span>Seit</span>
+        </div>
+        {members.map((m, i) => (
+          <div
+            key={m.name}
+            data-testid="team-row"
+            className="v5-row"
+            style={{
+              display: 'grid',
+              gridTemplateColumns: '40px 1fr 120px 100px 100px',
+              padding: '10px 16px',
+              borderBottom: i < members.length - 1 ? '1px solid var(--v5-bor)' : 'none',
+              alignItems: 'center',
+              gap: 4,
+            }}
+          >
+            <div
+              style={{
+                width: 30, height: 30, borderRadius: '50%',
+                background: 'var(--v5-acc-muted)', color: 'var(--v5-acc)',
+                display: 'flex', alignItems: 'center', justifyContent: 'center',
+                fontWeight: 700, fontSize: 12,
+              }}
+              aria-hidden="true"
+            >
+              {m.name[0]?.toUpperCase() ?? '?'}
+            </div>
+            <div>
+              <div style={{ fontSize: 12, fontWeight: 500, color: 'var(--v5-txt)' }}>{m.name}</div>
+              <div style={{ fontSize: 10, color: 'var(--v5-mut)' }}>{m.department}</div>
+            </div>
+            <Badge variant={statusVariant(m.status)} dot>{m.statusLabel}</Badge>
+            <span className="v5-mono" style={{ fontSize: 11, color: 'var(--v5-txt)' }}>{m.slot}</span>
+            <span style={{ fontSize: 11, color: 'var(--v5-mut)' }}>{m.since}</span>
+          </div>
+        ))}
+      </Card>
+
+      {todayEntries.length > 0 && (
+        <Card className="v5-ani" style={{ padding: 14, animationDelay: '0.16s' }} data-testid="today-absences">
+          <div className="v5-mono" style={{ fontSize: 9, letterSpacing: 1.4, color: 'var(--v5-mut)', textTransform: 'uppercase', marginBottom: 10 }}>
+            Heute abwesend ({todayEntries.length})
+          </div>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+            {todayEntries.map((e, i) => (
+              <div key={i} style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 12, color: 'var(--v5-txt)' }}>
+                <span style={{ width: 6, height: 6, borderRadius: '50%', background: 'var(--v5-err)' }} aria-hidden="true" />
+                <span style={{ fontWeight: 500 }}>{e.user_name}</span>
+                <span style={{ color: 'var(--v5-mut)', fontSize: 11 }}>{absenceLabel(e.absence_type)}</span>
+                <span style={{ marginLeft: 'auto', color: 'var(--v5-mut)', fontSize: 11 }}>
+                  {formatDate(e.start_date)}{e.start_date !== e.end_date ? ` – ${formatDate(e.end_date)}` : ''}
+                </span>
+              </div>
+            ))}
+          </div>
+        </Card>
+      )}
+    </div>
+  );
+}
+
+function StatTile({ label, value, accent = false }: { label: string; value: number; accent?: boolean }) {
+  return (
+    <Card style={{ padding: 14, background: accent ? 'var(--v5-acc-muted)' : 'var(--v5-sur)' }}>
+      <div className="v5-mono" style={{ fontSize: 9, letterSpacing: 1.4, color: accent ? 'var(--v5-acc)' : 'var(--v5-mut)', textTransform: 'uppercase' }}>
+        {label}
+      </div>
+      <div style={{ marginTop: 6, fontSize: 28, fontWeight: 800, color: accent ? 'var(--v5-acc)' : 'var(--v5-txt)', letterSpacing: -1 }}>
+        <NumberFlow value={value} />
+      </div>
+    </Card>
+  );
+}

--- a/parkhub-web/src/design-v5/screens/Vorhersagen.test.tsx
+++ b/parkhub-web/src/design-v5/screens/Vorhersagen.test.tsx
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+const mockGetStats = vi.fn();
+vi.mock('../../api/client', () => ({
+  api: {
+    getAdminStatsExtended: (...a: unknown[]) => mockGetStats(...a),
+  },
+}));
+
+const mockToast = vi.fn();
+vi.mock('../Toast', () => ({
+  useV5Toast: () => mockToast,
+  V5ToastProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+import { VorhersagenV5 } from './Vorhersagen';
+
+function renderScreen(navigate = vi.fn()) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <VorhersagenV5 navigate={navigate} />
+    </QueryClientProvider>
+  );
+}
+
+const STATS_BASE = {
+  total_users: 10,
+  total_lots: 2,
+  total_bookings: 100,
+  active_bookings: 20,
+};
+
+describe('VorhersagenV5', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('renders error state when query fails', async () => {
+    mockGetStats.mockRejectedValue(new Error('network'));
+    renderScreen();
+    await waitFor(() => expect(screen.getByText('Fehler beim Laden')).toBeInTheDocument());
+  });
+
+  it('surfaces error when success:false', async () => {
+    mockGetStats.mockResolvedValue({ success: false, data: null, error: { code: 'FORBIDDEN', message: 'denied' } });
+    renderScreen();
+    await waitFor(() => expect(screen.getByText('Fehler beim Laden')).toBeInTheDocument());
+  });
+
+  it('renders 7 day cards with fallback data when no historical stats', async () => {
+    mockGetStats.mockResolvedValue({ success: true, data: STATS_BASE });
+    renderScreen();
+    await waitFor(() => expect(screen.getAllByTestId('day-card')).toHaveLength(7));
+    expect(screen.getByTestId('forecast-grid')).toBeInTheDocument();
+  });
+
+  it('shows recommendation card with best day/time', async () => {
+    mockGetStats.mockResolvedValue({ success: true, data: STATS_BASE });
+    renderScreen();
+    await waitFor(() => expect(screen.getByTestId('recommendation')).toBeInTheDocument());
+    expect(screen.getByText('Beste Buchungszeit')).toBeInTheDocument();
+  });
+
+  it('uses historical occupancy when provided and renders high-load badge', async () => {
+    mockGetStats.mockResolvedValue({
+      success: true,
+      data: {
+        ...STATS_BASE,
+        occupancy_by_day: {
+          '0': { avg_percentage: 85, peak_hour: 10, peak_percentage: 95, bookings: 100 },
+        },
+        occupancy_by_hour: { '10': 90 },
+      },
+    });
+    renderScreen();
+    await waitFor(() => expect(screen.getByText('85%')).toBeInTheDocument());
+    expect(screen.getAllByText('Voll').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Ruhig').length).toBeGreaterThan(0);
+  });
+
+  it('renders confidence tag on each day', async () => {
+    mockGetStats.mockResolvedValue({ success: true, data: STATS_BASE });
+    renderScreen();
+    await waitFor(() => expect(screen.getAllByText(/% Konfidenz/i).length).toBe(7));
+  });
+
+  it('shows KI label in header', async () => {
+    mockGetStats.mockResolvedValue({ success: true, data: STATS_BASE });
+    renderScreen();
+    await waitFor(() => expect(screen.getByText('Vorhersagen')).toBeInTheDocument());
+    expect(screen.getByText('KI')).toBeInTheDocument();
+  });
+});

--- a/parkhub-web/src/design-v5/screens/Vorhersagen.test.tsx
+++ b/parkhub-web/src/design-v5/screens/Vorhersagen.test.tsx
@@ -42,8 +42,27 @@ describe('VorhersagenV5', () => {
     await waitFor(() => expect(screen.getByText('Fehler beim Laden')).toBeInTheDocument());
   });
 
-  it('surfaces error when success:false', async () => {
+  it('renders fallback 7-day forecast when admin stats are forbidden (non-admin)', async () => {
+    // Regression for PR #374: `/api/v1/admin/stats` is admin-gated; non-admin
+    // users must see the deterministic weekday/weekend fallback instead of a
+    // blocking error page.
     mockGetStats.mockResolvedValue({ success: false, data: null, error: { code: 'FORBIDDEN', message: 'denied' } });
+    renderScreen();
+    await waitFor(() => expect(screen.getAllByTestId('day-card')).toHaveLength(7));
+    expect(screen.queryByText('Fehler beim Laden')).toBeNull();
+    // Fallback confidence is 40% on every day when no historical data arrived.
+    expect(screen.getAllByText(/40% Konfidenz/).length).toBe(7);
+  });
+
+  it('also degrades on HTTP_403 error code from admin stats', async () => {
+    mockGetStats.mockResolvedValue({ success: false, data: null, error: { code: 'HTTP_403', message: 'forbidden' } });
+    renderScreen();
+    await waitFor(() => expect(screen.getAllByTestId('day-card')).toHaveLength(7));
+    expect(screen.queryByText('Fehler beim Laden')).toBeNull();
+  });
+
+  it('still surfaces error when stats fail with non-auth error', async () => {
+    mockGetStats.mockResolvedValue({ success: false, data: null, error: { code: 'HTTP_500', message: 'server error' } });
     renderScreen();
     await waitFor(() => expect(screen.getByText('Fehler beim Laden')).toBeInTheDocument());
   });

--- a/parkhub-web/src/design-v5/screens/Vorhersagen.tsx
+++ b/parkhub-web/src/design-v5/screens/Vorhersagen.tsx
@@ -1,0 +1,212 @@
+import { useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { Badge, Card, V5NamedIcon } from '../primitives';
+import { api } from '../../api/client';
+import type { ScreenId } from '../nav';
+
+const DAYS_FULL = ['Montag', 'Dienstag', 'Mittwoch', 'Donnerstag', 'Freitag', 'Samstag', 'Sonntag'];
+const DAYS_SHORT = ['Mo', 'Di', 'Mi', 'Do', 'Fr', 'Sa', 'So'];
+const DAY_KEY_EN = ['monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday', 'sunday'];
+
+type Level = 'low' | 'medium' | 'high';
+
+interface DayPrediction {
+  dayIndex: number;
+  dayName: string;
+  dayShort: string;
+  predicted: number;
+  confidence: number;
+  peakHour: number;
+  offPeakHour: number;
+  level: Level;
+}
+
+function getLevel(pct: number): Level {
+  if (pct >= 70) return 'high';
+  if (pct >= 40) return 'medium';
+  return 'low';
+}
+
+function levelColor(level: Level): string {
+  switch (level) {
+    case 'low': return 'oklch(0.65 0.17 160)';
+    case 'medium': return 'oklch(0.74 0.16 75)';
+    case 'high': return 'oklch(0.58 0.22 25)';
+  }
+}
+
+function levelLabel(level: Level): string {
+  switch (level) {
+    case 'low': return 'Ruhig';
+    case 'medium': return 'Mittel';
+    case 'high': return 'Voll';
+  }
+}
+
+function levelVariant(level: Level) {
+  switch (level) {
+    case 'low': return 'success' as const;
+    case 'medium': return 'warning' as const;
+    case 'high': return 'error' as const;
+  }
+}
+
+function formatHour(hour: number): string {
+  return `${String(hour).padStart(2, '0')}:00`;
+}
+
+// Stable deterministic weekday/weekend fallback when historical data is absent.
+function fallbackPrediction(idx: number): { predicted: number; peakHour: number; offPeakHour: number } {
+  if (idx < 5) return { predicted: 60, peakHour: 9, offPeakHour: 14 };
+  return { predicted: 20, peakHour: 10, offPeakHour: 7 };
+}
+
+export function VorhersagenV5({ navigate: _navigate }: { navigate: (id: ScreenId) => void }) {
+  const statsQuery = useQuery({
+    queryKey: ['admin-stats-forecast'],
+    queryFn: async () => {
+      const res = await api.getAdminStatsExtended();
+      if (!res.success) throw new Error(res.error?.message ?? 'Vorhersagen konnten nicht geladen werden');
+      return res.data;
+    },
+    staleTime: 60_000,
+    refetchOnWindowFocus: true,
+  });
+
+  const predictions = useMemo<DayPrediction[]>(() => {
+    const byDay = statsQuery.data?.occupancy_by_day ?? {};
+    const byHour = statsQuery.data?.occupancy_by_hour ?? {};
+    const hasHourly = Object.keys(byHour).length > 0;
+    return DAYS_FULL.map((name, idx) => {
+      const dayData = byDay[String(idx)] ?? byDay[DAY_KEY_EN[idx]] ?? byDay[name.toLowerCase()];
+      let predicted: number;
+      let peakHour: number;
+      let offPeakHour: number;
+      let confidence: number;
+      if (dayData) {
+        predicted = Math.round(dayData.avg_percentage);
+        peakHour = dayData.peak_hour;
+        offPeakHour = peakHour >= 12 ? 7 : 14;
+        confidence = hasHourly ? 85 : 65;
+      } else {
+        const f = fallbackPrediction(idx);
+        predicted = f.predicted;
+        peakHour = f.peakHour;
+        offPeakHour = f.offPeakHour;
+        confidence = 40;
+      }
+      return {
+        dayIndex: idx,
+        dayName: name,
+        dayShort: DAYS_SHORT[idx],
+        predicted,
+        confidence,
+        peakHour,
+        offPeakHour,
+        level: getLevel(predicted),
+      };
+    });
+  }, [statsQuery.data]);
+
+  const recommendation = useMemo(() => {
+    if (!predictions.length) return null;
+    const best = [...predictions].sort((a, b) => a.predicted - b.predicted)[0];
+    return {
+      day: best.dayName,
+      timeSlot: `${formatHour(best.offPeakHour)}–${formatHour(best.offPeakHour + 2)}`,
+    };
+  }, [predictions]);
+
+  if (statsQuery.isLoading) {
+    return (
+      <div style={{ padding: 16, flex: 1, overflow: 'auto' }}>
+        <div style={{ height: 32, width: 200, borderRadius: 8, background: 'var(--v5-sur2)', marginBottom: 14, animation: 'ph-v5-pulse 1.6s ease infinite' }} />
+        <div style={{ height: 110, borderRadius: 14, background: 'var(--v5-sur2)', marginBottom: 12, animation: 'ph-v5-pulse 1.6s ease infinite' }} />
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(7, 1fr)', gap: 8 }}>
+          {[0, 1, 2, 3, 4, 5, 6].map((i) => (
+            <div key={i} style={{ height: 160, borderRadius: 12, background: 'var(--v5-sur2)', animation: 'ph-v5-pulse 1.6s ease infinite', animationDelay: `${i * 0.06}s` }} />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  if (statsQuery.isError) {
+    return (
+      <div style={{ padding: 16, flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+        <Card className="v5-ani" style={{ padding: 28, textAlign: 'center', maxWidth: 360 }}>
+          <V5NamedIcon name="x" size={26} color="var(--v5-err)" />
+          <div style={{ marginTop: 10, fontWeight: 600, color: 'var(--v5-txt)' }}>Fehler beim Laden</div>
+          <div style={{ fontSize: 12, color: 'var(--v5-mut)', marginTop: 4 }}>Vorhersagen konnten nicht geladen werden.</div>
+        </Card>
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ padding: 16, flex: 1, overflow: 'auto', display: 'flex', flexDirection: 'column', gap: 12 }}>
+      <div className="v5-ani" style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+        <span style={{ fontWeight: 700, fontSize: 15, color: 'var(--v5-txt)' }}>Vorhersagen</span>
+        <Badge variant="purple">KI</Badge>
+      </div>
+
+      {recommendation && (
+        <Card className="v5-ani" style={{ padding: 18, animationDelay: '0.06s', background: 'linear-gradient(145deg, var(--v5-acc-muted), transparent)', border: '1px solid color-mix(in oklch, var(--v5-acc) 30%, transparent)' }} data-testid="recommendation">
+          <div className="v5-mono" style={{ fontSize: 9, letterSpacing: 1.4, color: 'var(--v5-acc)', textTransform: 'uppercase' }}>
+            Beste Buchungszeit
+          </div>
+          <div style={{ marginTop: 6, fontSize: 20, fontWeight: 700, color: 'var(--v5-txt)' }}>
+            {recommendation.day}, {recommendation.timeSlot}
+          </div>
+          <div style={{ fontSize: 11, color: 'var(--v5-mut)', marginTop: 4 }}>
+            Basierend auf historischen Buchungsmustern und aktueller Auslastung.
+          </div>
+        </Card>
+      )}
+
+      <div className="v5-ani" style={{ animationDelay: '0.12s' }}>
+        <div className="v5-mono" style={{ fontSize: 9, letterSpacing: 1.4, color: 'var(--v5-mut)', textTransform: 'uppercase', marginBottom: 10 }}>
+          7-Tage-Prognose
+        </div>
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(120px, 1fr))', gap: 8 }} data-testid="forecast-grid">
+          {predictions.map((day) => (
+            <Card
+              key={day.dayIndex}
+              data-testid="day-card"
+              style={{ padding: 12, display: 'flex', flexDirection: 'column', gap: 8 }}
+            >
+              <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+                <span style={{ fontSize: 12, fontWeight: 700, color: 'var(--v5-txt)' }}>{day.dayShort}</span>
+                <Badge variant={levelVariant(day.level)} dot>{levelLabel(day.level)}</Badge>
+              </div>
+              <div
+                className="v5-mono"
+                style={{ fontSize: 22, fontWeight: 800, color: levelColor(day.level), fontVariantNumeric: 'tabular-nums', letterSpacing: -1 }}
+              >
+                {day.predicted}%
+              </div>
+              <div style={{ height: 6, background: 'var(--v5-sur2)', borderRadius: 999, overflow: 'hidden' }}>
+                <div style={{ height: '100%', width: `${day.predicted}%`, background: levelColor(day.level), borderRadius: 999 }} />
+              </div>
+              <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: 10 }}>
+                <span style={{ color: 'var(--v5-mut)' }}>Spitze</span>
+                <span className="v5-mono" style={{ color: 'var(--v5-err)', fontWeight: 500 }}>{formatHour(day.peakHour)}</span>
+              </div>
+              <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: 10 }}>
+                <span style={{ color: 'var(--v5-mut)' }}>Ruhig</span>
+                <span className="v5-mono" style={{ color: 'var(--v5-ok)', fontWeight: 500 }}>{formatHour(day.offPeakHour)}</span>
+              </div>
+              <div style={{ fontSize: 10, color: 'var(--v5-mut)', textAlign: 'center', marginTop: 2 }}>
+                {day.confidence}% Konfidenz
+              </div>
+            </Card>
+          ))}
+        </div>
+      </div>
+
+      <div style={{ fontSize: 10, color: 'var(--v5-mut)', textAlign: 'center', marginTop: 6 }}>
+        Prognosen basieren auf historischen Mustern. Genauigkeit verbessert sich mit der Zeit.
+      </div>
+    </div>
+  );
+}

--- a/parkhub-web/src/design-v5/screens/Vorhersagen.tsx
+++ b/parkhub-web/src/design-v5/screens/Vorhersagen.tsx
@@ -62,11 +62,22 @@ function fallbackPrediction(idx: number): { predicted: number; peakHour: number;
 }
 
 export function VorhersagenV5({ navigate: _navigate }: { navigate: (id: ScreenId) => void }) {
+  // Admin stats are optional inputs — `/api/v1/admin/stats` is admin-gated on
+  // both the Rust (`check_admin`) and PHP (admin middleware) backends. Non-admin
+  // users predictably receive FORBIDDEN; in that case we degrade gracefully
+  // and let the deterministic weekday/weekend fallback drive the forecast
+  // (confidence = 40%). Network or other non-auth failures continue to surface
+  // as hard errors.
   const statsQuery = useQuery({
     queryKey: ['admin-stats-forecast'],
     queryFn: async () => {
       const res = await api.getAdminStatsExtended();
-      if (!res.success) throw new Error(res.error?.message ?? 'Vorhersagen konnten nicht geladen werden');
+      if (!res.success) {
+        if (res.error?.code === 'FORBIDDEN' || res.error?.code === 'HTTP_403') {
+          return null;
+        }
+        throw new Error(res.error?.message ?? 'Vorhersagen konnten nicht geladen werden');
+      }
       return res.data;
     },
     staleTime: 60_000,


### PR DESCRIPTION
## Summary
Byte-identical mirror of `parkhub-php` Wave-3 Fleet (#333) into `parkhub-rust`.
Ports the 7 Fleet section screens: **Team, Rangliste, EV-Laden, Tausch, Einchecken, Vorhersagen, Gaestepass**.

Brings `parkhub-rust` to **15/26 v5 screens live** — parity with `parkhub-php` main.

## API client (parkhub-web/src/api/client.ts)
Adds **15 new methods** + **11 new TypeScript types**:
- **Team / Fleet**: `getTeam`, `getAdminStatsExtended`
- **EV Chargers**: `getLotChargers`, `getChargerSessions`, `startCharging`, `stopCharging`
- **Swap Requests**: `getSwapRequests`, `acceptSwap`, `declineSwap`, `createSwapRequest`
- **Check-in**: `getCheckInStatus`, `checkIn`, `checkOut`
- **Guest Passes**: `getGuestBookings`, `createGuestBooking`, `cancelGuestBooking`

## Rust backend route divergences (handled transparently in client.ts)
| PHP URL | Rust URL | Handling |
|---|---|---|
| `POST /swap-requests/{id}/accept` + `/decline` | `PUT /swap-requests/{id}` with `{action}` body | Client rewrites URL + body shape |
| `POST /bookings/{id}/check-in` | `POST /bookings/{id}/checkin` (no dash) | Client uses rust path |
| `GET /bookings/{id}/check-in` | *(no rust handler yet)* | PHP URL kept; 404 gracefully → default status |
| `POST /bookings/{id}/check-out` | *(no rust handler yet)* | PHP URL kept; 404 surfaces as toast |
| `DELETE /bookings/guest/{id}` | *(only admin PATCH cancel)* | PHP URL kept; 404 surfaces as toast |

The screens themselves are byte-identical with PHP — only the api client translates.

## Infra tweak
`Card` primitive now forwards `data-testid` (parity with PHP Wave-3 infra tweak).

## Test plan
- [x] `npm run test -- --run src/design-v5` → **146 tests in 19 files all green** (7 new test files: Team, Rangliste, EV, Tausch, Einchecken, Vorhersagen, Gaestepass)
- [x] `npm run build` → clean, 2 pages built in 15.93s
- [ ] CI green
- [ ] Render deploy verify post-merge

## Follow-ups (backend gaps, not blocking)
- Rust handler for `GET /bookings/{id}/check-in` status probe
- Rust handler for `POST /bookings/{id}/check-out`
- User-side `DELETE /bookings/guest/{id}` (only admin PATCH today)