### PR TITLE
feat(v5): Wave 4+5 — port 11 admin screens (26/26 parity with PHP #337)

### DIFF
--- a/parkhub-web/src/api/client.ts
+++ b/parkhub-web/src/api/client.ts
@@ -362,6 +362,14 @@ export const api = {
   adminUpdateSettings: (data: Record<string, string>) =>
     request('/api/v1/admin/settings', { method: 'PUT', body: JSON.stringify(data) }),
 
+  // ── Admin Cost-Center Billing (parkhub-server/src/api/billing.rs) ──
+  // Admin-only aggregates for tenant-wide finance reporting. The v5 Billing
+  // screen surfaces these instead of the personal `/payments/history` feed.
+  adminBillingByCostCenter: () =>
+    request<AdminCostCenterSummary[]>('/api/v1/admin/billing/by-cost-center'),
+  adminBillingByDepartment: () =>
+    request<AdminDepartmentSummary[]>('/api/v1/admin/billing/by-department'),
+
   // ── Admin Modules (T-1720 v2 — runtime enable/disable) ──
   patchModule: (name: string, runtime_enabled: boolean) =>
     request<ModuleInfo>(`/api/v1/admin/modules/${encodeURIComponent(name)}`, {
@@ -963,6 +971,34 @@ export interface PaymentHistoryEntry {
 export interface StripeConfigResponse {
   publishable_key?: string;
   configured: boolean;
+}
+
+/**
+ * Admin cost-center billing aggregate — matches `CostCenterSummary` in
+ * `parkhub-server/src/api/billing.rs`. Amount is in whole currency units
+ * (f64 euros), not cents like PaymentHistoryEntry.
+ */
+export interface AdminCostCenterSummary {
+  cost_center: string;
+  department: string;
+  user_count: number;
+  total_bookings: number;
+  total_credits_used: number;
+  total_amount: number;
+  currency: string;
+}
+
+/**
+ * Admin department billing aggregate — matches `DepartmentSummary` in
+ * `parkhub-server/src/api/billing.rs`.
+ */
+export interface AdminDepartmentSummary {
+  department: string;
+  user_count: number;
+  total_bookings: number;
+  total_credits_used: number;
+  total_amount: number;
+  currency: string;
 }
 
 export interface UserStats {

--- a/parkhub-web/src/api/client.ts
+++ b/parkhub-web/src/api/client.ts
@@ -652,7 +652,83 @@ export const api = {
     request<GuestBooking>('/api/v1/bookings/guest', { method: 'POST', body: JSON.stringify(data) }),
   cancelGuestBooking: (id: string) =>
     request<void>(`/api/v1/bookings/guest/${id}`, { method: 'DELETE' }),
+
+  // ── API Keys (v5 Wave 4) ──
+  getApiKeys: () => request<ApiKey[]>('/api/v1/admin/api-keys'),
+  createApiKey: (label: string) =>
+    request<CreatedApiKey>('/api/v1/admin/api-keys', {
+      method: 'POST', body: JSON.stringify({ label }),
+    }),
+  rotateApiKey: (id: string) =>
+    request<CreatedApiKey>(`/api/v1/admin/api-keys/${id}/rotate`, { method: 'POST' }),
+  revokeApiKey: (id: string) =>
+    request<void>(`/api/v1/admin/api-keys/${id}`, { method: 'DELETE' }),
+
+  // ── Integrations (v5 Wave 4) ──
+  getIntegrations: () => request<Integration[]>('/api/v1/admin/integrations'),
+  connectIntegration: (id: string) =>
+    request<Integration>(`/api/v1/admin/integrations/${id}/connect`, { method: 'POST' }),
+  disconnectIntegration: (id: string) =>
+    request<Integration>(`/api/v1/admin/integrations/${id}/disconnect`, { method: 'POST' }),
+
+  // ── Policies (v5 Wave 4) ──
+  getPolicies: () => request<Policy[]>('/api/v1/admin/policies'),
+  updatePolicy: (id: string, body: string) =>
+    request<Policy>(`/api/v1/admin/policies/${id}`, {
+      method: 'PUT', body: JSON.stringify({ body }),
+    }),
+
+  // ── Lobby Display (v5 Wave 4) ──
+  getLobbyConfig: () => request<LobbyConfig>('/api/v1/admin/lobby'),
+  updateLobbyConfig: (data: Partial<LobbyConfig>) =>
+    request<LobbyConfig>('/api/v1/admin/lobby', {
+      method: 'PUT', body: JSON.stringify(data),
+    }),
 };
+
+// ── API Keys ──
+export interface ApiKey {
+  id: string;
+  label: string;
+  masked_key: string;
+  last_used_at: string | null;
+  created_at: string;
+}
+
+export interface CreatedApiKey extends ApiKey {
+  /** Full key — returned exactly once on create/rotate. */
+  token: string;
+}
+
+// ── Integrations ──
+export interface Integration {
+  id: string;
+  name: string;
+  provider: string;
+  description: string;
+  connected: boolean;
+  connected_at: string | null;
+  account_label: string | null;
+}
+
+// ── Policies ──
+export interface Policy {
+  id: string;
+  title: string;
+  slug: string;
+  body: string;
+  updated_at: string;
+}
+
+// ── Lobby Display ──
+export type LobbyScreenKey = 'queue' | 'map' | 'announcements' | 'welcome';
+
+export interface LobbyConfig {
+  active_screen: LobbyScreenKey;
+  rotate_interval_seconds: number;
+  show_clock: boolean;
+  show_weather: boolean;
+}
 
 // ── Types ──
 

--- a/parkhub-web/src/design-v5/App.tsx
+++ b/parkhub-web/src/design-v5/App.tsx
@@ -22,6 +22,17 @@ import { TauschV5 } from './screens/Tausch';
 import { EincheckenV5 } from './screens/Einchecken';
 import { VorhersagenV5 } from './screens/Vorhersagen';
 import { GaestepassV5 } from './screens/Gaestepass';
+import { AnalyticsV5 } from './screens/Analytics';
+import { NutzerV5 } from './screens/Nutzer';
+import { BillingV5 } from './screens/Billing';
+import { LobbyV5 } from './screens/Lobby';
+import { BenachrichtigungenV5 } from './screens/Benachrichtigungen';
+import { EinstellungenV5 } from './screens/Einstellungen';
+import { StandorteV5 } from './screens/Standorte';
+import { IntegrationsV5 } from './screens/Integrations';
+import { ApikeysV5 } from './screens/Apikeys';
+import { AuditV5 } from './screens/Audit';
+import { PoliciesV5 } from './screens/Policies';
 import { PlaceholderV5 } from './screens/Placeholder';
 
 import './fonts';
@@ -48,6 +59,17 @@ const SCREENS: Partial<Record<ScreenId, ComponentType<{ navigate: (id: ScreenId)
   einchecken: EincheckenV5,
   vorhersagen: VorhersagenV5,
   gaestepass: GaestepassV5,
+  analytics: AnalyticsV5,
+  nutzer: NutzerV5,
+  billing: BillingV5,
+  lobby: LobbyV5,
+  benachrichtigungen: BenachrichtigungenV5,
+  einstellungen: EinstellungenV5,
+  standorte: StandorteV5,
+  integrations: IntegrationsV5,
+  apikeys: ApikeysV5,
+  audit: AuditV5,
+  policies: PoliciesV5,
 };
 
 const STORAGE_KEY = 'ph-v5-screen';

--- a/parkhub-web/src/design-v5/screens/Analytics.test.tsx
+++ b/parkhub-web/src/design-v5/screens/Analytics.test.tsx
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+const mockStats = vi.fn();
+vi.mock('../../api/client', () => ({
+  api: {
+    getAdminStatsExtended: (...a: unknown[]) => mockStats(...a),
+  },
+}));
+
+vi.mock('@number-flow/react', () => ({
+  default: ({ value }: { value: number }) => <span>{value}</span>,
+}));
+
+import { AnalyticsV5 } from './Analytics';
+
+const STATS = {
+  total_users: 42,
+  total_lots: 5,
+  total_bookings: 1200,
+  active_bookings: 7,
+  occupancy_by_hour: { '08': 40, '09': 60, '10': 75 },
+  occupancy_by_day: {
+    Mo: { avg_percentage: 55, peak_hour: 10, peak_percentage: 80, bookings: 120 },
+    Di: { avg_percentage: 65, peak_hour: 9, peak_percentage: 85, bookings: 140 },
+  },
+};
+
+function renderScreen() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <AnalyticsV5 navigate={vi.fn()} />
+    </QueryClientProvider>
+  );
+}
+
+describe('AnalyticsV5', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('renders error state when stats fail', async () => {
+    mockStats.mockResolvedValue({ success: false, data: null, error: { code: 'X', message: 'denied' } });
+    renderScreen();
+    await waitFor(() => expect(screen.getByText('Fehler beim Laden')).toBeInTheDocument());
+  });
+
+  it('renders KPI cards from stats', async () => {
+    mockStats.mockResolvedValue({ success: true, data: STATS });
+    renderScreen();
+    await waitFor(() => expect(screen.getByText('Nutzer')).toBeInTheDocument());
+    expect(screen.getByText('42')).toBeInTheDocument();
+    expect(screen.getByText('Aktive Buchungen')).toBeInTheDocument();
+  });
+
+  it('renders both bar charts', async () => {
+    mockStats.mockResolvedValue({ success: true, data: STATS });
+    renderScreen();
+    await waitFor(() => expect(screen.getAllByTestId('analytics-chart')).toHaveLength(2));
+  });
+
+  it('hour chart renders 24 bars', async () => {
+    mockStats.mockResolvedValue({ success: true, data: STATS });
+    renderScreen();
+    await waitFor(() => expect(screen.getAllByTestId('analytics-chart').length).toBeGreaterThan(0));
+    const charts = screen.getAllByTestId('analytics-chart');
+    // hour chart should have rects for 24 hours
+    const hourRects = charts[0].querySelectorAll('rect');
+    expect(hourRects.length).toBe(24);
+  });
+
+  it('gracefully handles missing occupancy data', async () => {
+    mockStats.mockResolvedValue({ success: true, data: { total_users: 1, total_lots: 1, total_bookings: 1, active_bookings: 1 } });
+    renderScreen();
+    await waitFor(() => expect(screen.getByText('Nutzer')).toBeInTheDocument());
+    // Should still render chart containers (with 0 values)
+    expect(screen.getAllByTestId('analytics-chart')).toHaveLength(2);
+  });
+
+  it('renders title', async () => {
+    mockStats.mockResolvedValue({ success: true, data: STATS });
+    renderScreen();
+    await waitFor(() => expect(screen.getByText('Analytics')).toBeInTheDocument());
+  });
+});

--- a/parkhub-web/src/design-v5/screens/Analytics.tsx
+++ b/parkhub-web/src/design-v5/screens/Analytics.tsx
@@ -1,0 +1,136 @@
+import NumberFlow from '@number-flow/react';
+import { useQuery } from '@tanstack/react-query';
+import { Card, SectionLabel, StatCard, V5NamedIcon } from '../primitives';
+import { api } from '../../api/client';
+import type { ScreenId } from '../nav';
+
+function BarChart({ data, label, color = 'var(--v5-acc)' }: {
+  data: { label: string; value: number }[];
+  label: string;
+  color?: string;
+}) {
+  if (data.length === 0) {
+    return (
+      <div style={{ fontSize: 11, color: 'var(--v5-mut)', padding: '14px 0' }}>Keine Daten</div>
+    );
+  }
+  const max = Math.max(...data.map((d) => d.value), 1);
+  const width = 520;
+  const height = 120;
+  const pad = 6;
+  const barW = (width - pad * 2) / data.length;
+  return (
+    <div>
+      <SectionLabel>{label}</SectionLabel>
+      <svg
+        viewBox={`0 0 ${width} ${height + 24}`}
+        style={{ width: '100%', height: 'auto', display: 'block' }}
+        role="img"
+        aria-label={label}
+        data-testid="analytics-chart"
+      >
+        {data.map((d, i) => {
+          const h = (d.value / max) * height;
+          const x = pad + i * barW;
+          const y = height - h;
+          return (
+            <g key={`${d.label}-${i}`}>
+              <rect
+                x={x + 2}
+                y={y}
+                width={barW - 4}
+                height={h}
+                fill={color}
+                rx={3}
+                opacity={0.85}
+              />
+              <text
+                x={x + barW / 2}
+                y={height + 14}
+                fontSize="9"
+                fill="var(--v5-mut)"
+                textAnchor="middle"
+                fontFamily="ui-monospace, SFMono-Regular, Menlo, monospace"
+              >
+                {d.label}
+              </text>
+            </g>
+          );
+        })}
+      </svg>
+    </div>
+  );
+}
+
+const DAY_LABELS = ['Mo', 'Di', 'Mi', 'Do', 'Fr', 'Sa', 'So'];
+
+export function AnalyticsV5({ navigate: _navigate }: { navigate: (id: ScreenId) => void }) {
+  const { data: stats, isLoading, isError } = useQuery({
+    queryKey: ['analytics-stats'],
+    queryFn: async () => {
+      const res = await api.getAdminStatsExtended();
+      if (!res.success) throw new Error(res.error?.message ?? 'Statistiken konnten nicht geladen werden');
+      return res.data;
+    },
+    staleTime: 60_000,
+  });
+
+  if (isLoading) {
+    return (
+      <div style={{ padding: 16, flex: 1, overflow: 'auto', display: 'flex', flexDirection: 'column', gap: 12 }}>
+        {[120, 200, 200].map((h, i) => (
+          <div key={i} style={{ height: h, borderRadius: 14, background: 'var(--v5-sur2)', animation: 'ph-v5-pulse 1.6s ease infinite', animationDelay: `${i * 0.1}s` }} />
+        ))}
+      </div>
+    );
+  }
+
+  if (isError || !stats) {
+    return (
+      <div style={{ padding: 16, flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+        <Card className="v5-ani" style={{ padding: 28, textAlign: 'center', maxWidth: 360 }}>
+          <V5NamedIcon name="x" size={26} color="var(--v5-err)" />
+          <div style={{ marginTop: 10, fontWeight: 600, color: 'var(--v5-txt)' }}>Fehler beim Laden</div>
+        </Card>
+      </div>
+    );
+  }
+
+  const byHour = stats.occupancy_by_hour ?? {};
+  const hourBars: { label: string; value: number }[] = [];
+  for (let h = 0; h < 24; h++) {
+    const key = String(h).padStart(2, '0');
+    hourBars.push({ label: key, value: Number(byHour[key] ?? byHour[String(h)] ?? 0) });
+  }
+
+  const byDay = stats.occupancy_by_day ?? {};
+  const dayBars = DAY_LABELS.map((lbl, i) => {
+    const entry = byDay[lbl] ?? byDay[String(i)] ?? null;
+    return { label: lbl, value: entry ? entry.avg_percentage : 0 };
+  });
+
+  return (
+    <div style={{ padding: 16, flex: 1, overflow: 'auto', display: 'flex', flexDirection: 'column', gap: 12 }}>
+      <div className="v5-ani" style={{ fontWeight: 700, fontSize: 15, color: 'var(--v5-txt)' }}>Analytics</div>
+
+      <div className="v5-ani" style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(160px, 1fr))', gap: 10, animationDelay: '0.06s' }}>
+        <StatCard label="Nutzer" value={<NumberFlow value={stats.total_users} />} icon="users" />
+        <StatCard label="Standorte" value={<NumberFlow value={stats.total_lots} />} icon="map" />
+        <StatCard label="Buchungen" value={<NumberFlow value={stats.total_bookings} />} icon="list" />
+        <StatCard label="Aktive Buchungen" value={<NumberFlow value={stats.active_bookings} />} icon="check" accent />
+      </div>
+
+      <Card className="v5-ani" style={{ padding: 16, animationDelay: '0.12s' }}>
+        <BarChart data={hourBars} label="Auslastung nach Stunde (%)" />
+      </Card>
+
+      <Card className="v5-ani" style={{ padding: 16, animationDelay: '0.18s' }}>
+        <BarChart data={dayBars} label="Auslastung nach Wochentag (%)" color="var(--v5-ok, oklch(0.65 0.17 160))" />
+      </Card>
+
+      <div className="v5-ani" style={{ fontSize: 10, color: 'var(--v5-mut)' }}>
+        Interaktive Charts (uPlot) folgen in separater PR.
+      </div>
+    </div>
+  );
+}

--- a/parkhub-web/src/design-v5/screens/Apikeys.test.tsx
+++ b/parkhub-web/src/design-v5/screens/Apikeys.test.tsx
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+const mockList = vi.fn();
+const mockCreate = vi.fn();
+const mockRotate = vi.fn();
+const mockRevoke = vi.fn();
+vi.mock('../../api/client', () => ({
+  api: {
+    getApiKeys: (...a: unknown[]) => mockList(...a),
+    createApiKey: (...a: unknown[]) => mockCreate(...a),
+    rotateApiKey: (...a: unknown[]) => mockRotate(...a),
+    revokeApiKey: (...a: unknown[]) => mockRevoke(...a),
+  },
+}));
+
+vi.mock('@number-flow/react', () => ({
+  default: ({ value }: { value: number }) => <span>{value}</span>,
+}));
+
+const mockToast = vi.fn();
+vi.mock('../Toast', () => ({
+  useV5Toast: () => mockToast,
+  V5ToastProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+import { ApikeysV5 } from './Apikeys';
+
+const K1 = { id: 'k1', label: 'CI', masked_key: 'ph_abc***xyz', last_used_at: '2026-04-20T10:00:00Z', created_at: '2026-01-01T00:00:00Z' };
+
+function renderScreen() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <ApikeysV5 navigate={vi.fn()} />
+    </QueryClientProvider>
+  );
+}
+
+describe('ApikeysV5', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('renders empty state', async () => {
+    mockList.mockResolvedValue({ success: true, data: [] });
+    renderScreen();
+    await waitFor(() => expect(screen.getByText('Keine Schlüssel')).toBeInTheDocument());
+  });
+
+  it('renders error state', async () => {
+    mockList.mockResolvedValue({ success: false, data: null, error: { code: 'X', message: 'fail' } });
+    renderScreen();
+    await waitFor(() => expect(screen.getByText('Fehler beim Laden')).toBeInTheDocument());
+  });
+
+  it('renders key rows with masked value', async () => {
+    mockList.mockResolvedValue({ success: true, data: [K1] });
+    renderScreen();
+    await waitFor(() => expect(screen.getAllByTestId('apikeys-row')).toHaveLength(1));
+    expect(screen.getByText('CI')).toBeInTheDocument();
+    expect(screen.getByText('ph_abc***xyz')).toBeInTheDocument();
+  });
+
+  it('create shows revealed token banner', async () => {
+    mockList.mockResolvedValue({ success: true, data: [] });
+    mockCreate.mockResolvedValue({ success: true, data: { ...K1, id: 'new', token: 'ph_FULL_TOKEN_123' } });
+    renderScreen();
+    await waitFor(() => expect(screen.getByTestId('apikeys-label')).toBeInTheDocument());
+    fireEvent.change(screen.getByTestId('apikeys-label'), { target: { value: 'Deploy' } });
+    fireEvent.click(screen.getByTestId('apikeys-create'));
+    await waitFor(() => expect(screen.getByTestId('apikeys-revealed')).toBeInTheDocument());
+    expect(screen.getByText('ph_FULL_TOKEN_123')).toBeInTheDocument();
+    expect(mockToast).toHaveBeenCalledWith('API-Schlüssel erstellt', 'success');
+  });
+
+  it('create error surfaces via toast', async () => {
+    mockList.mockResolvedValue({ success: true, data: [] });
+    mockCreate.mockResolvedValue({ success: false, data: null, error: { code: 'X', message: 'limit' } });
+    renderScreen();
+    await waitFor(() => expect(screen.getByTestId('apikeys-label')).toBeInTheDocument());
+    fireEvent.change(screen.getByTestId('apikeys-label'), { target: { value: 'Deploy' } });
+    fireEvent.click(screen.getByTestId('apikeys-create'));
+    await waitFor(() => expect(mockToast).toHaveBeenCalledWith('limit', 'error'));
+  });
+
+  it('rotate calls rotateApiKey', async () => {
+    mockList.mockResolvedValue({ success: true, data: [K1] });
+    mockRotate.mockResolvedValue({ success: true, data: { ...K1, token: 'ph_NEW' } });
+    renderScreen();
+    await waitFor(() => expect(screen.getByText('Rotieren')).toBeInTheDocument());
+    fireEvent.click(screen.getByText('Rotieren'));
+    await waitFor(() => {
+      expect(mockRotate).toHaveBeenCalledWith('k1');
+      expect(mockToast).toHaveBeenCalledWith('Schlüssel rotiert', 'success');
+    });
+  });
+
+  it('revoke calls revokeApiKey', async () => {
+    mockList.mockResolvedValue({ success: true, data: [K1] });
+    mockRevoke.mockResolvedValue({ success: true, data: null });
+    renderScreen();
+    await waitFor(() => expect(screen.getByText('Widerrufen')).toBeInTheDocument());
+    fireEvent.click(screen.getByText('Widerrufen'));
+    await waitFor(() => {
+      expect(mockRevoke).toHaveBeenCalledWith('k1');
+      expect(mockToast).toHaveBeenCalledWith('Schlüssel widerrufen', 'success');
+    });
+  });
+
+  it('revoke error surfaces via toast', async () => {
+    mockList.mockResolvedValue({ success: true, data: [K1] });
+    mockRevoke.mockResolvedValue({ success: false, data: null, error: { code: 'X', message: 'forbidden' } });
+    renderScreen();
+    await waitFor(() => expect(screen.getByText('Widerrufen')).toBeInTheDocument());
+    fireEvent.click(screen.getByText('Widerrufen'));
+    await waitFor(() => expect(mockToast).toHaveBeenCalledWith('forbidden', 'error'));
+  });
+});

--- a/parkhub-web/src/design-v5/screens/Apikeys.tsx
+++ b/parkhub-web/src/design-v5/screens/Apikeys.tsx
@@ -1,0 +1,204 @@
+import { useState } from 'react';
+import NumberFlow from '@number-flow/react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { Badge, Card, SectionLabel, V5NamedIcon } from '../primitives';
+import { useV5Toast } from '../Toast';
+import { api, type CreatedApiKey } from '../../api/client';
+import type { ScreenId } from '../nav';
+
+function formatWhen(iso: string | null): string {
+  if (!iso) return 'Nie';
+  return new Date(iso).toLocaleDateString('de-DE', { day: '2-digit', month: '2-digit', year: 'numeric' });
+}
+
+export function ApikeysV5({ navigate: _navigate }: { navigate: (id: ScreenId) => void }) {
+  const toast = useV5Toast();
+  const qc = useQueryClient();
+  const [newLabel, setNewLabel] = useState('');
+  const [revealed, setRevealed] = useState<CreatedApiKey | null>(null);
+
+  const { data: keys = [], isLoading, isError } = useQuery({
+    queryKey: ['apikeys'],
+    queryFn: async () => {
+      const res = await api.getApiKeys();
+      if (!res.success) throw new Error(res.error?.message ?? 'API-Schlüssel konnten nicht geladen werden');
+      return res.data ?? [];
+    },
+    staleTime: 30_000,
+  });
+
+  const create = useMutation({
+    mutationFn: async (label: string) => {
+      const res = await api.createApiKey(label);
+      if (!res.success) throw new Error(res.error?.message ?? 'Erstellen fehlgeschlagen');
+      return res.data;
+    },
+    onSuccess: (data) => {
+      qc.invalidateQueries({ queryKey: ['apikeys'] });
+      if (data) setRevealed(data);
+      toast('API-Schlüssel erstellt', 'success');
+      setNewLabel('');
+    },
+    onError: (err: Error) => toast(err.message || 'Erstellen fehlgeschlagen', 'error'),
+  });
+
+  const rotate = useMutation({
+    mutationFn: async (id: string) => {
+      const res = await api.rotateApiKey(id);
+      if (!res.success) throw new Error(res.error?.message ?? 'Rotation fehlgeschlagen');
+      return res.data;
+    },
+    onSuccess: (data) => {
+      qc.invalidateQueries({ queryKey: ['apikeys'] });
+      if (data) setRevealed(data);
+      toast('Schlüssel rotiert', 'success');
+    },
+    onError: (err: Error) => toast(err.message || 'Rotation fehlgeschlagen', 'error'),
+  });
+
+  const revoke = useMutation({
+    mutationFn: async (id: string) => {
+      const res = await api.revokeApiKey(id);
+      if (!res.success) throw new Error(res.error?.message ?? 'Widerruf fehlgeschlagen');
+      return res.data;
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['apikeys'] });
+      toast('Schlüssel widerrufen', 'success');
+    },
+    onError: (err: Error) => toast(err.message || 'Widerruf fehlgeschlagen', 'error'),
+  });
+
+  async function copyToken() {
+    if (!revealed?.token || typeof navigator === 'undefined' || !navigator.clipboard) return;
+    try {
+      await navigator.clipboard.writeText(revealed.token);
+      toast('In Zwischenablage kopiert', 'success');
+    } catch {
+      toast('Kopieren fehlgeschlagen', 'error');
+    }
+  }
+
+  if (isLoading) {
+    return (
+      <div style={{ padding: 16, flex: 1, overflow: 'auto' }}>
+        {[0, 1, 2].map((i) => (
+          <div key={i} style={{ height: 60, borderRadius: 12, background: 'var(--v5-sur2)', marginBottom: 8, animation: 'ph-v5-pulse 1.6s ease infinite', animationDelay: `${i * 0.1}s` }} />
+        ))}
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div style={{ padding: 16, flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+        <Card className="v5-ani" style={{ padding: 28, textAlign: 'center', maxWidth: 360 }}>
+          <V5NamedIcon name="x" size={26} color="var(--v5-err)" />
+          <div style={{ marginTop: 10, fontWeight: 600, color: 'var(--v5-txt)' }}>Fehler beim Laden</div>
+        </Card>
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ padding: 16, flex: 1, overflow: 'auto', display: 'flex', flexDirection: 'column', gap: 12 }}>
+      <div className="v5-ani" style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+        <span style={{ fontWeight: 700, fontSize: 15, color: 'var(--v5-txt)' }}>API-Schlüssel</span>
+        <Badge variant="gray"><NumberFlow value={keys.length} /></Badge>
+      </div>
+
+      {revealed && (
+        <Card className="v5-ani" data-testid="apikeys-revealed" style={{ padding: 16, borderLeft: '3px solid var(--v5-warn)' }}>
+          <SectionLabel>Neuer Schlüssel – einmalig sichtbar</SectionLabel>
+          <div style={{ fontSize: 11, color: 'var(--v5-mut)', marginBottom: 8 }}>
+            Kopieren Sie den Schlüssel jetzt – nach dem Schließen wird er maskiert.
+          </div>
+          <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+            <code
+              className="v5-mono"
+              style={{
+                flex: 1, padding: '8px 11px', borderRadius: 9,
+                background: 'var(--v5-sur2)', border: '1px solid var(--v5-bor)',
+                color: 'var(--v5-txt)', fontSize: 11, wordBreak: 'break-all',
+              }}
+            >{revealed.token}</code>
+            <button
+              type="button" onClick={copyToken} data-testid="apikeys-copy"
+              style={{ padding: '7px 12px', borderRadius: 9, background: 'var(--v5-acc)', color: 'var(--v5-accent-fg)', border: 'none', fontSize: 11, fontWeight: 600, cursor: 'pointer' }}
+            >Kopieren</button>
+            <button
+              type="button" onClick={() => setRevealed(null)} data-testid="apikeys-dismiss"
+              style={{ padding: '7px 12px', borderRadius: 9, background: 'var(--v5-sur2)', border: '1px solid var(--v5-bor)', color: 'var(--v5-txt)', fontSize: 11, fontWeight: 500, cursor: 'pointer' }}
+            >Schließen</button>
+          </div>
+        </Card>
+      )}
+
+      <Card className="v5-ani" style={{ padding: 16, display: 'flex', flexDirection: 'column', gap: 10 }}>
+        <SectionLabel>Neuen Schlüssel erstellen</SectionLabel>
+        <div style={{ display: 'flex', gap: 8 }}>
+          <input
+            data-testid="apikeys-label"
+            placeholder="Label (z. B. CI/CD)"
+            value={newLabel}
+            onChange={(e) => setNewLabel(e.target.value)}
+            style={{ flex: 1, padding: '8px 11px', borderRadius: 9, background: 'var(--v5-sur2)', border: '1px solid var(--v5-bor)', color: 'var(--v5-txt)', fontSize: 12, outline: 'none', fontFamily: 'inherit' }}
+          />
+          <button
+            type="button"
+            disabled={newLabel.trim().length < 2 || create.isPending}
+            onClick={() => create.mutate(newLabel.trim())}
+            data-testid="apikeys-create"
+            style={{
+              padding: '8px 16px', borderRadius: 9, background: 'var(--v5-acc)', color: 'var(--v5-accent-fg)',
+              border: 'none', fontSize: 12, fontWeight: 600,
+              cursor: newLabel.trim().length >= 2 && !create.isPending ? 'pointer' : 'not-allowed',
+              opacity: newLabel.trim().length >= 2 && !create.isPending ? 1 : 0.5,
+            }}
+          >{create.isPending ? 'Erstellt …' : 'Erstellen'}</button>
+        </div>
+      </Card>
+
+      {keys.length === 0 ? (
+        <Card className="v5-ani" style={{ padding: 36, textAlign: 'center' }}>
+          <V5NamedIcon name="key" size={20} color="var(--v5-mut)" />
+          <div style={{ marginTop: 10, fontWeight: 600, color: 'var(--v5-txt)' }}>Keine Schlüssel</div>
+        </Card>
+      ) : (
+        <Card className="v5-ani" style={{ overflow: 'hidden' }}>
+          {keys.map((k, i) => {
+            const rotBusy = rotate.isPending && rotate.variables === k.id;
+            const revBusy = revoke.isPending && revoke.variables === k.id;
+            return (
+              <div key={k.id} data-testid="apikeys-row" style={{
+                display: 'grid', gridTemplateColumns: '1fr 1fr 120px 180px',
+                padding: '12px 16px', alignItems: 'center', gap: 8,
+                borderBottom: i < keys.length - 1 ? '1px solid var(--v5-bor)' : 'none',
+              }}>
+                <span style={{ fontSize: 12, fontWeight: 500, color: 'var(--v5-txt)' }}>{k.label}</span>
+                <code className="v5-mono" style={{ fontSize: 11, color: 'var(--v5-mut)' }}>{k.masked_key}</code>
+                <span style={{ fontSize: 10, color: 'var(--v5-mut)' }}>
+                  Zuletzt: {formatWhen(k.last_used_at)}
+                </span>
+                <div style={{ display: 'flex', gap: 6, justifyContent: 'flex-end' }}>
+                  <button
+                    type="button" disabled={rotBusy}
+                    onClick={() => rotate.mutate(k.id)}
+                    aria-label={`Schlüssel ${k.label} rotieren`}
+                    style={{ padding: '4px 10px', borderRadius: 7, background: 'var(--v5-acc-muted)', border: 'none', fontSize: 10, fontWeight: 500, color: 'var(--v5-acc)', cursor: rotBusy ? 'default' : 'pointer', opacity: rotBusy ? 0.5 : 1 }}
+                  >{rotBusy ? '…' : 'Rotieren'}</button>
+                  <button
+                    type="button" disabled={revBusy}
+                    onClick={() => revoke.mutate(k.id)}
+                    aria-label={`Schlüssel ${k.label} widerrufen`}
+                    style={{ padding: '4px 10px', borderRadius: 7, background: 'color-mix(in oklch, var(--v5-err) 8%, transparent)', border: 'none', fontSize: 10, fontWeight: 500, color: 'var(--v5-err)', cursor: revBusy ? 'default' : 'pointer', opacity: revBusy ? 0.5 : 1 }}
+                  >{revBusy ? '…' : 'Widerrufen'}</button>
+                </div>
+              </div>
+            );
+          })}
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/parkhub-web/src/design-v5/screens/Audit.test.tsx
+++ b/parkhub-web/src/design-v5/screens/Audit.test.tsx
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+const mockGet = vi.fn();
+vi.mock('../../api/client', () => ({
+  api: {
+    getAuditLog: (...a: unknown[]) => mockGet(...a),
+  },
+}));
+
+vi.mock('@number-flow/react', () => ({
+  default: ({ value }: { value: number }) => <span>{value}</span>,
+}));
+
+import { AuditV5 } from './Audit';
+
+const E1 = { id: 'e1', timestamp: '2026-04-20T10:00:00Z', event_type: 'login', username: 'flo', details: 'OK' };
+const E2 = { id: 'e2', timestamp: '2026-04-20T11:00:00Z', event_type: 'update', username: 'anna', details: 'role=admin' };
+
+function renderScreen() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <AuditV5 navigate={vi.fn()} />
+    </QueryClientProvider>
+  );
+}
+
+describe('AuditV5', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('renders empty state', async () => {
+    mockGet.mockResolvedValue({ success: true, data: { entries: [], total: 0, page: 1, per_page: 25, total_pages: 1 } });
+    renderScreen();
+    await waitFor(() => expect(screen.getByText('Keine Einträge')).toBeInTheDocument());
+  });
+
+  it('renders error state when query fails', async () => {
+    mockGet.mockResolvedValue({ success: false, data: null, error: { code: 'X', message: 'denied' } });
+    renderScreen();
+    await waitFor(() => expect(screen.getByText('Fehler beim Laden')).toBeInTheDocument());
+  });
+
+  it('renders entry rows', async () => {
+    mockGet.mockResolvedValue({ success: true, data: { entries: [E1, E2], total: 2, page: 1, per_page: 25, total_pages: 1 } });
+    renderScreen();
+    await waitFor(() => expect(screen.getAllByTestId('audit-row')).toHaveLength(2));
+    expect(screen.getByText('flo')).toBeInTheDocument();
+    expect(screen.getByText('role=admin')).toBeInTheDocument();
+  });
+
+  it('applies filters and refetches', async () => {
+    mockGet.mockResolvedValue({ success: true, data: { entries: [E1], total: 1, page: 1, per_page: 25, total_pages: 1 } });
+    renderScreen();
+    await waitFor(() => expect(screen.getAllByTestId('audit-row')).toHaveLength(1));
+    fireEvent.change(screen.getByTestId('audit-action'), { target: { value: 'login' } });
+    fireEvent.change(screen.getByTestId('audit-user'), { target: { value: 'flo' } });
+    fireEvent.click(screen.getByTestId('audit-apply'));
+    await waitFor(() => {
+      expect(mockGet).toHaveBeenCalledWith(expect.objectContaining({ action: 'login', user: 'flo', page: 1 }));
+    });
+  });
+
+  it('pagination next/prev moves page', async () => {
+    mockGet.mockResolvedValue({ success: true, data: { entries: [E1], total: 50, page: 1, per_page: 25, total_pages: 2 } });
+    renderScreen();
+    await waitFor(() => expect(screen.getByTestId('audit-next')).not.toBeDisabled());
+    fireEvent.click(screen.getByTestId('audit-next'));
+    await waitFor(() => {
+      expect(mockGet).toHaveBeenCalledWith(expect.objectContaining({ page: 2 }));
+    });
+  });
+
+  it('reset clears filters', async () => {
+    mockGet.mockResolvedValue({ success: true, data: { entries: [E1], total: 1, page: 1, per_page: 25, total_pages: 1 } });
+    renderScreen();
+    await waitFor(() => expect(screen.getByTestId('audit-action')).toBeInTheDocument());
+    fireEvent.change(screen.getByTestId('audit-action'), { target: { value: 'login' } });
+    fireEvent.click(screen.getByTestId('audit-reset'));
+    await waitFor(() => {
+      expect((screen.getByTestId('audit-action') as HTMLInputElement).value).toBe('');
+    });
+  });
+
+  it('prev button disabled on first page', async () => {
+    mockGet.mockResolvedValue({ success: true, data: { entries: [E1], total: 50, page: 1, per_page: 25, total_pages: 2 } });
+    renderScreen();
+    await waitFor(() => expect(screen.getByTestId('audit-prev')).toBeDisabled());
+  });
+});

--- a/parkhub-web/src/design-v5/screens/Audit.tsx
+++ b/parkhub-web/src/design-v5/screens/Audit.tsx
@@ -1,0 +1,165 @@
+import { useState } from 'react';
+import NumberFlow from '@number-flow/react';
+import { useQuery } from '@tanstack/react-query';
+import { Badge, Card, V5NamedIcon } from '../primitives';
+import { api } from '../../api/client';
+import type { ScreenId } from '../nav';
+
+function formatWhen(iso: string): string {
+  return new Date(iso).toLocaleString('de-DE', {
+    day: '2-digit', month: '2-digit', year: 'numeric',
+    hour: '2-digit', minute: '2-digit',
+  });
+}
+
+export function AuditV5({ navigate: _navigate }: { navigate: (id: ScreenId) => void }) {
+  const [page, setPage] = useState(1);
+  const [actionFilter, setActionFilter] = useState('');
+  const [userFilter, setUserFilter] = useState('');
+  const PER_PAGE = 25;
+
+  const [appliedAction, setAppliedAction] = useState('');
+  const [appliedUser, setAppliedUser] = useState('');
+
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ['audit', page, appliedAction, appliedUser],
+    queryFn: async () => {
+      const res = await api.getAuditLog({
+        page,
+        per_page: PER_PAGE,
+        action: appliedAction || undefined,
+        user: appliedUser || undefined,
+      });
+      if (!res.success) throw new Error(res.error?.message ?? 'Audit-Log konnte nicht geladen werden');
+      return res.data ?? { entries: [], total: 0, page: 1, per_page: PER_PAGE, total_pages: 1 };
+    },
+    staleTime: 15_000,
+    placeholderData: (prev) => prev,
+  });
+
+  function applyFilters() {
+    setAppliedAction(actionFilter);
+    setAppliedUser(userFilter);
+    setPage(1);
+  }
+
+  if (isLoading && !data) {
+    return (
+      <div style={{ padding: 16, flex: 1, overflow: 'auto' }}>
+        {[0, 1, 2].map((i) => (
+          <div key={i} style={{ height: 50, borderRadius: 10, background: 'var(--v5-sur2)', marginBottom: 6, animation: 'ph-v5-pulse 1.6s ease infinite', animationDelay: `${i * 0.05}s` }} />
+        ))}
+      </div>
+    );
+  }
+
+  if (isError || !data) {
+    return (
+      <div style={{ padding: 16, flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+        <Card className="v5-ani" style={{ padding: 28, textAlign: 'center', maxWidth: 360 }}>
+          <V5NamedIcon name="x" size={26} color="var(--v5-err)" />
+          <div style={{ marginTop: 10, fontWeight: 600, color: 'var(--v5-txt)' }}>Fehler beim Laden</div>
+        </Card>
+      </div>
+    );
+  }
+
+  const entries = data.entries ?? [];
+
+  return (
+    <div style={{ padding: 16, flex: 1, overflow: 'auto', display: 'flex', flexDirection: 'column', gap: 12 }}>
+      <div className="v5-ani" style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <span style={{ fontWeight: 700, fontSize: 15, color: 'var(--v5-txt)' }}>Audit-Log</span>
+          <Badge variant="gray"><NumberFlow value={data.total} /></Badge>
+        </div>
+        <span style={{ fontSize: 11, color: 'var(--v5-mut)' }}>
+          Seite {data.page} / {Math.max(1, data.total_pages)}
+        </span>
+      </div>
+
+      <Card className="v5-ani" style={{ padding: 12, display: 'flex', gap: 8, flexWrap: 'wrap', alignItems: 'flex-end', animationDelay: '0.06s' }}>
+        <label style={{ display: 'flex', flexDirection: 'column', gap: 4, flex: '1 1 160px' }}>
+          <span style={{ fontSize: 10, color: 'var(--v5-mut)' }}>Aktion</span>
+          <input
+            data-testid="audit-action"
+            placeholder="z. B. login"
+            value={actionFilter}
+            onChange={(e) => setActionFilter(e.target.value)}
+            style={{ padding: '6px 10px', borderRadius: 8, background: 'var(--v5-sur2)', border: '1px solid var(--v5-bor)', color: 'var(--v5-txt)', fontSize: 11, outline: 'none', fontFamily: 'inherit' }}
+          />
+        </label>
+        <label style={{ display: 'flex', flexDirection: 'column', gap: 4, flex: '1 1 160px' }}>
+          <span style={{ fontSize: 10, color: 'var(--v5-mut)' }}>Nutzer</span>
+          <input
+            data-testid="audit-user"
+            placeholder="username"
+            value={userFilter}
+            onChange={(e) => setUserFilter(e.target.value)}
+            style={{ padding: '6px 10px', borderRadius: 8, background: 'var(--v5-sur2)', border: '1px solid var(--v5-bor)', color: 'var(--v5-txt)', fontSize: 11, outline: 'none', fontFamily: 'inherit' }}
+          />
+        </label>
+        <button
+          type="button" onClick={applyFilters} data-testid="audit-apply"
+          style={{ padding: '7px 14px', borderRadius: 8, background: 'var(--v5-acc)', color: 'var(--v5-accent-fg)', border: 'none', fontSize: 11, fontWeight: 600, cursor: 'pointer' }}
+        >Filtern</button>
+        <button
+          type="button"
+          onClick={() => { setActionFilter(''); setUserFilter(''); setAppliedAction(''); setAppliedUser(''); setPage(1); }}
+          data-testid="audit-reset"
+          style={{ padding: '7px 14px', borderRadius: 8, background: 'var(--v5-sur2)', border: '1px solid var(--v5-bor)', color: 'var(--v5-txt)', fontSize: 11, fontWeight: 500, cursor: 'pointer' }}
+        >Zurücksetzen</button>
+      </Card>
+
+      {entries.length === 0 ? (
+        <Card className="v5-ani" style={{ padding: 36, textAlign: 'center', animationDelay: '0.12s' }}>
+          <V5NamedIcon name="shield" size={20} color="var(--v5-mut)" />
+          <div style={{ marginTop: 10, fontWeight: 600, color: 'var(--v5-txt)' }}>Keine Einträge</div>
+        </Card>
+      ) : (
+        <Card className="v5-ani" style={{ overflow: 'hidden', animationDelay: '0.12s' }}>
+          <div className="v5-mono" style={{
+            display: 'grid', gridTemplateColumns: '140px 110px 130px 1fr',
+            padding: '6px 14px', fontSize: 9, letterSpacing: 1.2, textTransform: 'uppercase',
+            color: 'var(--v5-mut)', borderBottom: '1px solid var(--v5-bor)',
+          }}>
+            <span>Zeit</span><span>Nutzer</span><span>Aktion</span><span>Details</span>
+          </div>
+          {entries.map((e, i) => (
+            <div key={e.id} data-testid="audit-row" style={{
+              display: 'grid', gridTemplateColumns: '140px 110px 130px 1fr',
+              padding: '8px 14px', alignItems: 'center', gap: 6,
+              borderBottom: i < entries.length - 1 ? '1px solid var(--v5-bor)' : 'none',
+              fontSize: 11,
+            }}>
+              <span className="v5-mono" style={{ fontSize: 10, color: 'var(--v5-mut)' }}>{formatWhen(e.timestamp)}</span>
+              <span style={{ color: 'var(--v5-txt)' }}>{e.username ?? '—'}</span>
+              <Badge variant="info">{e.event_type}</Badge>
+              <span className="v5-mono" style={{ fontSize: 10, color: 'var(--v5-mut)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }} title={e.details ?? ''}>
+                {e.details ?? '—'}
+              </span>
+            </div>
+          ))}
+        </Card>
+      )}
+
+      <div className="v5-ani" style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', animationDelay: '0.18s' }}>
+        <button
+          type="button" disabled={page <= 1}
+          onClick={() => setPage((p) => Math.max(1, p - 1))}
+          data-testid="audit-prev"
+          style={{ padding: '7px 14px', borderRadius: 8, background: 'var(--v5-sur2)', border: '1px solid var(--v5-bor)', color: 'var(--v5-txt)', fontSize: 11, fontWeight: 500, cursor: page > 1 ? 'pointer' : 'not-allowed', opacity: page > 1 ? 1 : 0.5 }}
+        >← Zurück</button>
+        <span style={{ fontSize: 11, color: 'var(--v5-mut)' }}>
+          {data.entries.length > 0 ? `${(data.page - 1) * data.per_page + 1}–${(data.page - 1) * data.per_page + data.entries.length}` : '0'} von {data.total}
+        </span>
+        <button
+          type="button" disabled={page >= data.total_pages}
+          onClick={() => setPage((p) => Math.min(data.total_pages, p + 1))}
+          data-testid="audit-next"
+          style={{ padding: '7px 14px', borderRadius: 8, background: 'var(--v5-sur2)', border: '1px solid var(--v5-bor)', color: 'var(--v5-txt)', fontSize: 11, fontWeight: 500, cursor: page < data.total_pages ? 'pointer' : 'not-allowed', opacity: page < data.total_pages ? 1 : 0.5 }}
+        >Weiter →</button>
+      </div>
+    </div>
+  );
+}

--- a/parkhub-web/src/design-v5/screens/Benachrichtigungen.test.tsx
+++ b/parkhub-web/src/design-v5/screens/Benachrichtigungen.test.tsx
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+const mockList = vi.fn();
+const mockRead = vi.fn();
+const mockReadAll = vi.fn();
+vi.mock('../../api/client', () => ({
+  api: {
+    getNotifications: (...a: unknown[]) => mockList(...a),
+    markNotificationRead: (...a: unknown[]) => mockRead(...a),
+    markAllNotificationsRead: (...a: unknown[]) => mockReadAll(...a),
+  },
+}));
+
+vi.mock('@number-flow/react', () => ({
+  default: ({ value }: { value: number }) => <span>{value}</span>,
+}));
+
+const mockToast = vi.fn();
+vi.mock('../Toast', () => ({
+  useV5Toast: () => mockToast,
+  V5ToastProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+import { BenachrichtigungenV5 } from './Benachrichtigungen';
+
+const N1 = { id: 'n1', title: 'Neue Buchung', message: 'Platz A3', notification_type: 'booking', read: false, created_at: '2026-04-23T10:00:00Z' };
+const N2 = { id: 'n2', title: 'Tauschanfrage', message: 'Swap', notification_type: 'swap', read: true, created_at: '2026-04-22T10:00:00Z' };
+
+function renderScreen() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <BenachrichtigungenV5 navigate={vi.fn()} />
+    </QueryClientProvider>
+  );
+}
+
+describe('BenachrichtigungenV5', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('renders empty state', async () => {
+    mockList.mockResolvedValue({ success: true, data: [] });
+    renderScreen();
+    await waitFor(() => expect(screen.getByText('Keine Benachrichtigungen')).toBeInTheDocument());
+  });
+
+  it('renders error when query fails', async () => {
+    mockList.mockResolvedValue({ success: false, data: null, error: { code: 'X', message: 'denied' } });
+    renderScreen();
+    await waitFor(() => expect(screen.getByText('Fehler beim Laden')).toBeInTheDocument());
+  });
+
+  it('renders rows and shows unread count', async () => {
+    mockList.mockResolvedValue({ success: true, data: [N1, N2] });
+    renderScreen();
+    await waitFor(() => expect(screen.getAllByTestId('benach-row')).toHaveLength(2));
+    expect(screen.getByText('1 ungelesen')).toBeInTheDocument();
+  });
+
+  it('filters to unread only', async () => {
+    mockList.mockResolvedValue({ success: true, data: [N1, N2] });
+    renderScreen();
+    await waitFor(() => expect(screen.getAllByTestId('benach-row')).toHaveLength(2));
+    fireEvent.click(screen.getByRole('button', { name: 'Ungelesen' }));
+    await waitFor(() => expect(screen.getAllByTestId('benach-row')).toHaveLength(1));
+  });
+
+  it('mark-read mutation fires for individual item', async () => {
+    mockList.mockResolvedValue({ success: true, data: [N1] });
+    mockRead.mockResolvedValue({ success: true, data: null });
+    renderScreen();
+    await waitFor(() => expect(screen.getByLabelText('Benachrichtigung n1 als gelesen markieren')).toBeInTheDocument());
+    fireEvent.click(screen.getByLabelText('Benachrichtigung n1 als gelesen markieren'));
+    await waitFor(() => {
+      expect(mockRead).toHaveBeenCalledWith('n1');
+      expect(mockToast).toHaveBeenCalledWith('Als gelesen markiert', 'success');
+    });
+  });
+
+  it('mark-read error surfaces via toast', async () => {
+    mockList.mockResolvedValue({ success: true, data: [N1] });
+    mockRead.mockResolvedValue({ success: false, data: null, error: { code: 'X', message: 'fail' } });
+    renderScreen();
+    await waitFor(() => expect(screen.getByLabelText('Benachrichtigung n1 als gelesen markieren')).toBeInTheDocument());
+    fireEvent.click(screen.getByLabelText('Benachrichtigung n1 als gelesen markieren'));
+    await waitFor(() => expect(mockToast).toHaveBeenCalledWith('fail', 'error'));
+  });
+
+  it('mark-all button calls markAllNotificationsRead', async () => {
+    mockList.mockResolvedValue({ success: true, data: [N1, N2] });
+    mockReadAll.mockResolvedValue({ success: true, data: null });
+    renderScreen();
+    await waitFor(() => expect(screen.getByTestId('benach-mark-all')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('benach-mark-all'));
+    await waitFor(() => {
+      expect(mockReadAll).toHaveBeenCalled();
+      expect(mockToast).toHaveBeenCalledWith('Alle als gelesen markiert', 'success');
+    });
+  });
+});

--- a/parkhub-web/src/design-v5/screens/Benachrichtigungen.test.tsx
+++ b/parkhub-web/src/design-v5/screens/Benachrichtigungen.test.tsx
@@ -2,14 +2,20 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
+// v5 Benachrichtigungen is an admin-nav entry — it broadcasts
+// system-wide announcements to the whole tenant. It must call the
+// /api/v1/admin/announcements endpoints, NOT the per-user notification
+// inbox (that feed is surfaced by the bell dropdown + NotificationCenter).
 const mockList = vi.fn();
-const mockRead = vi.fn();
-const mockReadAll = vi.fn();
+const mockCreate = vi.fn();
+const mockUpdate = vi.fn();
+const mockDelete = vi.fn();
 vi.mock('../../api/client', () => ({
   api: {
-    getNotifications: (...a: unknown[]) => mockList(...a),
-    markNotificationRead: (...a: unknown[]) => mockRead(...a),
-    markAllNotificationsRead: (...a: unknown[]) => mockReadAll(...a),
+    adminListAnnouncements: (...a: unknown[]) => mockList(...a),
+    adminCreateAnnouncement: (...a: unknown[]) => mockCreate(...a),
+    adminUpdateAnnouncement: (...a: unknown[]) => mockUpdate(...a),
+    adminDeleteAnnouncement: (...a: unknown[]) => mockDelete(...a),
   },
 }));
 
@@ -25,8 +31,14 @@ vi.mock('../Toast', () => ({
 
 import { BenachrichtigungenV5 } from './Benachrichtigungen';
 
-const N1 = { id: 'n1', title: 'Neue Buchung', message: 'Platz A3', notification_type: 'booking', read: false, created_at: '2026-04-23T10:00:00Z' };
-const N2 = { id: 'n2', title: 'Tauschanfrage', message: 'Swap', notification_type: 'swap', read: true, created_at: '2026-04-22T10:00:00Z' };
+const A1 = {
+  id: 'a1', title: 'Wartung 1. Mai', message: 'Lot 3 geschlossen',
+  severity: 'warning', active: true, created_at: '2026-04-23T10:00:00Z',
+};
+const A2 = {
+  id: 'a2', title: 'Alte Info', message: 'Ignorieren',
+  severity: 'info', active: false, created_at: '2026-04-10T10:00:00Z',
+};
 
 function renderScreen() {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
@@ -37,13 +49,13 @@ function renderScreen() {
   );
 }
 
-describe('BenachrichtigungenV5', () => {
+describe('BenachrichtigungenV5 (admin)', () => {
   beforeEach(() => vi.clearAllMocks());
 
   it('renders empty state', async () => {
     mockList.mockResolvedValue({ success: true, data: [] });
     renderScreen();
-    await waitFor(() => expect(screen.getByText('Keine Benachrichtigungen')).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText('Keine Ankündigungen')).toBeInTheDocument());
   });
 
   it('renders error when query fails', async () => {
@@ -52,51 +64,52 @@ describe('BenachrichtigungenV5', () => {
     await waitFor(() => expect(screen.getByText('Fehler beim Laden')).toBeInTheDocument());
   });
 
-  it('renders rows and shows unread count', async () => {
-    mockList.mockResolvedValue({ success: true, data: [N1, N2] });
+  it('renders one row per announcement with active + inactive badges', async () => {
+    mockList.mockResolvedValue({ success: true, data: [A1, A2] });
     renderScreen();
     await waitFor(() => expect(screen.getAllByTestId('benach-row')).toHaveLength(2));
-    expect(screen.getByText('1 ungelesen')).toBeInTheDocument();
+    expect(screen.getByText('Wartung 1. Mai')).toBeInTheDocument();
+    expect(screen.getByText('Alte Info')).toBeInTheDocument();
   });
 
-  it('filters to unread only', async () => {
-    mockList.mockResolvedValue({ success: true, data: [N1, N2] });
+  it('creates a new announcement via adminCreateAnnouncement', async () => {
+    mockList.mockResolvedValue({ success: true, data: [] });
+    mockCreate.mockResolvedValue({ success: true, data: { ...A1, id: 'a-new' } });
     renderScreen();
-    await waitFor(() => expect(screen.getAllByTestId('benach-row')).toHaveLength(2));
-    fireEvent.click(screen.getByRole('button', { name: 'Ungelesen' }));
-    await waitFor(() => expect(screen.getAllByTestId('benach-row')).toHaveLength(1));
-  });
-
-  it('mark-read mutation fires for individual item', async () => {
-    mockList.mockResolvedValue({ success: true, data: [N1] });
-    mockRead.mockResolvedValue({ success: true, data: null });
-    renderScreen();
-    await waitFor(() => expect(screen.getByLabelText('Benachrichtigung n1 als gelesen markieren')).toBeInTheDocument());
-    fireEvent.click(screen.getByLabelText('Benachrichtigung n1 als gelesen markieren'));
+    await waitFor(() => expect(screen.getByTestId('benach-new-title')).toBeInTheDocument());
+    fireEvent.change(screen.getByTestId('benach-new-title'), { target: { value: 'Neu' } });
+    fireEvent.change(screen.getByTestId('benach-new-message'), { target: { value: 'Hallo Team' } });
+    fireEvent.click(screen.getByTestId('benach-new-submit'));
     await waitFor(() => {
-      expect(mockRead).toHaveBeenCalledWith('n1');
-      expect(mockToast).toHaveBeenCalledWith('Als gelesen markiert', 'success');
+      expect(mockCreate).toHaveBeenCalledWith(expect.objectContaining({
+        title: 'Neu',
+        message: 'Hallo Team',
+        active: true,
+      }));
+      expect(mockToast).toHaveBeenCalledWith('Ankündigung erstellt', 'success');
     });
   });
 
-  it('mark-read error surfaces via toast', async () => {
-    mockList.mockResolvedValue({ success: true, data: [N1] });
-    mockRead.mockResolvedValue({ success: false, data: null, error: { code: 'X', message: 'fail' } });
+  it('surfaces create error when success:false', async () => {
+    mockList.mockResolvedValue({ success: true, data: [] });
+    mockCreate.mockResolvedValue({ success: false, data: null, error: { code: 'E', message: 'fail' } });
     renderScreen();
-    await waitFor(() => expect(screen.getByLabelText('Benachrichtigung n1 als gelesen markieren')).toBeInTheDocument());
-    fireEvent.click(screen.getByLabelText('Benachrichtigung n1 als gelesen markieren'));
+    await waitFor(() => expect(screen.getByTestId('benach-new-title')).toBeInTheDocument());
+    fireEvent.change(screen.getByTestId('benach-new-title'), { target: { value: 'x' } });
+    fireEvent.change(screen.getByTestId('benach-new-message'), { target: { value: 'y' } });
+    fireEvent.click(screen.getByTestId('benach-new-submit'));
     await waitFor(() => expect(mockToast).toHaveBeenCalledWith('fail', 'error'));
   });
 
-  it('mark-all button calls markAllNotificationsRead', async () => {
-    mockList.mockResolvedValue({ success: true, data: [N1, N2] });
-    mockReadAll.mockResolvedValue({ success: true, data: null });
+  it('deletes an announcement via adminDeleteAnnouncement', async () => {
+    mockList.mockResolvedValue({ success: true, data: [A1] });
+    mockDelete.mockResolvedValue({ success: true, data: null });
     renderScreen();
-    await waitFor(() => expect(screen.getByTestId('benach-mark-all')).toBeInTheDocument());
-    fireEvent.click(screen.getByTestId('benach-mark-all'));
+    await waitFor(() => expect(screen.getByLabelText('Ankündigung a1 löschen')).toBeInTheDocument());
+    fireEvent.click(screen.getByLabelText('Ankündigung a1 löschen'));
     await waitFor(() => {
-      expect(mockReadAll).toHaveBeenCalled();
-      expect(mockToast).toHaveBeenCalledWith('Alle als gelesen markiert', 'success');
+      expect(mockDelete).toHaveBeenCalledWith('a1');
+      expect(mockToast).toHaveBeenCalledWith('Ankündigung gelöscht', 'success');
     });
   });
 });

--- a/parkhub-web/src/design-v5/screens/Benachrichtigungen.tsx
+++ b/parkhub-web/src/design-v5/screens/Benachrichtigungen.tsx
@@ -1,18 +1,35 @@
 import { useState } from 'react';
 import NumberFlow from '@number-flow/react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { Badge, Card, V5NamedIcon } from '../primitives';
+import { Badge, Card, V5NamedIcon, type BadgeVariant } from '../primitives';
 import { useV5Toast } from '../Toast';
-import { api, type Notification } from '../../api/client';
+import { api, type Announcement } from '../../api/client';
 import type { ScreenId } from '../nav';
 
-type FilterKey = 'alle' | 'ungelesen' | 'gelesen';
+/**
+ * Benachrichtigungen — admin view of tenant-wide announcements.
+ *
+ * This screen is the admin authoring surface for the broadcast banner
+ * that surfaces to every user via the bell dropdown + top banner. It
+ * talks to `/api/v1/admin/announcements` (list/create/delete), NOT the
+ * per-user notification inbox which is surfaced elsewhere.
+ *
+ * Codex #376: the v5 draft shipped this admin-nav entry wired to
+ * `getNotifications` / `markNotificationRead`, so admins could only
+ * read-state their own alerts and had no way to compose or retire a
+ * system-wide announcement from the new shell.
+ */
 
-const FILTERS: { key: FilterKey; label: string }[] = [
-  { key: 'alle', label: 'Alle' },
-  { key: 'ungelesen', label: 'Ungelesen' },
-  { key: 'gelesen', label: 'Gelesen' },
-];
+function severityVariant(sev: string): BadgeVariant {
+  switch (sev) {
+    case 'critical': return 'error';
+    case 'warning': return 'warning';
+    case 'success': return 'success';
+    case 'info':
+    default:
+      return 'info';
+  }
+}
 
 function formatWhen(iso: string): string {
   return new Date(iso).toLocaleString('de-DE', {
@@ -21,53 +38,66 @@ function formatWhen(iso: string): string {
   });
 }
 
+const SEVERITIES: { value: string; label: string }[] = [
+  { value: 'info', label: 'Info' },
+  { value: 'success', label: 'Erfolg' },
+  { value: 'warning', label: 'Warnung' },
+  { value: 'critical', label: 'Kritisch' },
+];
+
 export function BenachrichtigungenV5({ navigate: _navigate }: { navigate: (id: ScreenId) => void }) {
   const toast = useV5Toast();
   const qc = useQueryClient();
-  const [filter, setFilter] = useState<FilterKey>('alle');
 
   const { data: items = [], isLoading, isError } = useQuery({
-    queryKey: ['benachrichtigungen'],
+    queryKey: ['admin-announcements'],
     queryFn: async () => {
-      const res = await api.getNotifications();
-      if (!res.success) throw new Error(res.error?.message ?? 'Benachrichtigungen konnten nicht geladen werden');
+      const res = await api.adminListAnnouncements();
+      if (!res.success) throw new Error(res.error?.message ?? 'Ankündigungen konnten nicht geladen werden');
       return res.data ?? [];
     },
     staleTime: 30_000,
   });
 
-  const markRead = useMutation({
-    mutationFn: async (id: string) => {
-      const res = await api.markNotificationRead(id);
-      if (!res.success) throw new Error(res.error?.message ?? 'Markieren fehlgeschlagen');
-      return res.data;
-    },
-    onSuccess: () => {
-      qc.invalidateQueries({ queryKey: ['benachrichtigungen'] });
-      toast('Als gelesen markiert', 'success');
-    },
-    onError: (err: Error) => toast(err.message || 'Markieren fehlgeschlagen', 'error'),
-  });
+  const [title, setTitle] = useState('');
+  const [message, setMessage] = useState('');
+  const [severity, setSeverity] = useState('info');
+  const [active, setActive] = useState(true);
 
-  const markAll = useMutation({
+  const createMutation = useMutation({
     mutationFn: async () => {
-      const res = await api.markAllNotificationsRead();
-      if (!res.success) throw new Error(res.error?.message ?? 'Aktion fehlgeschlagen');
+      const res = await api.adminCreateAnnouncement({
+        title: title.trim(),
+        message: message.trim(),
+        severity,
+        active,
+      });
+      if (!res.success) throw new Error(res.error?.message ?? 'Erstellen fehlgeschlagen');
       return res.data;
     },
     onSuccess: () => {
-      qc.invalidateQueries({ queryKey: ['benachrichtigungen'] });
-      toast('Alle als gelesen markiert', 'success');
+      qc.invalidateQueries({ queryKey: ['admin-announcements'] });
+      setTitle('');
+      setMessage('');
+      toast('Ankündigung erstellt', 'success');
     },
-    onError: (err: Error) => toast(err.message || 'Aktion fehlgeschlagen', 'error'),
+    onError: (err: Error) => toast(err.message || 'Erstellen fehlgeschlagen', 'error'),
   });
 
-  const filtered = items.filter((n: Notification) => {
-    if (filter === 'ungelesen') return !n.read;
-    if (filter === 'gelesen') return n.read;
-    return true;
+  const deleteMutation = useMutation({
+    mutationFn: async (id: string) => {
+      const res = await api.adminDeleteAnnouncement(id);
+      if (!res.success) throw new Error(res.error?.message ?? 'Löschen fehlgeschlagen');
+      return res.data;
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['admin-announcements'] });
+      toast('Ankündigung gelöscht', 'success');
+    },
+    onError: (err: Error) => toast(err.message || 'Löschen fehlgeschlagen', 'error'),
   });
-  const unreadCount = items.filter((n) => !n.read).length;
+
+  const activeCount = items.filter((a: Announcement) => a.active).length;
 
   if (isLoading) {
     return (
@@ -94,88 +124,133 @@ export function BenachrichtigungenV5({ navigate: _navigate }: { navigate: (id: S
     <div style={{ padding: 16, flex: 1, overflow: 'auto', display: 'flex', flexDirection: 'column', gap: 12 }}>
       <div className="v5-ani" style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
         <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-          <span style={{ fontWeight: 700, fontSize: 15, color: 'var(--v5-txt)' }}>Benachrichtigungen</span>
+          <span style={{ fontWeight: 700, fontSize: 15, color: 'var(--v5-txt)' }}>Ankündigungen</span>
           <Badge variant="gray"><NumberFlow value={items.length} /></Badge>
-          {unreadCount > 0 && <Badge variant="primary" dot>{unreadCount} ungelesen</Badge>}
+          {activeCount > 0 && <Badge variant="primary" dot>{activeCount} aktiv</Badge>}
         </div>
-        <button
-          type="button"
-          disabled={unreadCount === 0 || markAll.isPending}
-          onClick={() => markAll.mutate()}
-          data-testid="benach-mark-all"
+      </div>
+
+      <Card className="v5-ani" style={{ padding: 16, display: 'flex', flexDirection: 'column', gap: 10, animationDelay: '0.06s' }}>
+        <div style={{ fontSize: 12, fontWeight: 600, color: 'var(--v5-txt)' }}>Neue Ankündigung</div>
+        <input
+          data-testid="benach-new-title"
+          type="text"
+          placeholder="Titel"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
           style={{
-            padding: '7px 14px', borderRadius: 9, background: 'var(--v5-acc)', color: 'var(--v5-accent-fg)',
-            border: 'none', fontSize: 11, fontWeight: 600,
-            cursor: unreadCount > 0 && !markAll.isPending ? 'pointer' : 'not-allowed',
-            opacity: unreadCount > 0 && !markAll.isPending ? 1 : 0.5,
+            padding: '8px 11px', borderRadius: 9, background: 'var(--v5-sur2)',
+            border: '1px solid var(--v5-bor)', color: 'var(--v5-txt)', fontSize: 12,
+            width: '100%', outline: 'none', boxSizing: 'border-box', fontFamily: 'inherit',
           }}
-        >
-          Alle als gelesen
-        </button>
-      </div>
+        />
+        <textarea
+          data-testid="benach-new-message"
+          placeholder="Nachricht"
+          value={message}
+          onChange={(e) => setMessage(e.target.value)}
+          rows={3}
+          style={{
+            padding: '8px 11px', borderRadius: 9, background: 'var(--v5-sur2)',
+            border: '1px solid var(--v5-bor)', color: 'var(--v5-txt)', fontSize: 12,
+            width: '100%', outline: 'none', boxSizing: 'border-box', fontFamily: 'inherit',
+            resize: 'vertical',
+          }}
+        />
+        <div style={{ display: 'flex', alignItems: 'center', gap: 12, flexWrap: 'wrap' }}>
+          <div role="group" aria-label="Priorität" style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
+            {SEVERITIES.map((s) => {
+              const selected = severity === s.value;
+              return (
+                <button
+                  key={s.value} type="button" aria-pressed={selected}
+                  onClick={() => setSeverity(s.value)}
+                  style={{
+                    padding: '5px 12px', borderRadius: 999, fontSize: 11, fontWeight: 500, cursor: 'pointer',
+                    border: `1.5px solid ${selected ? 'var(--v5-acc)' : 'var(--v5-bor)'}`,
+                    background: selected ? 'var(--v5-acc-muted)' : 'transparent',
+                    color: selected ? 'var(--v5-acc)' : 'var(--v5-mut)',
+                  }}
+                >{s.label}</button>
+              );
+            })}
+          </div>
+          <label style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 11, color: 'var(--v5-mut)' }}>
+            <input
+              type="checkbox"
+              checked={active}
+              onChange={(e) => setActive(e.target.checked)}
+              data-testid="benach-new-active"
+            />
+            Aktiv
+          </label>
+          <div style={{ flex: 1 }} />
+          <button
+            type="button"
+            disabled={!title.trim() || !message.trim() || createMutation.isPending}
+            onClick={() => createMutation.mutate()}
+            data-testid="benach-new-submit"
+            style={{
+              padding: '7px 14px', borderRadius: 9, background: 'var(--v5-acc)', color: 'var(--v5-accent-fg)',
+              border: 'none', fontSize: 11, fontWeight: 600,
+              cursor: (!title.trim() || !message.trim() || createMutation.isPending) ? 'not-allowed' : 'pointer',
+              opacity: (!title.trim() || !message.trim() || createMutation.isPending) ? 0.5 : 1,
+            }}
+          >
+            {createMutation.isPending ? 'Erstellt …' : 'Senden'}
+          </button>
+        </div>
+      </Card>
 
-      <div className="v5-ani" role="group" aria-label="Filter" style={{ display: 'flex', gap: 6, flexWrap: 'wrap', animationDelay: '0.06s' }}>
-        {FILTERS.map((f) => {
-          const active = filter === f.key;
-          return (
-            <button
-              key={f.key} type="button" aria-pressed={active} onClick={() => setFilter(f.key)}
-              style={{
-                padding: '5px 12px', borderRadius: 999, fontSize: 11, fontWeight: 500, cursor: 'pointer',
-                border: `1.5px solid ${active ? 'var(--v5-acc)' : 'var(--v5-bor)'}`,
-                background: active ? 'var(--v5-acc-muted)' : 'transparent',
-                color: active ? 'var(--v5-acc)' : 'var(--v5-mut)',
-              }}
-            >{f.label}</button>
-          );
-        })}
-      </div>
-
-      {filtered.length === 0 ? (
+      {items.length === 0 ? (
         <Card className="v5-ani" style={{ padding: 36, textAlign: 'center', animationDelay: '0.12s' }}>
           <V5NamedIcon name="bell" size={20} color="var(--v5-mut)" />
-          <div style={{ marginTop: 10, fontWeight: 600, color: 'var(--v5-txt)' }}>Keine Benachrichtigungen</div>
+          <div style={{ marginTop: 10, fontWeight: 600, color: 'var(--v5-txt)' }}>Keine Ankündigungen</div>
+          <div style={{ fontSize: 12, color: 'var(--v5-mut)', marginTop: 4 }}>
+            Erstelle oben eine neue Ankündigung für das gesamte Team.
+          </div>
         </Card>
       ) : (
         <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
-          {filtered.map((n, i) => {
-            const busy = markRead.isPending && markRead.variables === n.id;
+          {items.map((a: Announcement, i: number) => {
+            const deleting = deleteMutation.isPending && deleteMutation.variables === a.id;
             return (
               <Card
-                key={n.id} data-testid="benach-row"
+                key={a.id} data-testid="benach-row"
                 className="v5-ani"
                 style={{
                   padding: 14, display: 'flex', alignItems: 'flex-start', gap: 12,
                   animationDelay: `${0.1 + i * 0.03}s`,
-                  borderLeft: n.read ? undefined : '3px solid var(--v5-acc)',
+                  borderLeft: a.active ? '3px solid var(--v5-acc)' : undefined,
+                  opacity: a.active ? 1 : 0.7,
                 }}
               >
                 <div style={{
                   width: 32, height: 32, borderRadius: 8,
-                  background: n.read ? 'var(--v5-sur2)' : 'var(--v5-acc-muted)',
+                  background: a.active ? 'var(--v5-acc-muted)' : 'var(--v5-sur2)',
                   display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0,
                 }}>
-                  <V5NamedIcon name="bell" size={14} color={n.read ? 'var(--v5-mut)' : 'var(--v5-acc)'} />
+                  <V5NamedIcon name="bell" size={14} color={a.active ? 'var(--v5-acc)' : 'var(--v5-mut)'} />
                 </div>
                 <div style={{ flex: 1, minWidth: 0 }}>
-                  <div style={{ display: 'flex', alignItems: 'baseline', gap: 8 }}>
-                    <span style={{ fontSize: 12, fontWeight: 600, color: 'var(--v5-txt)' }}>{n.title}</span>
-                    <span style={{ fontSize: 10, color: 'var(--v5-mut)' }}>{formatWhen(n.created_at)}</span>
+                  <div style={{ display: 'flex', alignItems: 'baseline', gap: 8, flexWrap: 'wrap' }}>
+                    <span style={{ fontSize: 12, fontWeight: 600, color: 'var(--v5-txt)' }}>{a.title}</span>
+                    <Badge variant={severityVariant(a.severity)} dot>{a.severity}</Badge>
+                    {!a.active && <Badge variant="gray">Inaktiv</Badge>}
+                    <span style={{ fontSize: 10, color: 'var(--v5-mut)' }}>{formatWhen(a.created_at)}</span>
                   </div>
-                  <div style={{ fontSize: 11, color: 'var(--v5-mut)', marginTop: 3 }}>{n.message}</div>
+                  <div style={{ fontSize: 11, color: 'var(--v5-mut)', marginTop: 3 }}>{a.message}</div>
                 </div>
-                {!n.read && (
-                  <button
-                    type="button" disabled={busy}
-                    aria-label={`Benachrichtigung ${n.id} als gelesen markieren`}
-                    onClick={() => markRead.mutate(n.id)}
-                    style={{
-                      padding: '4px 10px', borderRadius: 7, background: 'var(--v5-acc-muted)',
-                      border: 'none', fontSize: 10, fontWeight: 500, color: 'var(--v5-acc)',
-                      cursor: busy ? 'default' : 'pointer', opacity: busy ? 0.5 : 1, flexShrink: 0,
-                    }}
-                  >{busy ? '…' : 'Gelesen'}</button>
-                )}
+                <button
+                  type="button" disabled={deleting}
+                  aria-label={`Ankündigung ${a.id} löschen`}
+                  onClick={() => deleteMutation.mutate(a.id)}
+                  style={{
+                    padding: '4px 10px', borderRadius: 7, background: 'var(--v5-sur2)',
+                    border: '1px solid var(--v5-bor)', fontSize: 10, fontWeight: 500, color: 'var(--v5-err)',
+                    cursor: deleting ? 'default' : 'pointer', opacity: deleting ? 0.5 : 1, flexShrink: 0,
+                  }}
+                >{deleting ? '…' : 'Löschen'}</button>
               </Card>
             );
           })}

--- a/parkhub-web/src/design-v5/screens/Benachrichtigungen.tsx
+++ b/parkhub-web/src/design-v5/screens/Benachrichtigungen.tsx
@@ -1,0 +1,186 @@
+import { useState } from 'react';
+import NumberFlow from '@number-flow/react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { Badge, Card, V5NamedIcon } from '../primitives';
+import { useV5Toast } from '../Toast';
+import { api, type Notification } from '../../api/client';
+import type { ScreenId } from '../nav';
+
+type FilterKey = 'alle' | 'ungelesen' | 'gelesen';
+
+const FILTERS: { key: FilterKey; label: string }[] = [
+  { key: 'alle', label: 'Alle' },
+  { key: 'ungelesen', label: 'Ungelesen' },
+  { key: 'gelesen', label: 'Gelesen' },
+];
+
+function formatWhen(iso: string): string {
+  return new Date(iso).toLocaleString('de-DE', {
+    day: '2-digit', month: '2-digit', year: 'numeric',
+    hour: '2-digit', minute: '2-digit',
+  });
+}
+
+export function BenachrichtigungenV5({ navigate: _navigate }: { navigate: (id: ScreenId) => void }) {
+  const toast = useV5Toast();
+  const qc = useQueryClient();
+  const [filter, setFilter] = useState<FilterKey>('alle');
+
+  const { data: items = [], isLoading, isError } = useQuery({
+    queryKey: ['benachrichtigungen'],
+    queryFn: async () => {
+      const res = await api.getNotifications();
+      if (!res.success) throw new Error(res.error?.message ?? 'Benachrichtigungen konnten nicht geladen werden');
+      return res.data ?? [];
+    },
+    staleTime: 30_000,
+  });
+
+  const markRead = useMutation({
+    mutationFn: async (id: string) => {
+      const res = await api.markNotificationRead(id);
+      if (!res.success) throw new Error(res.error?.message ?? 'Markieren fehlgeschlagen');
+      return res.data;
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['benachrichtigungen'] });
+      toast('Als gelesen markiert', 'success');
+    },
+    onError: (err: Error) => toast(err.message || 'Markieren fehlgeschlagen', 'error'),
+  });
+
+  const markAll = useMutation({
+    mutationFn: async () => {
+      const res = await api.markAllNotificationsRead();
+      if (!res.success) throw new Error(res.error?.message ?? 'Aktion fehlgeschlagen');
+      return res.data;
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['benachrichtigungen'] });
+      toast('Alle als gelesen markiert', 'success');
+    },
+    onError: (err: Error) => toast(err.message || 'Aktion fehlgeschlagen', 'error'),
+  });
+
+  const filtered = items.filter((n: Notification) => {
+    if (filter === 'ungelesen') return !n.read;
+    if (filter === 'gelesen') return n.read;
+    return true;
+  });
+  const unreadCount = items.filter((n) => !n.read).length;
+
+  if (isLoading) {
+    return (
+      <div style={{ padding: 16, flex: 1, overflow: 'auto' }}>
+        {[0, 1, 2].map((i) => (
+          <div key={i} style={{ height: 60, borderRadius: 12, background: 'var(--v5-sur2)', marginBottom: 8, animation: 'ph-v5-pulse 1.6s ease infinite', animationDelay: `${i * 0.1}s` }} />
+        ))}
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div style={{ padding: 16, flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+        <Card className="v5-ani" style={{ padding: 28, textAlign: 'center', maxWidth: 360 }}>
+          <V5NamedIcon name="x" size={26} color="var(--v5-err)" />
+          <div style={{ marginTop: 10, fontWeight: 600, color: 'var(--v5-txt)' }}>Fehler beim Laden</div>
+        </Card>
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ padding: 16, flex: 1, overflow: 'auto', display: 'flex', flexDirection: 'column', gap: 12 }}>
+      <div className="v5-ani" style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <span style={{ fontWeight: 700, fontSize: 15, color: 'var(--v5-txt)' }}>Benachrichtigungen</span>
+          <Badge variant="gray"><NumberFlow value={items.length} /></Badge>
+          {unreadCount > 0 && <Badge variant="primary" dot>{unreadCount} ungelesen</Badge>}
+        </div>
+        <button
+          type="button"
+          disabled={unreadCount === 0 || markAll.isPending}
+          onClick={() => markAll.mutate()}
+          data-testid="benach-mark-all"
+          style={{
+            padding: '7px 14px', borderRadius: 9, background: 'var(--v5-acc)', color: 'var(--v5-accent-fg)',
+            border: 'none', fontSize: 11, fontWeight: 600,
+            cursor: unreadCount > 0 && !markAll.isPending ? 'pointer' : 'not-allowed',
+            opacity: unreadCount > 0 && !markAll.isPending ? 1 : 0.5,
+          }}
+        >
+          Alle als gelesen
+        </button>
+      </div>
+
+      <div className="v5-ani" role="group" aria-label="Filter" style={{ display: 'flex', gap: 6, flexWrap: 'wrap', animationDelay: '0.06s' }}>
+        {FILTERS.map((f) => {
+          const active = filter === f.key;
+          return (
+            <button
+              key={f.key} type="button" aria-pressed={active} onClick={() => setFilter(f.key)}
+              style={{
+                padding: '5px 12px', borderRadius: 999, fontSize: 11, fontWeight: 500, cursor: 'pointer',
+                border: `1.5px solid ${active ? 'var(--v5-acc)' : 'var(--v5-bor)'}`,
+                background: active ? 'var(--v5-acc-muted)' : 'transparent',
+                color: active ? 'var(--v5-acc)' : 'var(--v5-mut)',
+              }}
+            >{f.label}</button>
+          );
+        })}
+      </div>
+
+      {filtered.length === 0 ? (
+        <Card className="v5-ani" style={{ padding: 36, textAlign: 'center', animationDelay: '0.12s' }}>
+          <V5NamedIcon name="bell" size={20} color="var(--v5-mut)" />
+          <div style={{ marginTop: 10, fontWeight: 600, color: 'var(--v5-txt)' }}>Keine Benachrichtigungen</div>
+        </Card>
+      ) : (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+          {filtered.map((n, i) => {
+            const busy = markRead.isPending && markRead.variables === n.id;
+            return (
+              <Card
+                key={n.id} data-testid="benach-row"
+                className="v5-ani"
+                style={{
+                  padding: 14, display: 'flex', alignItems: 'flex-start', gap: 12,
+                  animationDelay: `${0.1 + i * 0.03}s`,
+                  borderLeft: n.read ? undefined : '3px solid var(--v5-acc)',
+                }}
+              >
+                <div style={{
+                  width: 32, height: 32, borderRadius: 8,
+                  background: n.read ? 'var(--v5-sur2)' : 'var(--v5-acc-muted)',
+                  display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0,
+                }}>
+                  <V5NamedIcon name="bell" size={14} color={n.read ? 'var(--v5-mut)' : 'var(--v5-acc)'} />
+                </div>
+                <div style={{ flex: 1, minWidth: 0 }}>
+                  <div style={{ display: 'flex', alignItems: 'baseline', gap: 8 }}>
+                    <span style={{ fontSize: 12, fontWeight: 600, color: 'var(--v5-txt)' }}>{n.title}</span>
+                    <span style={{ fontSize: 10, color: 'var(--v5-mut)' }}>{formatWhen(n.created_at)}</span>
+                  </div>
+                  <div style={{ fontSize: 11, color: 'var(--v5-mut)', marginTop: 3 }}>{n.message}</div>
+                </div>
+                {!n.read && (
+                  <button
+                    type="button" disabled={busy}
+                    aria-label={`Benachrichtigung ${n.id} als gelesen markieren`}
+                    onClick={() => markRead.mutate(n.id)}
+                    style={{
+                      padding: '4px 10px', borderRadius: 7, background: 'var(--v5-acc-muted)',
+                      border: 'none', fontSize: 10, fontWeight: 500, color: 'var(--v5-acc)',
+                      cursor: busy ? 'default' : 'pointer', opacity: busy ? 0.5 : 1, flexShrink: 0,
+                    }}
+                  >{busy ? '…' : 'Gelesen'}</button>
+                )}
+              </Card>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/parkhub-web/src/design-v5/screens/Billing.test.tsx
+++ b/parkhub-web/src/design-v5/screens/Billing.test.tsx
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+const mockHistory = vi.fn();
+const mockConfig = vi.fn();
+vi.mock('../../api/client', () => ({
+  api: {
+    getPaymentHistory: (...a: unknown[]) => mockHistory(...a),
+    getStripeConfig: (...a: unknown[]) => mockConfig(...a),
+  },
+}));
+
+vi.mock('@number-flow/react', () => ({
+  default: ({ value }: { value: number }) => <span>{value}</span>,
+}));
+
+import { BillingV5 } from './Billing';
+
+const P1 = { id: 'p-abcdefghij12345', amount: 1200, credits: 10, currency: 'EUR', status: 'completed' as const, created_at: '2026-04-01T10:00:00Z' };
+const P2 = { id: 'p-pending000000', amount: 500, credits: 5, currency: 'EUR', status: 'pending' as const, created_at: '2026-04-20T10:00:00Z' };
+
+function renderScreen() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <BillingV5 navigate={vi.fn()} />
+    </QueryClientProvider>
+  );
+}
+
+describe('BillingV5', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockConfig.mockResolvedValue({ success: true, data: { configured: true } });
+  });
+
+  it('renders empty history message', async () => {
+    mockHistory.mockResolvedValue({ success: true, data: [] });
+    renderScreen();
+    await waitFor(() => expect(screen.getByText('Noch keine Zahlungen')).toBeInTheDocument());
+  });
+
+  it('renders error state when history fails', async () => {
+    mockHistory.mockResolvedValue({ success: false, data: null, error: { code: 'X', message: 'denied' } });
+    renderScreen();
+    await waitFor(() => expect(screen.getByText('Fehler beim Laden')).toBeInTheDocument());
+  });
+
+  it('renders payment rows with status badges', async () => {
+    mockHistory.mockResolvedValue({ success: true, data: [P1, P2] });
+    renderScreen();
+    await waitFor(() => expect(screen.getAllByTestId('billing-row')).toHaveLength(2));
+    expect(screen.getByText('Bezahlt')).toBeInTheDocument();
+    expect(screen.getByText('Ausstehend')).toBeInTheDocument();
+  });
+
+  it('surfaces Stripe configured badge from config', async () => {
+    mockHistory.mockResolvedValue({ success: true, data: [] });
+    mockConfig.mockResolvedValue({ success: true, data: { configured: false } });
+    renderScreen();
+    await waitFor(() => expect(screen.getByText('Nicht konfiguriert')).toBeInTheDocument());
+  });
+
+  it('computes total paid only from completed payments', async () => {
+    mockHistory.mockResolvedValue({ success: true, data: [P1, P2] });
+    renderScreen();
+    await waitFor(() => expect(screen.getAllByTestId('billing-row')).toHaveLength(2));
+    // 1200 cents / EUR => 12,00 €
+    expect(screen.getAllByText(/12,00/).length).toBeGreaterThan(0);
+  });
+
+  it('renders loading skeleton initially then replaces with content', async () => {
+    mockHistory.mockResolvedValue({ success: true, data: [P1] });
+    renderScreen();
+    await waitFor(() => expect(screen.getAllByTestId('billing-row')).toHaveLength(1));
+  });
+});

--- a/parkhub-web/src/design-v5/screens/Billing.test.tsx
+++ b/parkhub-web/src/design-v5/screens/Billing.test.tsx
@@ -2,11 +2,13 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
-const mockHistory = vi.fn();
+const mockCostCenter = vi.fn();
+const mockDepartment = vi.fn();
 const mockConfig = vi.fn();
 vi.mock('../../api/client', () => ({
   api: {
-    getPaymentHistory: (...a: unknown[]) => mockHistory(...a),
+    adminBillingByCostCenter: (...a: unknown[]) => mockCostCenter(...a),
+    adminBillingByDepartment: (...a: unknown[]) => mockDepartment(...a),
     getStripeConfig: (...a: unknown[]) => mockConfig(...a),
   },
 }));
@@ -17,8 +19,35 @@ vi.mock('@number-flow/react', () => ({
 
 import { BillingV5 } from './Billing';
 
-const P1 = { id: 'p-abcdefghij12345', amount: 1200, credits: 10, currency: 'EUR', status: 'completed' as const, created_at: '2026-04-01T10:00:00Z' };
-const P2 = { id: 'p-pending000000', amount: 500, credits: 5, currency: 'EUR', status: 'pending' as const, created_at: '2026-04-20T10:00:00Z' };
+// Tenant-wide billing fixtures (admin view): aggregates per cost-center and
+// per-department as returned by /api/v1/admin/billing/by-cost-center +
+// /by-department. Amount is euros (f64), NOT cents as in personal payment
+// history — that's the server-side schema from parkhub-server/src/api/billing.rs.
+const CC_ROWS = [
+  {
+    cost_center: 'CC-100', department: 'Engineering',
+    user_count: 12, total_bookings: 180,
+    total_credits_used: 1800, total_amount: 3600.50,
+    currency: 'EUR',
+  },
+  {
+    cost_center: 'CC-200', department: 'Sales',
+    user_count: 6, total_bookings: 40,
+    total_credits_used: 400, total_amount: 800.00,
+    currency: 'EUR',
+  },
+];
+
+const DEPT_ROWS = [
+  {
+    department: 'Engineering', user_count: 12, total_bookings: 180,
+    total_credits_used: 1800, total_amount: 3600.50, currency: 'EUR',
+  },
+  {
+    department: 'Sales', user_count: 6, total_bookings: 40,
+    total_credits_used: 400, total_amount: 800.00, currency: 'EUR',
+  },
+];
 
 function renderScreen() {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
@@ -29,50 +58,52 @@ function renderScreen() {
   );
 }
 
-describe('BillingV5', () => {
+describe('BillingV5 (admin)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockConfig.mockResolvedValue({ success: true, data: { configured: true } });
+    mockCostCenter.mockResolvedValue({ success: true, data: CC_ROWS });
+    mockDepartment.mockResolvedValue({ success: true, data: DEPT_ROWS });
   });
 
-  it('renders empty history message', async () => {
-    mockHistory.mockResolvedValue({ success: true, data: [] });
+  it('renders empty state when no cost centers are configured', async () => {
+    mockCostCenter.mockResolvedValue({ success: true, data: [] });
+    mockDepartment.mockResolvedValue({ success: true, data: [] });
     renderScreen();
-    await waitFor(() => expect(screen.getByText('Noch keine Zahlungen')).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText(/keine Kostenstellen/i)).toBeInTheDocument());
   });
 
-  it('renders error state when history fails', async () => {
-    mockHistory.mockResolvedValue({ success: false, data: null, error: { code: 'X', message: 'denied' } });
+  it('renders error state when cost-center query fails', async () => {
+    mockCostCenter.mockResolvedValue({ success: false, data: null, error: { code: 'X', message: 'denied' } });
     renderScreen();
     await waitFor(() => expect(screen.getByText('Fehler beim Laden')).toBeInTheDocument());
   });
 
-  it('renders payment rows with status badges', async () => {
-    mockHistory.mockResolvedValue({ success: true, data: [P1, P2] });
+  it('renders one row per cost center', async () => {
     renderScreen();
-    await waitFor(() => expect(screen.getAllByTestId('billing-row')).toHaveLength(2));
-    expect(screen.getByText('Bezahlt')).toBeInTheDocument();
-    expect(screen.getByText('Ausstehend')).toBeInTheDocument();
+    await waitFor(() => expect(screen.getAllByTestId('billing-row')).toHaveLength(CC_ROWS.length));
+    expect(screen.getByText('CC-100')).toBeInTheDocument();
+    expect(screen.getByText('CC-200')).toBeInTheDocument();
+  });
+
+  it('shows aggregate totals across all cost centers', async () => {
+    renderScreen();
+    await waitFor(() => expect(screen.getAllByTestId('billing-row')).toHaveLength(CC_ROWS.length));
+    // Total = 3600.50 + 800.00 = 4400.50 EUR
+    expect(screen.getAllByText(/4\.400,50/).length).toBeGreaterThan(0);
+    // Total bookings = 220
+    expect(screen.getAllByText(/220/).length).toBeGreaterThan(0);
+  });
+
+  it('calls the admin billing endpoints on mount (not the personal payment history)', async () => {
+    renderScreen();
+    await waitFor(() => expect(mockCostCenter).toHaveBeenCalled());
+    expect(mockDepartment).toHaveBeenCalled();
   });
 
   it('surfaces Stripe configured badge from config', async () => {
-    mockHistory.mockResolvedValue({ success: true, data: [] });
     mockConfig.mockResolvedValue({ success: true, data: { configured: false } });
     renderScreen();
     await waitFor(() => expect(screen.getByText('Nicht konfiguriert')).toBeInTheDocument());
-  });
-
-  it('computes total paid only from completed payments', async () => {
-    mockHistory.mockResolvedValue({ success: true, data: [P1, P2] });
-    renderScreen();
-    await waitFor(() => expect(screen.getAllByTestId('billing-row')).toHaveLength(2));
-    // 1200 cents / EUR => 12,00 €
-    expect(screen.getAllByText(/12,00/).length).toBeGreaterThan(0);
-  });
-
-  it('renders loading skeleton initially then replaces with content', async () => {
-    mockHistory.mockResolvedValue({ success: true, data: [P1] });
-    renderScreen();
-    await waitFor(() => expect(screen.getAllByTestId('billing-row')).toHaveLength(1));
   });
 });

--- a/parkhub-web/src/design-v5/screens/Billing.tsx
+++ b/parkhub-web/src/design-v5/screens/Billing.tsx
@@ -1,0 +1,142 @@
+import NumberFlow from '@number-flow/react';
+import { useQuery } from '@tanstack/react-query';
+import { Badge, Card, V5NamedIcon, type BadgeVariant } from '../primitives';
+import { api, type PaymentHistoryEntry } from '../../api/client';
+import type { ScreenId } from '../nav';
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString('de-DE', { day: '2-digit', month: '2-digit', year: 'numeric' });
+}
+
+function formatMoney(amount: number, currency: string): string {
+  return new Intl.NumberFormat('de-DE', { style: 'currency', currency: currency || 'EUR' }).format(amount / 100);
+}
+
+function statusVariant(s: PaymentHistoryEntry['status']): BadgeVariant {
+  switch (s) {
+    case 'completed': return 'success';
+    case 'pending': return 'warning';
+    case 'failed': return 'error';
+    default: return 'gray';
+  }
+}
+
+const STATUS_LABEL: Record<PaymentHistoryEntry['status'], string> = {
+  completed: 'Bezahlt', pending: 'Ausstehend', failed: 'Fehlgeschlagen', expired: 'Abgelaufen',
+};
+
+export function BillingV5({ navigate: _navigate }: { navigate: (id: ScreenId) => void }) {
+  const { data: history = [], isLoading, isError } = useQuery({
+    queryKey: ['billing-history'],
+    queryFn: async () => {
+      const res = await api.getPaymentHistory();
+      if (!res.success) throw new Error(res.error?.message ?? 'Zahlungsverlauf konnte nicht geladen werden');
+      return res.data ?? [];
+    },
+    staleTime: 30_000,
+  });
+
+  const { data: config } = useQuery({
+    queryKey: ['billing-config'],
+    queryFn: async () => {
+      const res = await api.getStripeConfig();
+      if (!res.success) throw new Error(res.error?.message ?? 'Konfiguration fehlt');
+      return res.data;
+    },
+    staleTime: 60_000,
+  });
+
+  const totalPaid = history
+    .filter((h) => h.status === 'completed')
+    .reduce((sum, h) => sum + h.amount, 0);
+  const totalCredits = history
+    .filter((h) => h.status === 'completed')
+    .reduce((sum, h) => sum + h.credits, 0);
+
+  if (isLoading) {
+    return (
+      <div style={{ padding: 16, flex: 1, overflow: 'auto' }}>
+        {[0, 1, 2].map((i) => (
+          <div key={i} style={{ height: 60, borderRadius: 12, background: 'var(--v5-sur2)', marginBottom: 8, animation: 'ph-v5-pulse 1.6s ease infinite', animationDelay: `${i * 0.1}s` }} />
+        ))}
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div style={{ padding: 16, flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+        <Card className="v5-ani" style={{ padding: 28, textAlign: 'center', maxWidth: 360 }}>
+          <V5NamedIcon name="x" size={26} color="var(--v5-err)" />
+          <div style={{ marginTop: 10, fontWeight: 600, color: 'var(--v5-txt)' }}>Fehler beim Laden</div>
+        </Card>
+      </div>
+    );
+  }
+
+  const currency = history[0]?.currency ?? 'EUR';
+
+  return (
+    <div style={{ padding: 16, flex: 1, overflow: 'auto', display: 'flex', flexDirection: 'column', gap: 12 }}>
+      <div className="v5-ani" style={{ fontWeight: 700, fontSize: 15, color: 'var(--v5-txt)' }}>Abrechnung</div>
+
+      <div className="v5-ani" style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(200px, 1fr))', gap: 10, animationDelay: '0.06s' }}>
+        <Card style={{ padding: 14 }}>
+          <div className="v5-mono" style={{ fontSize: 9, letterSpacing: 1.3, color: 'var(--v5-mut)', textTransform: 'uppercase' }}>Gesamt bezahlt</div>
+          <div className="v5-mono" style={{ fontSize: 22, fontWeight: 700, color: 'var(--v5-txt)', marginTop: 4 }}>{formatMoney(totalPaid, currency)}</div>
+        </Card>
+        <Card style={{ padding: 14 }}>
+          <div className="v5-mono" style={{ fontSize: 9, letterSpacing: 1.3, color: 'var(--v5-mut)', textTransform: 'uppercase' }}>Credits erworben</div>
+          <div className="v5-mono" style={{ fontSize: 22, fontWeight: 700, color: 'var(--v5-txt)', marginTop: 4 }}><NumberFlow value={totalCredits} /></div>
+        </Card>
+        <Card style={{ padding: 14 }}>
+          <div className="v5-mono" style={{ fontSize: 9, letterSpacing: 1.3, color: 'var(--v5-mut)', textTransform: 'uppercase' }}>Stripe</div>
+          <div style={{ marginTop: 8 }}>
+            <Badge variant={config?.configured ? 'success' : 'gray'} dot>
+              {config?.configured ? 'Konfiguriert' : 'Nicht konfiguriert'}
+            </Badge>
+          </div>
+        </Card>
+      </div>
+
+      <Card className="v5-ani" style={{ padding: 16, animationDelay: '0.12s' }}>
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 10 }}>
+          <span style={{ fontWeight: 600, fontSize: 13, color: 'var(--v5-txt)' }}>Zahlungsverlauf</span>
+          <Badge variant="gray">{history.length}</Badge>
+        </div>
+        {history.length === 0 ? (
+          <div style={{ padding: 24, textAlign: 'center', fontSize: 12, color: 'var(--v5-mut)' }}>
+            Noch keine Zahlungen
+          </div>
+        ) : (
+          <div>
+            <div className="v5-mono" style={{
+              display: 'grid', gridTemplateColumns: '110px 1fr 100px 120px 110px',
+              padding: '6px 4px', fontSize: 9, letterSpacing: 1.2, textTransform: 'uppercase',
+              color: 'var(--v5-mut)', borderBottom: '1px solid var(--v5-bor)',
+            }}>
+              <span>Datum</span><span>ID</span><span>Credits</span><span>Betrag</span><span>Status</span>
+            </div>
+            {history.map((h, i) => (
+              <div
+                key={h.id} data-testid="billing-row"
+                style={{
+                  display: 'grid', gridTemplateColumns: '110px 1fr 100px 120px 110px',
+                  padding: '10px 4px', alignItems: 'center',
+                  borderBottom: i < history.length - 1 ? '1px solid var(--v5-bor)' : 'none',
+                  fontSize: 11, color: 'var(--v5-txt)',
+                }}
+              >
+                <span>{formatDate(h.created_at)}</span>
+                <span className="v5-mono" style={{ fontSize: 10, color: 'var(--v5-mut)' }} title={h.id}>{h.id.slice(0, 14)}…</span>
+                <span className="v5-mono"><NumberFlow value={h.credits} /></span>
+                <span className="v5-mono" style={{ fontWeight: 500 }}>{formatMoney(h.amount, h.currency)}</span>
+                <Badge variant={statusVariant(h.status)} dot>{STATUS_LABEL[h.status]}</Badge>
+              </div>
+            ))}
+          </div>
+        )}
+      </Card>
+    </div>
+  );
+}

--- a/parkhub-web/src/design-v5/screens/Billing.tsx
+++ b/parkhub-web/src/design-v5/screens/Billing.tsx
@@ -1,36 +1,41 @@
 import NumberFlow from '@number-flow/react';
 import { useQuery } from '@tanstack/react-query';
-import { Badge, Card, V5NamedIcon, type BadgeVariant } from '../primitives';
-import { api, type PaymentHistoryEntry } from '../../api/client';
+import { Badge, Card, V5NamedIcon } from '../primitives';
+import { api, type AdminCostCenterSummary } from '../../api/client';
 import type { ScreenId } from '../nav';
 
-function formatDate(iso: string): string {
-  return new Date(iso).toLocaleDateString('de-DE', { day: '2-digit', month: '2-digit', year: 'numeric' });
-}
+/**
+ * Billing — admin view of tenant-wide finance.
+ *
+ * v5 mirrors the legacy `views/AdminBilling.tsx` workflow: cost-center +
+ * department aggregates from `/api/v1/admin/billing/*`, NOT the personal
+ * `/payments/history` feed (that lives on the user-facing Kredits screen).
+ *
+ * Codex #376: the v5 draft originally wired this admin-nav entry to
+ * `api.getPaymentHistory()`, which broke the tenant finance workflow
+ * (cost-center rollups + CSV export) for operators.
+ */
 
 function formatMoney(amount: number, currency: string): string {
-  return new Intl.NumberFormat('de-DE', { style: 'currency', currency: currency || 'EUR' }).format(amount / 100);
+  return new Intl.NumberFormat('de-DE', { style: 'currency', currency: currency || 'EUR' }).format(amount);
 }
-
-function statusVariant(s: PaymentHistoryEntry['status']): BadgeVariant {
-  switch (s) {
-    case 'completed': return 'success';
-    case 'pending': return 'warning';
-    case 'failed': return 'error';
-    default: return 'gray';
-  }
-}
-
-const STATUS_LABEL: Record<PaymentHistoryEntry['status'], string> = {
-  completed: 'Bezahlt', pending: 'Ausstehend', failed: 'Fehlgeschlagen', expired: 'Abgelaufen',
-};
 
 export function BillingV5({ navigate: _navigate }: { navigate: (id: ScreenId) => void }) {
-  const { data: history = [], isLoading, isError } = useQuery({
-    queryKey: ['billing-history'],
+  const costCenterQuery = useQuery({
+    queryKey: ['admin-billing-cost-center'],
     queryFn: async () => {
-      const res = await api.getPaymentHistory();
-      if (!res.success) throw new Error(res.error?.message ?? 'Zahlungsverlauf konnte nicht geladen werden');
+      const res = await api.adminBillingByCostCenter();
+      if (!res.success) throw new Error(res.error?.message ?? 'Kostenstellen konnten nicht geladen werden');
+      return res.data ?? [];
+    },
+    staleTime: 30_000,
+  });
+
+  const departmentQuery = useQuery({
+    queryKey: ['admin-billing-department'],
+    queryFn: async () => {
+      const res = await api.adminBillingByDepartment();
+      if (!res.success) throw new Error(res.error?.message ?? 'Abteilungen konnten nicht geladen werden');
       return res.data ?? [];
     },
     staleTime: 30_000,
@@ -46,12 +51,21 @@ export function BillingV5({ navigate: _navigate }: { navigate: (id: ScreenId) =>
     staleTime: 60_000,
   });
 
-  const totalPaid = history
-    .filter((h) => h.status === 'completed')
-    .reduce((sum, h) => sum + h.amount, 0);
-  const totalCredits = history
-    .filter((h) => h.status === 'completed')
-    .reduce((sum, h) => sum + h.credits, 0);
+  const isLoading = costCenterQuery.isLoading || departmentQuery.isLoading;
+  const isError = costCenterQuery.isError || departmentQuery.isError;
+  const ccRows: AdminCostCenterSummary[] = costCenterQuery.data ?? [];
+
+  const totalAmount = ccRows.reduce((sum, r) => sum + r.total_amount, 0);
+  const totalBookings = ccRows.reduce((sum, r) => sum + r.total_bookings, 0);
+  const totalUsers = ccRows.reduce((sum, r) => sum + r.user_count, 0);
+  const currency = ccRows[0]?.currency ?? 'EUR';
+
+  async function handleExport() {
+    // Triggers the CSV endpoint so the browser handles the file download.
+    // Kept as a plain anchor rather than api.* because the endpoint returns
+    // raw CSV bytes, not the ApiResponse<T> envelope.
+    window.location.assign('/api/v1/admin/billing/export');
+  }
 
   if (isLoading) {
     return (
@@ -74,20 +88,33 @@ export function BillingV5({ navigate: _navigate }: { navigate: (id: ScreenId) =>
     );
   }
 
-  const currency = history[0]?.currency ?? 'EUR';
-
   return (
     <div style={{ padding: 16, flex: 1, overflow: 'auto', display: 'flex', flexDirection: 'column', gap: 12 }}>
-      <div className="v5-ani" style={{ fontWeight: 700, fontSize: 15, color: 'var(--v5-txt)' }}>Abrechnung</div>
+      <div className="v5-ani" style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+        <span style={{ fontWeight: 700, fontSize: 15, color: 'var(--v5-txt)' }}>Abrechnung</span>
+        <button
+          type="button"
+          onClick={handleExport}
+          data-testid="billing-export"
+          style={{
+            padding: '7px 14px', borderRadius: 9, background: 'var(--v5-acc)', color: 'var(--v5-accent-fg)',
+            border: 'none', fontSize: 11, fontWeight: 600, cursor: 'pointer',
+          }}
+        >CSV Export</button>
+      </div>
 
-      <div className="v5-ani" style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(200px, 1fr))', gap: 10, animationDelay: '0.06s' }}>
+      <div className="v5-ani" style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(180px, 1fr))', gap: 10, animationDelay: '0.06s' }}>
         <Card style={{ padding: 14 }}>
-          <div className="v5-mono" style={{ fontSize: 9, letterSpacing: 1.3, color: 'var(--v5-mut)', textTransform: 'uppercase' }}>Gesamt bezahlt</div>
-          <div className="v5-mono" style={{ fontSize: 22, fontWeight: 700, color: 'var(--v5-txt)', marginTop: 4 }}>{formatMoney(totalPaid, currency)}</div>
+          <div className="v5-mono" style={{ fontSize: 9, letterSpacing: 1.3, color: 'var(--v5-mut)', textTransform: 'uppercase' }}>Gesamt</div>
+          <div className="v5-mono" style={{ fontSize: 22, fontWeight: 700, color: 'var(--v5-txt)', marginTop: 4 }}>{formatMoney(totalAmount, currency)}</div>
         </Card>
         <Card style={{ padding: 14 }}>
-          <div className="v5-mono" style={{ fontSize: 9, letterSpacing: 1.3, color: 'var(--v5-mut)', textTransform: 'uppercase' }}>Credits erworben</div>
-          <div className="v5-mono" style={{ fontSize: 22, fontWeight: 700, color: 'var(--v5-txt)', marginTop: 4 }}><NumberFlow value={totalCredits} /></div>
+          <div className="v5-mono" style={{ fontSize: 9, letterSpacing: 1.3, color: 'var(--v5-mut)', textTransform: 'uppercase' }}>Buchungen</div>
+          <div className="v5-mono" style={{ fontSize: 22, fontWeight: 700, color: 'var(--v5-txt)', marginTop: 4 }}><NumberFlow value={totalBookings} /></div>
+        </Card>
+        <Card style={{ padding: 14 }}>
+          <div className="v5-mono" style={{ fontSize: 9, letterSpacing: 1.3, color: 'var(--v5-mut)', textTransform: 'uppercase' }}>Nutzer</div>
+          <div className="v5-mono" style={{ fontSize: 22, fontWeight: 700, color: 'var(--v5-txt)', marginTop: 4 }}><NumberFlow value={totalUsers} /></div>
         </Card>
         <Card style={{ padding: 14 }}>
           <div className="v5-mono" style={{ fontSize: 9, letterSpacing: 1.3, color: 'var(--v5-mut)', textTransform: 'uppercase' }}>Stripe</div>
@@ -101,37 +128,37 @@ export function BillingV5({ navigate: _navigate }: { navigate: (id: ScreenId) =>
 
       <Card className="v5-ani" style={{ padding: 16, animationDelay: '0.12s' }}>
         <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 10 }}>
-          <span style={{ fontWeight: 600, fontSize: 13, color: 'var(--v5-txt)' }}>Zahlungsverlauf</span>
-          <Badge variant="gray">{history.length}</Badge>
+          <span style={{ fontWeight: 600, fontSize: 13, color: 'var(--v5-txt)' }}>Kostenstellen</span>
+          <Badge variant="gray">{ccRows.length}</Badge>
         </div>
-        {history.length === 0 ? (
+        {ccRows.length === 0 ? (
           <div style={{ padding: 24, textAlign: 'center', fontSize: 12, color: 'var(--v5-mut)' }}>
-            Noch keine Zahlungen
+            Noch keine Kostenstellen konfiguriert
           </div>
         ) : (
           <div>
             <div className="v5-mono" style={{
-              display: 'grid', gridTemplateColumns: '110px 1fr 100px 120px 110px',
+              display: 'grid', gridTemplateColumns: '120px 1fr 80px 90px 120px',
               padding: '6px 4px', fontSize: 9, letterSpacing: 1.2, textTransform: 'uppercase',
               color: 'var(--v5-mut)', borderBottom: '1px solid var(--v5-bor)',
             }}>
-              <span>Datum</span><span>ID</span><span>Credits</span><span>Betrag</span><span>Status</span>
+              <span>Kostenstelle</span><span>Abteilung</span><span>Nutzer</span><span>Buchungen</span><span>Betrag</span>
             </div>
-            {history.map((h, i) => (
+            {ccRows.map((r, i) => (
               <div
-                key={h.id} data-testid="billing-row"
+                key={r.cost_center} data-testid="billing-row"
                 style={{
-                  display: 'grid', gridTemplateColumns: '110px 1fr 100px 120px 110px',
+                  display: 'grid', gridTemplateColumns: '120px 1fr 80px 90px 120px',
                   padding: '10px 4px', alignItems: 'center',
-                  borderBottom: i < history.length - 1 ? '1px solid var(--v5-bor)' : 'none',
+                  borderBottom: i < ccRows.length - 1 ? '1px solid var(--v5-bor)' : 'none',
                   fontSize: 11, color: 'var(--v5-txt)',
                 }}
               >
-                <span>{formatDate(h.created_at)}</span>
-                <span className="v5-mono" style={{ fontSize: 10, color: 'var(--v5-mut)' }} title={h.id}>{h.id.slice(0, 14)}…</span>
-                <span className="v5-mono"><NumberFlow value={h.credits} /></span>
-                <span className="v5-mono" style={{ fontWeight: 500 }}>{formatMoney(h.amount, h.currency)}</span>
-                <Badge variant={statusVariant(h.status)} dot>{STATUS_LABEL[h.status]}</Badge>
+                <span className="v5-mono">{r.cost_center}</span>
+                <span>{r.department}</span>
+                <span className="v5-mono"><NumberFlow value={r.user_count} /></span>
+                <span className="v5-mono"><NumberFlow value={r.total_bookings} /></span>
+                <span className="v5-mono" style={{ fontWeight: 500 }}>{formatMoney(r.total_amount, r.currency)}</span>
               </div>
             ))}
           </div>

--- a/parkhub-web/src/design-v5/screens/Einstellungen.test.tsx
+++ b/parkhub-web/src/design-v5/screens/Einstellungen.test.tsx
@@ -2,16 +2,17 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
-const mockMe = vi.fn();
-const mockUpdateMe = vi.fn();
-const mockGetPrefs = vi.fn();
-const mockUpdatePrefs = vi.fn();
+// v5 Einstellungen is under the admin nav section → it must surface tenant
+// settings (company, booking rules, cost-center tagging, etc.) via
+// `api.adminGetSettings`/`api.adminUpdateSettings`. The former draft called
+// `api.me`/`api.updateMe`, which is the user-scoped profile endpoint and is
+// wired into the separate Profil screen instead.
+const mockGetSettings = vi.fn();
+const mockUpdateSettings = vi.fn();
 vi.mock('../../api/client', () => ({
   api: {
-    me: (...a: unknown[]) => mockMe(...a),
-    updateMe: (...a: unknown[]) => mockUpdateMe(...a),
-    getNotificationPreferences: (...a: unknown[]) => mockGetPrefs(...a),
-    updateNotificationPreferences: (...a: unknown[]) => mockUpdatePrefs(...a),
+    adminGetSettings: (...a: unknown[]) => mockGetSettings(...a),
+    adminUpdateSettings: (...a: unknown[]) => mockUpdateSettings(...a),
   },
 }));
 
@@ -29,17 +30,11 @@ vi.mock('../ThemeProvider', () => ({
 
 import { EinstellungenV5 } from './Einstellungen';
 
-const USER = {
-  id: 'u-1', username: 'flo', email: 'f@e', name: 'Flo',
-  role: 'admin' as const, preferences: {}, is_active: true,
-  credits_balance: 0, credits_monthly_quota: 0, department: 'IT',
-};
-
-const PREFS = {
-  email_booking_confirm: true, email_booking_reminder: false,
-  email_swap_request: true, push_enabled: false,
-  sms_booking_confirm: false, sms_booking_reminder: false, sms_booking_cancelled: false,
-  whatsapp_booking_confirm: false, whatsapp_booking_reminder: false, whatsapp_booking_cancelled: false,
+const SETTINGS: Record<string, string> = {
+  company_name: 'ACME GmbH',
+  default_currency: 'EUR',
+  booking_window_days: '30',
+  cost_center_required: 'true',
 };
 
 function renderScreen() {
@@ -51,72 +46,60 @@ function renderScreen() {
   );
 }
 
-describe('EinstellungenV5', () => {
+describe('EinstellungenV5 (admin)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockGetPrefs.mockResolvedValue({ success: true, data: PREFS });
   });
 
-  it('renders error state when me fails', async () => {
-    mockMe.mockResolvedValue({ success: false, data: null, error: { code: 'X', message: 'oops' } });
+  it('renders error state when adminGetSettings fails', async () => {
+    mockGetSettings.mockResolvedValue({ success: false, data: null, error: { code: 'X', message: 'oops' } });
     renderScreen();
     await waitFor(() => expect(screen.getByText('Fehler beim Laden')).toBeInTheDocument());
   });
 
-  it('renders department field populated from user', async () => {
-    mockMe.mockResolvedValue({ success: true, data: USER });
+  it('renders company name field populated from admin settings', async () => {
+    mockGetSettings.mockResolvedValue({ success: true, data: SETTINGS });
     renderScreen();
-    await waitFor(() => expect((screen.getByTestId('einst-department') as HTMLInputElement).value).toBe('IT'));
+    await waitFor(() => expect((screen.getByTestId('einst-company-name') as HTMLInputElement).value).toBe('ACME GmbH'));
   });
 
-  it('saves department change via updateMe', async () => {
-    mockMe.mockResolvedValue({ success: true, data: USER });
-    mockUpdateMe.mockResolvedValue({ success: true, data: { ...USER, department: 'Ops' } });
+  it('renders booking window (days) field populated from admin settings', async () => {
+    mockGetSettings.mockResolvedValue({ success: true, data: SETTINGS });
     renderScreen();
-    await waitFor(() => expect(screen.getByTestId('einst-department')).toBeInTheDocument());
-    fireEvent.change(screen.getByTestId('einst-department'), { target: { value: 'Ops' } });
+    await waitFor(() => expect((screen.getByTestId('einst-booking-window') as HTMLInputElement).value).toBe('30'));
+  });
+
+  it('saves changed admin settings via adminUpdateSettings', async () => {
+    mockGetSettings.mockResolvedValue({ success: true, data: SETTINGS });
+    mockUpdateSettings.mockResolvedValue({ success: true, data: null });
+    renderScreen();
+    await waitFor(() => expect(screen.getByTestId('einst-company-name')).toBeInTheDocument());
+    fireEvent.change(screen.getByTestId('einst-company-name'), { target: { value: 'New Co' } });
+    fireEvent.change(screen.getByTestId('einst-booking-window'), { target: { value: '45' } });
     fireEvent.click(screen.getByTestId('einst-save'));
     await waitFor(() => {
-      expect(mockUpdateMe).toHaveBeenCalledWith({ department: 'Ops' });
+      expect(mockUpdateSettings).toHaveBeenCalledWith(
+        expect.objectContaining({
+          company_name: 'New Co',
+          booking_window_days: '45',
+        }),
+      );
       expect(mockToast).toHaveBeenCalledWith('Einstellungen gespeichert', 'success');
     });
   });
 
-  it('surfaces updateMe error when success:false', async () => {
-    mockMe.mockResolvedValue({ success: true, data: USER });
-    mockUpdateMe.mockResolvedValue({ success: false, data: null, error: { code: 'E', message: 'denied' } });
+  it('surfaces adminUpdateSettings error when success:false', async () => {
+    mockGetSettings.mockResolvedValue({ success: true, data: SETTINGS });
+    mockUpdateSettings.mockResolvedValue({ success: false, data: null, error: { code: 'E', message: 'denied' } });
     renderScreen();
-    await waitFor(() => expect(screen.getByTestId('einst-department')).toBeInTheDocument());
-    fireEvent.change(screen.getByTestId('einst-department'), { target: { value: 'Ops' } });
+    await waitFor(() => expect(screen.getByTestId('einst-company-name')).toBeInTheDocument());
+    fireEvent.change(screen.getByTestId('einst-company-name'), { target: { value: 'Changed' } });
     fireEvent.click(screen.getByTestId('einst-save'));
     await waitFor(() => expect(mockToast).toHaveBeenCalledWith('denied', 'error'));
   });
 
-  it('toggles a notification preference and calls updatePrefs', async () => {
-    mockMe.mockResolvedValue({ success: true, data: USER });
-    mockUpdatePrefs.mockResolvedValue({ success: true, data: { ...PREFS, push_enabled: true } });
-    renderScreen();
-    await waitFor(() => expect(screen.getByText('Push aktiviert')).toBeInTheDocument());
-    const toggles = screen.getAllByRole('switch');
-    fireEvent.click(toggles[toggles.length - 1]);
-    await waitFor(() => {
-      expect(mockUpdatePrefs).toHaveBeenCalled();
-      expect(mockToast).toHaveBeenCalledWith('Benachrichtigungen gespeichert', 'success');
-    });
-  });
-
-  it('surfaces prefs error when success:false', async () => {
-    mockMe.mockResolvedValue({ success: true, data: USER });
-    mockUpdatePrefs.mockResolvedValue({ success: false, data: null, error: { code: 'E', message: 'fail' } });
-    renderScreen();
-    await waitFor(() => expect(screen.getByText('Push aktiviert')).toBeInTheDocument());
-    const toggles = screen.getAllByRole('switch');
-    fireEvent.click(toggles[0]);
-    await waitFor(() => expect(mockToast).toHaveBeenCalledWith('fail', 'error'));
-  });
-
-  it('switches language chip and toasts', async () => {
-    mockMe.mockResolvedValue({ success: true, data: USER });
+  it('switches language chip and toasts (UI pref, independent of admin settings)', async () => {
+    mockGetSettings.mockResolvedValue({ success: true, data: SETTINGS });
     renderScreen();
     await waitFor(() => expect(screen.getByText('Deutsch')).toBeInTheDocument());
     fireEvent.click(screen.getByText('English'));

--- a/parkhub-web/src/design-v5/screens/Einstellungen.test.tsx
+++ b/parkhub-web/src/design-v5/screens/Einstellungen.test.tsx
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+const mockMe = vi.fn();
+const mockUpdateMe = vi.fn();
+const mockGetPrefs = vi.fn();
+const mockUpdatePrefs = vi.fn();
+vi.mock('../../api/client', () => ({
+  api: {
+    me: (...a: unknown[]) => mockMe(...a),
+    updateMe: (...a: unknown[]) => mockUpdateMe(...a),
+    getNotificationPreferences: (...a: unknown[]) => mockGetPrefs(...a),
+    updateNotificationPreferences: (...a: unknown[]) => mockUpdatePrefs(...a),
+  },
+}));
+
+const mockToast = vi.fn();
+vi.mock('../Toast', () => ({
+  useV5Toast: () => mockToast,
+  V5ToastProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('../ThemeProvider', () => ({
+  useV5Theme: () => ({ mode: 'marble', setMode: vi.fn() }),
+  V5_MODES: ['marble', 'void'] as const,
+  V5_MODE_LABELS: { marble: 'Marble', void: 'Void' },
+}));
+
+import { EinstellungenV5 } from './Einstellungen';
+
+const USER = {
+  id: 'u-1', username: 'flo', email: 'f@e', name: 'Flo',
+  role: 'admin' as const, preferences: {}, is_active: true,
+  credits_balance: 0, credits_monthly_quota: 0, department: 'IT',
+};
+
+const PREFS = {
+  email_booking_confirm: true, email_booking_reminder: false,
+  email_swap_request: true, push_enabled: false,
+  sms_booking_confirm: false, sms_booking_reminder: false, sms_booking_cancelled: false,
+  whatsapp_booking_confirm: false, whatsapp_booking_reminder: false, whatsapp_booking_cancelled: false,
+};
+
+function renderScreen() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <EinstellungenV5 navigate={vi.fn()} />
+    </QueryClientProvider>
+  );
+}
+
+describe('EinstellungenV5', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetPrefs.mockResolvedValue({ success: true, data: PREFS });
+  });
+
+  it('renders error state when me fails', async () => {
+    mockMe.mockResolvedValue({ success: false, data: null, error: { code: 'X', message: 'oops' } });
+    renderScreen();
+    await waitFor(() => expect(screen.getByText('Fehler beim Laden')).toBeInTheDocument());
+  });
+
+  it('renders department field populated from user', async () => {
+    mockMe.mockResolvedValue({ success: true, data: USER });
+    renderScreen();
+    await waitFor(() => expect((screen.getByTestId('einst-department') as HTMLInputElement).value).toBe('IT'));
+  });
+
+  it('saves department change via updateMe', async () => {
+    mockMe.mockResolvedValue({ success: true, data: USER });
+    mockUpdateMe.mockResolvedValue({ success: true, data: { ...USER, department: 'Ops' } });
+    renderScreen();
+    await waitFor(() => expect(screen.getByTestId('einst-department')).toBeInTheDocument());
+    fireEvent.change(screen.getByTestId('einst-department'), { target: { value: 'Ops' } });
+    fireEvent.click(screen.getByTestId('einst-save'));
+    await waitFor(() => {
+      expect(mockUpdateMe).toHaveBeenCalledWith({ department: 'Ops' });
+      expect(mockToast).toHaveBeenCalledWith('Einstellungen gespeichert', 'success');
+    });
+  });
+
+  it('surfaces updateMe error when success:false', async () => {
+    mockMe.mockResolvedValue({ success: true, data: USER });
+    mockUpdateMe.mockResolvedValue({ success: false, data: null, error: { code: 'E', message: 'denied' } });
+    renderScreen();
+    await waitFor(() => expect(screen.getByTestId('einst-department')).toBeInTheDocument());
+    fireEvent.change(screen.getByTestId('einst-department'), { target: { value: 'Ops' } });
+    fireEvent.click(screen.getByTestId('einst-save'));
+    await waitFor(() => expect(mockToast).toHaveBeenCalledWith('denied', 'error'));
+  });
+
+  it('toggles a notification preference and calls updatePrefs', async () => {
+    mockMe.mockResolvedValue({ success: true, data: USER });
+    mockUpdatePrefs.mockResolvedValue({ success: true, data: { ...PREFS, push_enabled: true } });
+    renderScreen();
+    await waitFor(() => expect(screen.getByText('Push aktiviert')).toBeInTheDocument());
+    const toggles = screen.getAllByRole('switch');
+    fireEvent.click(toggles[toggles.length - 1]);
+    await waitFor(() => {
+      expect(mockUpdatePrefs).toHaveBeenCalled();
+      expect(mockToast).toHaveBeenCalledWith('Benachrichtigungen gespeichert', 'success');
+    });
+  });
+
+  it('surfaces prefs error when success:false', async () => {
+    mockMe.mockResolvedValue({ success: true, data: USER });
+    mockUpdatePrefs.mockResolvedValue({ success: false, data: null, error: { code: 'E', message: 'fail' } });
+    renderScreen();
+    await waitFor(() => expect(screen.getByText('Push aktiviert')).toBeInTheDocument());
+    const toggles = screen.getAllByRole('switch');
+    fireEvent.click(toggles[0]);
+    await waitFor(() => expect(mockToast).toHaveBeenCalledWith('fail', 'error'));
+  });
+
+  it('switches language chip and toasts', async () => {
+    mockMe.mockResolvedValue({ success: true, data: USER });
+    renderScreen();
+    await waitFor(() => expect(screen.getByText('Deutsch')).toBeInTheDocument());
+    fireEvent.click(screen.getByText('English'));
+    expect(mockToast).toHaveBeenCalledWith('Sprache aktualisiert', 'success');
+  });
+});

--- a/parkhub-web/src/design-v5/screens/Einstellungen.tsx
+++ b/parkhub-web/src/design-v5/screens/Einstellungen.tsx
@@ -1,10 +1,29 @@
-import { useEffect, useState, type CSSProperties } from 'react';
+import { useEffect, useMemo, useState, type CSSProperties } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { Card, SectionLabel, Toggle, V5NamedIcon } from '../primitives';
+import { Card, SectionLabel, V5NamedIcon } from '../primitives';
 import { useV5Toast } from '../Toast';
 import { useV5Theme, V5_MODES, V5_MODE_LABELS, type V5Mode } from '../ThemeProvider';
-import { api, type User, type NotificationPreferences } from '../../api/client';
+import { api } from '../../api/client';
 import type { ScreenId } from '../nav';
+
+/**
+ * Einstellungen — admin view of tenant / system settings.
+ *
+ * This screen lives under the `admin` nav section (see design-v5/nav.ts),
+ * so it must surface system-wide configuration — `/api/v1/admin/settings`
+ * — instead of personal profile fields. The personal Profil screen stays
+ * wired to `api.me`/`api.updateMe`.
+ *
+ * Codex #376: the v5 draft accidentally wired this admin entry to
+ * `api.me()`, which meant the tenant-scoped keys (company name, default
+ * currency, booking window, cost-center policy) were unreachable for
+ * admins in the new shell. Re-wiring to `adminGetSettings` +
+ * `adminUpdateSettings` closes the regression.
+ *
+ * UI-side preferences that don't touch the backend — language chip and
+ * the `useV5Theme` mode selector — remain local because they're a
+ * per-browser thing, not tenant-level config.
+ */
 
 const LANGUAGES: { code: string; label: string }[] = [
   { code: 'de', label: 'Deutsch' },
@@ -27,27 +46,37 @@ const inputStyle: CSSProperties = {
   fontFamily: 'inherit',
 };
 
+/**
+ * Tenant settings keys surfaced as structured fields. The admin settings
+ * endpoint returns an open `Record<string, string>` so callers can extend
+ * without a schema migration; this array is the allowlist the v5 shell
+ * renders + writes. Unknown keys returned by the backend are preserved on
+ * save so we don't clobber values another tool set.
+ */
+const SETTING_FIELDS: Array<{
+  key: string;
+  label: string;
+  hint: string;
+  testId: string;
+  type: 'text' | 'number' | 'boolean';
+}> = [
+  { key: 'company_name',         label: 'Firma',           hint: 'Wird in Exporten + Rechnungen verwendet.', testId: 'einst-company-name',   type: 'text' },
+  { key: 'default_currency',     label: 'Währung',         hint: 'ISO-4217-Code, z. B. EUR, CHF, USD.',       testId: 'einst-currency',       type: 'text' },
+  { key: 'booking_window_days',  label: 'Buchungsfenster', hint: 'Wie weit im Voraus gebucht werden darf.',   testId: 'einst-booking-window', type: 'number' },
+  { key: 'cost_center_required', label: 'Kostenstelle Pflicht', hint: '`true` / `false` — erzwingt Kostenstelle pro Buchung.', testId: 'einst-cost-center-required', type: 'text' },
+];
+
 export function EinstellungenV5({ navigate: _navigate }: { navigate: (id: ScreenId) => void }) {
   const toast = useV5Toast();
   const qc = useQueryClient();
   const { mode, setMode } = useV5Theme();
 
-  const { data: user, isLoading, isError } = useQuery({
-    queryKey: ['einstellungen-me'],
+  const { data: settings, isLoading, isError } = useQuery({
+    queryKey: ['admin-settings'],
     queryFn: async () => {
-      const res = await api.me();
+      const res = await api.adminGetSettings();
       if (!res.success) throw new Error(res.error?.message ?? 'Einstellungen konnten nicht geladen werden');
-      return res.data;
-    },
-    staleTime: 30_000,
-  });
-
-  const { data: prefs } = useQuery({
-    queryKey: ['einstellungen-prefs'],
-    queryFn: async () => {
-      const res = await api.getNotificationPreferences();
-      if (!res.success) throw new Error(res.error?.message ?? 'Benachrichtigungen konnten nicht geladen werden');
-      return res.data;
+      return res.data ?? {};
     },
     staleTime: 30_000,
   });
@@ -56,54 +85,38 @@ export function EinstellungenV5({ navigate: _navigate }: { navigate: (id: Screen
     if (typeof window === 'undefined') return 'de';
     return window.localStorage.getItem(LANG_STORAGE_KEY) ?? 'de';
   });
-  const [department, setDepartment] = useState('');
-  const [localPrefs, setLocalPrefs] = useState<NotificationPreferences | null>(null);
+  const [draft, setDraft] = useState<Record<string, string>>({});
 
   useEffect(() => {
-    if (user) setDepartment(user.department ?? '');
-  }, [user]);
-
-  useEffect(() => {
-    if (prefs) setLocalPrefs(prefs);
-  }, [prefs]);
+    if (settings) setDraft(settings);
+  }, [settings]);
 
   const saveMutation = useMutation({
-    mutationFn: async (payload: Partial<User>) => {
-      const res = await api.updateMe(payload);
+    mutationFn: async (payload: Record<string, string>) => {
+      const res = await api.adminUpdateSettings(payload);
       if (!res.success) throw new Error(res.error?.message ?? 'Speichern fehlgeschlagen');
       return res.data;
     },
     onSuccess: () => {
-      qc.invalidateQueries({ queryKey: ['einstellungen-me'] });
+      qc.invalidateQueries({ queryKey: ['admin-settings'] });
       toast('Einstellungen gespeichert', 'success');
     },
     onError: (err: Error) => toast(err.message || 'Speichern fehlgeschlagen', 'error'),
   });
 
-  const prefsMutation = useMutation({
-    mutationFn: async (payload: NotificationPreferences) => {
-      const res = await api.updateNotificationPreferences(payload);
-      if (!res.success) throw new Error(res.error?.message ?? 'Speichern fehlgeschlagen');
-      return res.data;
-    },
-    onSuccess: () => {
-      qc.invalidateQueries({ queryKey: ['einstellungen-prefs'] });
-      toast('Benachrichtigungen gespeichert', 'success');
-    },
-    onError: (err: Error) => toast(err.message || 'Speichern fehlgeschlagen', 'error'),
-  });
+  const isDirty = useMemo(() => {
+    if (!settings) return false;
+    const keys = new Set([...Object.keys(settings), ...Object.keys(draft)]);
+    for (const k of keys) {
+      if ((settings[k] ?? '') !== (draft[k] ?? '')) return true;
+    }
+    return false;
+  }, [settings, draft]);
 
   function handleLangChange(code: string) {
     setLang(code);
     if (typeof window !== 'undefined') window.localStorage.setItem(LANG_STORAGE_KEY, code);
     toast('Sprache aktualisiert', 'success');
-  }
-
-  function togglePref(key: keyof NotificationPreferences) {
-    if (!localPrefs) return;
-    const next = { ...localPrefs, [key]: !localPrefs[key] } as NotificationPreferences;
-    setLocalPrefs(next);
-    prefsMutation.mutate(next);
   }
 
   if (isLoading) {
@@ -116,7 +129,7 @@ export function EinstellungenV5({ navigate: _navigate }: { navigate: (id: Screen
     );
   }
 
-  if (isError || !user) {
+  if (isError || !settings) {
     return (
       <div style={{ padding: 16, flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
         <Card className="v5-ani" style={{ padding: 28, textAlign: 'center', maxWidth: 360 }}>
@@ -133,28 +146,31 @@ export function EinstellungenV5({ navigate: _navigate }: { navigate: (id: Screen
       <div className="v5-ani" style={{ fontWeight: 700, fontSize: 15, color: 'var(--v5-txt)' }}>Einstellungen</div>
 
       <Card className="v5-ani" style={{ padding: 18, display: 'flex', flexDirection: 'column', gap: 12, animationDelay: '0.06s' }}>
-        <SectionLabel>Allgemein</SectionLabel>
-        <label style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
-          <span style={{ fontSize: 11, color: 'var(--v5-mut)' }}>Abteilung</span>
-          <input
-            data-testid="einst-department"
-            type="text"
-            value={department}
-            onChange={(e) => setDepartment(e.target.value)}
-            style={inputStyle}
-          />
-        </label>
+        <SectionLabel>System</SectionLabel>
+        {SETTING_FIELDS.map((f) => (
+          <label key={f.key} style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+            <span style={{ fontSize: 11, color: 'var(--v5-mut)' }}>{f.label}</span>
+            <input
+              data-testid={f.testId}
+              type={f.type === 'number' ? 'number' : 'text'}
+              value={draft[f.key] ?? ''}
+              onChange={(e) => setDraft({ ...draft, [f.key]: e.target.value })}
+              style={inputStyle}
+            />
+            <span style={{ fontSize: 10, color: 'var(--v5-mut)' }}>{f.hint}</span>
+          </label>
+        ))}
         <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
           <button
             type="button"
-            disabled={department === (user.department ?? '') || saveMutation.isPending}
-            onClick={() => saveMutation.mutate({ department: department.trim() })}
+            disabled={!isDirty || saveMutation.isPending}
+            onClick={() => saveMutation.mutate(draft)}
             data-testid="einst-save"
             style={{
               padding: '8px 16px', borderRadius: 9, background: 'var(--v5-acc)', color: 'var(--v5-accent-fg)',
               border: 'none', fontSize: 12, fontWeight: 600,
-              cursor: department !== (user.department ?? '') && !saveMutation.isPending ? 'pointer' : 'not-allowed',
-              opacity: department !== (user.department ?? '') && !saveMutation.isPending ? 1 : 0.5,
+              cursor: isDirty && !saveMutation.isPending ? 'pointer' : 'not-allowed',
+              opacity: isDirty && !saveMutation.isPending ? 1 : 0.5,
             }}
           >
             {saveMutation.isPending ? 'Speichert …' : 'Speichern'}
@@ -203,27 +219,6 @@ export function EinstellungenV5({ navigate: _navigate }: { navigate: (id: Screen
           })}
         </div>
       </Card>
-
-      {localPrefs && (
-        <Card className="v5-ani" style={{ padding: 18, display: 'flex', flexDirection: 'column', gap: 10, animationDelay: '0.24s' }}>
-          <SectionLabel>Benachrichtigungen</SectionLabel>
-          {([
-            ['email_booking_confirm', 'E-Mail: Buchungsbestätigung'],
-            ['email_booking_reminder', 'E-Mail: Erinnerung'],
-            ['email_swap_request', 'E-Mail: Tauschanfragen'],
-            ['push_enabled', 'Push aktiviert'],
-          ] as Array<[keyof NotificationPreferences, string]>).map(([key, label]) => (
-            <div key={key} style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
-              <span style={{ fontSize: 12, color: 'var(--v5-txt)' }}>{label}</span>
-              <Toggle
-                checked={Boolean(localPrefs[key])}
-                onChange={() => togglePref(key)}
-                ariaLabel={label}
-              />
-            </div>
-          ))}
-        </Card>
-      )}
     </div>
   );
 }

--- a/parkhub-web/src/design-v5/screens/Einstellungen.tsx
+++ b/parkhub-web/src/design-v5/screens/Einstellungen.tsx
@@ -1,0 +1,229 @@
+import { useEffect, useState, type CSSProperties } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { Card, SectionLabel, Toggle, V5NamedIcon } from '../primitives';
+import { useV5Toast } from '../Toast';
+import { useV5Theme, V5_MODES, V5_MODE_LABELS, type V5Mode } from '../ThemeProvider';
+import { api, type User, type NotificationPreferences } from '../../api/client';
+import type { ScreenId } from '../nav';
+
+const LANGUAGES: { code: string; label: string }[] = [
+  { code: 'de', label: 'Deutsch' },
+  { code: 'en', label: 'English' },
+  { code: 'fr', label: 'Français' },
+];
+
+const LANG_STORAGE_KEY = 'i18nextLng';
+
+const inputStyle: CSSProperties = {
+  padding: '8px 11px',
+  borderRadius: 9,
+  background: 'var(--v5-sur2)',
+  border: '1px solid var(--v5-bor)',
+  color: 'var(--v5-txt)',
+  fontSize: 12,
+  width: '100%',
+  outline: 'none',
+  boxSizing: 'border-box',
+  fontFamily: 'inherit',
+};
+
+export function EinstellungenV5({ navigate: _navigate }: { navigate: (id: ScreenId) => void }) {
+  const toast = useV5Toast();
+  const qc = useQueryClient();
+  const { mode, setMode } = useV5Theme();
+
+  const { data: user, isLoading, isError } = useQuery({
+    queryKey: ['einstellungen-me'],
+    queryFn: async () => {
+      const res = await api.me();
+      if (!res.success) throw new Error(res.error?.message ?? 'Einstellungen konnten nicht geladen werden');
+      return res.data;
+    },
+    staleTime: 30_000,
+  });
+
+  const { data: prefs } = useQuery({
+    queryKey: ['einstellungen-prefs'],
+    queryFn: async () => {
+      const res = await api.getNotificationPreferences();
+      if (!res.success) throw new Error(res.error?.message ?? 'Benachrichtigungen konnten nicht geladen werden');
+      return res.data;
+    },
+    staleTime: 30_000,
+  });
+
+  const [lang, setLang] = useState<string>(() => {
+    if (typeof window === 'undefined') return 'de';
+    return window.localStorage.getItem(LANG_STORAGE_KEY) ?? 'de';
+  });
+  const [department, setDepartment] = useState('');
+  const [localPrefs, setLocalPrefs] = useState<NotificationPreferences | null>(null);
+
+  useEffect(() => {
+    if (user) setDepartment(user.department ?? '');
+  }, [user]);
+
+  useEffect(() => {
+    if (prefs) setLocalPrefs(prefs);
+  }, [prefs]);
+
+  const saveMutation = useMutation({
+    mutationFn: async (payload: Partial<User>) => {
+      const res = await api.updateMe(payload);
+      if (!res.success) throw new Error(res.error?.message ?? 'Speichern fehlgeschlagen');
+      return res.data;
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['einstellungen-me'] });
+      toast('Einstellungen gespeichert', 'success');
+    },
+    onError: (err: Error) => toast(err.message || 'Speichern fehlgeschlagen', 'error'),
+  });
+
+  const prefsMutation = useMutation({
+    mutationFn: async (payload: NotificationPreferences) => {
+      const res = await api.updateNotificationPreferences(payload);
+      if (!res.success) throw new Error(res.error?.message ?? 'Speichern fehlgeschlagen');
+      return res.data;
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['einstellungen-prefs'] });
+      toast('Benachrichtigungen gespeichert', 'success');
+    },
+    onError: (err: Error) => toast(err.message || 'Speichern fehlgeschlagen', 'error'),
+  });
+
+  function handleLangChange(code: string) {
+    setLang(code);
+    if (typeof window !== 'undefined') window.localStorage.setItem(LANG_STORAGE_KEY, code);
+    toast('Sprache aktualisiert', 'success');
+  }
+
+  function togglePref(key: keyof NotificationPreferences) {
+    if (!localPrefs) return;
+    const next = { ...localPrefs, [key]: !localPrefs[key] } as NotificationPreferences;
+    setLocalPrefs(next);
+    prefsMutation.mutate(next);
+  }
+
+  if (isLoading) {
+    return (
+      <div style={{ padding: 16, flex: 1, overflow: 'auto', display: 'flex', flexDirection: 'column', gap: 12 }}>
+        {[160, 220, 160, 160].map((h, i) => (
+          <div key={i} style={{ height: h, borderRadius: 14, background: 'var(--v5-sur2)', animation: 'ph-v5-pulse 1.6s ease infinite', animationDelay: `${i * 0.1}s` }} />
+        ))}
+      </div>
+    );
+  }
+
+  if (isError || !user) {
+    return (
+      <div style={{ padding: 16, flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+        <Card className="v5-ani" style={{ padding: 28, textAlign: 'center', maxWidth: 360 }}>
+          <V5NamedIcon name="x" size={26} color="var(--v5-err)" />
+          <div style={{ marginTop: 10, fontWeight: 600, color: 'var(--v5-txt)' }}>Fehler beim Laden</div>
+          <div style={{ fontSize: 12, color: 'var(--v5-mut)', marginTop: 4 }}>Einstellungen konnten nicht geladen werden.</div>
+        </Card>
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ padding: 16, flex: 1, overflow: 'auto', display: 'flex', flexDirection: 'column', gap: 12 }}>
+      <div className="v5-ani" style={{ fontWeight: 700, fontSize: 15, color: 'var(--v5-txt)' }}>Einstellungen</div>
+
+      <Card className="v5-ani" style={{ padding: 18, display: 'flex', flexDirection: 'column', gap: 12, animationDelay: '0.06s' }}>
+        <SectionLabel>Allgemein</SectionLabel>
+        <label style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+          <span style={{ fontSize: 11, color: 'var(--v5-mut)' }}>Abteilung</span>
+          <input
+            data-testid="einst-department"
+            type="text"
+            value={department}
+            onChange={(e) => setDepartment(e.target.value)}
+            style={inputStyle}
+          />
+        </label>
+        <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
+          <button
+            type="button"
+            disabled={department === (user.department ?? '') || saveMutation.isPending}
+            onClick={() => saveMutation.mutate({ department: department.trim() })}
+            data-testid="einst-save"
+            style={{
+              padding: '8px 16px', borderRadius: 9, background: 'var(--v5-acc)', color: 'var(--v5-accent-fg)',
+              border: 'none', fontSize: 12, fontWeight: 600,
+              cursor: department !== (user.department ?? '') && !saveMutation.isPending ? 'pointer' : 'not-allowed',
+              opacity: department !== (user.department ?? '') && !saveMutation.isPending ? 1 : 0.5,
+            }}
+          >
+            {saveMutation.isPending ? 'Speichert …' : 'Speichern'}
+          </button>
+        </div>
+      </Card>
+
+      <Card className="v5-ani" style={{ padding: 18, display: 'flex', flexDirection: 'column', gap: 12, animationDelay: '0.12s' }}>
+        <SectionLabel>Sprache</SectionLabel>
+        <div role="group" aria-label="Sprache" style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
+          {LANGUAGES.map((l) => {
+            const active = lang === l.code;
+            return (
+              <button
+                key={l.code} type="button" aria-pressed={active} data-testid="einst-lang"
+                onClick={() => handleLangChange(l.code)}
+                style={{
+                  padding: '6px 14px', borderRadius: 999, fontSize: 11, fontWeight: 500, cursor: 'pointer',
+                  border: `1.5px solid ${active ? 'var(--v5-acc)' : 'var(--v5-bor)'}`,
+                  background: active ? 'var(--v5-acc-muted)' : 'transparent',
+                  color: active ? 'var(--v5-acc)' : 'var(--v5-mut)',
+                }}
+              >{l.label}</button>
+            );
+          })}
+        </div>
+      </Card>
+
+      <Card className="v5-ani" style={{ padding: 18, display: 'flex', flexDirection: 'column', gap: 12, animationDelay: '0.18s' }}>
+        <SectionLabel>Darstellung</SectionLabel>
+        <div role="group" aria-label="Darstellungsmodus" style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
+          {V5_MODES.map((m: V5Mode) => {
+            const active = mode === m;
+            return (
+              <button
+                key={m} type="button" aria-pressed={active} data-testid="einst-theme"
+                onClick={() => setMode(m)}
+                style={{
+                  padding: '8px 14px', borderRadius: 10, fontSize: 11, fontWeight: 500, cursor: 'pointer',
+                  border: `1.5px solid ${active ? 'var(--v5-acc)' : 'var(--v5-bor)'}`,
+                  background: active ? 'var(--v5-acc-muted)' : 'transparent',
+                  color: active ? 'var(--v5-acc)' : 'var(--v5-mut)',
+                }}
+              >{V5_MODE_LABELS[m]}</button>
+            );
+          })}
+        </div>
+      </Card>
+
+      {localPrefs && (
+        <Card className="v5-ani" style={{ padding: 18, display: 'flex', flexDirection: 'column', gap: 10, animationDelay: '0.24s' }}>
+          <SectionLabel>Benachrichtigungen</SectionLabel>
+          {([
+            ['email_booking_confirm', 'E-Mail: Buchungsbestätigung'],
+            ['email_booking_reminder', 'E-Mail: Erinnerung'],
+            ['email_swap_request', 'E-Mail: Tauschanfragen'],
+            ['push_enabled', 'Push aktiviert'],
+          ] as Array<[keyof NotificationPreferences, string]>).map(([key, label]) => (
+            <div key={key} style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+              <span style={{ fontSize: 12, color: 'var(--v5-txt)' }}>{label}</span>
+              <Toggle
+                checked={Boolean(localPrefs[key])}
+                onChange={() => togglePref(key)}
+                ariaLabel={label}
+              />
+            </div>
+          ))}
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/parkhub-web/src/design-v5/screens/Integrations.test.tsx
+++ b/parkhub-web/src/design-v5/screens/Integrations.test.tsx
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+const mockList = vi.fn();
+const mockConnect = vi.fn();
+const mockDisconnect = vi.fn();
+vi.mock('../../api/client', () => ({
+  api: {
+    getIntegrations: (...a: unknown[]) => mockList(...a),
+    connectIntegration: (...a: unknown[]) => mockConnect(...a),
+    disconnectIntegration: (...a: unknown[]) => mockDisconnect(...a),
+  },
+}));
+
+vi.mock('@number-flow/react', () => ({
+  default: ({ value }: { value: number }) => <span>{value}</span>,
+}));
+
+const mockToast = vi.fn();
+vi.mock('../Toast', () => ({
+  useV5Toast: () => mockToast,
+  V5ToastProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+import { IntegrationsV5 } from './Integrations';
+
+const I_DISC = { id: 'slack', name: 'Slack', provider: 'slack', description: 'Benachrichtigungen', connected: false, connected_at: null, account_label: null };
+const I_CONN = { id: 'gcal', name: 'Google Kalender', provider: 'google', description: 'Kalender sync', connected: true, connected_at: '2026-03-01T10:00:00Z', account_label: 'florian@example.com' };
+
+function renderScreen() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <IntegrationsV5 navigate={vi.fn()} />
+    </QueryClientProvider>
+  );
+}
+
+describe('IntegrationsV5', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('renders empty state', async () => {
+    mockList.mockResolvedValue({ success: true, data: [] });
+    renderScreen();
+    await waitFor(() => expect(screen.getByText('Keine Integrationen verfügbar')).toBeInTheDocument());
+  });
+
+  it('renders error state', async () => {
+    mockList.mockResolvedValue({ success: false, data: null, error: { code: 'X', message: 'fail' } });
+    renderScreen();
+    await waitFor(() => expect(screen.getByText('Fehler beim Laden')).toBeInTheDocument());
+  });
+
+  it('lists cards with connection status', async () => {
+    mockList.mockResolvedValue({ success: true, data: [I_DISC, I_CONN] });
+    renderScreen();
+    await waitFor(() => expect(screen.getAllByTestId('integrations-card')).toHaveLength(2));
+    expect(screen.getByText('Slack')).toBeInTheDocument();
+    expect(screen.getByText('Nicht verbunden')).toBeInTheDocument();
+    expect(screen.getByText('Verbunden')).toBeInTheDocument();
+  });
+
+  it('connect mutation fires', async () => {
+    mockList.mockResolvedValue({ success: true, data: [I_DISC] });
+    mockConnect.mockResolvedValue({ success: true, data: { ...I_DISC, connected: true } });
+    renderScreen();
+    await waitFor(() => expect(screen.getByTestId('integrations-connect')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('integrations-connect'));
+    await waitFor(() => {
+      expect(mockConnect).toHaveBeenCalledWith('slack');
+      expect(mockToast).toHaveBeenCalledWith('Integration verbunden', 'success');
+    });
+  });
+
+  it('connect error surfaces via toast', async () => {
+    mockList.mockResolvedValue({ success: true, data: [I_DISC] });
+    mockConnect.mockResolvedValue({ success: false, data: null, error: { code: 'X', message: 'denied' } });
+    renderScreen();
+    await waitFor(() => expect(screen.getByTestId('integrations-connect')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('integrations-connect'));
+    await waitFor(() => expect(mockToast).toHaveBeenCalledWith('denied', 'error'));
+  });
+
+  it('disconnect mutation fires', async () => {
+    mockList.mockResolvedValue({ success: true, data: [I_CONN] });
+    mockDisconnect.mockResolvedValue({ success: true, data: { ...I_CONN, connected: false } });
+    renderScreen();
+    await waitFor(() => expect(screen.getByTestId('integrations-disconnect')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('integrations-disconnect'));
+    await waitFor(() => {
+      expect(mockDisconnect).toHaveBeenCalledWith('gcal');
+      expect(mockToast).toHaveBeenCalledWith('Integration getrennt', 'success');
+    });
+  });
+
+  it('disconnect error surfaces via toast', async () => {
+    mockList.mockResolvedValue({ success: true, data: [I_CONN] });
+    mockDisconnect.mockResolvedValue({ success: false, data: null, error: { code: 'X', message: 'fail' } });
+    renderScreen();
+    await waitFor(() => expect(screen.getByTestId('integrations-disconnect')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('integrations-disconnect'));
+    await waitFor(() => expect(mockToast).toHaveBeenCalledWith('fail', 'error'));
+  });
+});

--- a/parkhub-web/src/design-v5/screens/Integrations.tsx
+++ b/parkhub-web/src/design-v5/screens/Integrations.tsx
@@ -1,0 +1,164 @@
+import NumberFlow from '@number-flow/react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { Badge, Card, V5NamedIcon } from '../primitives';
+import { useV5Toast } from '../Toast';
+import { api, type Integration } from '../../api/client';
+import type { ScreenId } from '../nav';
+
+function formatWhen(iso: string | null): string {
+  if (!iso) return '—';
+  return new Date(iso).toLocaleDateString('de-DE', { day: '2-digit', month: '2-digit', year: 'numeric' });
+}
+
+export function IntegrationsV5({ navigate: _navigate }: { navigate: (id: ScreenId) => void }) {
+  const toast = useV5Toast();
+  const qc = useQueryClient();
+
+  const { data: items = [], isLoading, isError } = useQuery({
+    queryKey: ['integrations'],
+    queryFn: async () => {
+      const res = await api.getIntegrations();
+      if (!res.success) throw new Error(res.error?.message ?? 'Integrationen konnten nicht geladen werden');
+      return res.data ?? [];
+    },
+    staleTime: 30_000,
+  });
+
+  const connect = useMutation({
+    mutationFn: async (id: string) => {
+      const res = await api.connectIntegration(id);
+      if (!res.success) throw new Error(res.error?.message ?? 'Verbindung fehlgeschlagen');
+      return res.data;
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['integrations'] });
+      toast('Integration verbunden', 'success');
+    },
+    onError: (err: Error) => toast(err.message || 'Verbindung fehlgeschlagen', 'error'),
+  });
+
+  const disconnect = useMutation({
+    mutationFn: async (id: string) => {
+      const res = await api.disconnectIntegration(id);
+      if (!res.success) throw new Error(res.error?.message ?? 'Trennen fehlgeschlagen');
+      return res.data;
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['integrations'] });
+      toast('Integration getrennt', 'success');
+    },
+    onError: (err: Error) => toast(err.message || 'Trennen fehlgeschlagen', 'error'),
+  });
+
+  const connectedCount = items.filter((i: Integration) => i.connected).length;
+
+  if (isLoading) {
+    return (
+      <div style={{ padding: 16, flex: 1, overflow: 'auto' }}>
+        {[0, 1, 2].map((i) => (
+          <div key={i} style={{ height: 80, borderRadius: 12, background: 'var(--v5-sur2)', marginBottom: 8, animation: 'ph-v5-pulse 1.6s ease infinite', animationDelay: `${i * 0.1}s` }} />
+        ))}
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div style={{ padding: 16, flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+        <Card className="v5-ani" style={{ padding: 28, textAlign: 'center', maxWidth: 360 }}>
+          <V5NamedIcon name="x" size={26} color="var(--v5-err)" />
+          <div style={{ marginTop: 10, fontWeight: 600, color: 'var(--v5-txt)' }}>Fehler beim Laden</div>
+        </Card>
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ padding: 16, flex: 1, overflow: 'auto', display: 'flex', flexDirection: 'column', gap: 12 }}>
+      <div className="v5-ani" style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+        <span style={{ fontWeight: 700, fontSize: 15, color: 'var(--v5-txt)' }}>Integrationen</span>
+        <Badge variant="gray"><NumberFlow value={items.length} /></Badge>
+        {connectedCount > 0 && <Badge variant="success" dot>{connectedCount} aktiv</Badge>}
+      </div>
+
+      {items.length === 0 ? (
+        <Card className="v5-ani" style={{ padding: 36, textAlign: 'center' }}>
+          <V5NamedIcon name="key" size={20} color="var(--v5-mut)" />
+          <div style={{ marginTop: 10, fontWeight: 600, color: 'var(--v5-txt)' }}>Keine Integrationen verfügbar</div>
+        </Card>
+      ) : (
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(280px, 1fr))', gap: 10 }}>
+          {items.map((item, idx) => {
+            const busy =
+              (connect.isPending && connect.variables === item.id) ||
+              (disconnect.isPending && disconnect.variables === item.id);
+            return (
+              <Card
+                key={item.id} data-testid="integrations-card"
+                className="v5-ani"
+                style={{ padding: 16, display: 'flex', flexDirection: 'column', gap: 10, animationDelay: `${idx * 0.04}s` }}
+              >
+                <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+                  <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+                    <div style={{
+                      width: 36, height: 36, borderRadius: 10,
+                      background: item.connected ? 'var(--v5-acc-muted)' : 'var(--v5-sur2)',
+                      display: 'flex', alignItems: 'center', justifyContent: 'center',
+                    }}>
+                      <V5NamedIcon name="key" size={16} color={item.connected ? 'var(--v5-acc)' : 'var(--v5-mut)'} />
+                    </div>
+                    <div>
+                      <div style={{ fontSize: 13, fontWeight: 600, color: 'var(--v5-txt)' }}>{item.name}</div>
+                      <div style={{ fontSize: 10, color: 'var(--v5-mut)' }}>{item.provider}</div>
+                    </div>
+                  </div>
+                  <Badge variant={item.connected ? 'success' : 'gray'} dot>
+                    {item.connected ? 'Verbunden' : 'Nicht verbunden'}
+                  </Badge>
+                </div>
+                <div style={{ fontSize: 11, color: 'var(--v5-mut)', minHeight: 28 }}>{item.description}</div>
+                {item.connected && item.account_label && (
+                  <div style={{ fontSize: 10, color: 'var(--v5-mut)' }}>
+                    Konto: <span style={{ color: 'var(--v5-txt)' }}>{item.account_label}</span>
+                    {' · '}seit {formatWhen(item.connected_at)}
+                  </div>
+                )}
+                <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
+                  {item.connected ? (
+                    <button
+                      type="button" disabled={busy}
+                      onClick={() => disconnect.mutate(item.id)}
+                      data-testid="integrations-disconnect"
+                      style={{
+                        padding: '6px 14px', borderRadius: 8,
+                        background: 'color-mix(in oklch, var(--v5-err) 8%, transparent)',
+                        border: 'none', fontSize: 11, fontWeight: 500, color: 'var(--v5-err)',
+                        cursor: busy ? 'default' : 'pointer', opacity: busy ? 0.5 : 1,
+                      }}
+                    >{busy ? '…' : 'Trennen'}</button>
+                  ) : (
+                    <button
+                      type="button" disabled={busy}
+                      onClick={() => connect.mutate(item.id)}
+                      data-testid="integrations-connect"
+                      style={{
+                        padding: '6px 14px', borderRadius: 8,
+                        background: 'var(--v5-acc)', color: 'var(--v5-accent-fg)',
+                        border: 'none', fontSize: 11, fontWeight: 600,
+                        cursor: busy ? 'default' : 'pointer', opacity: busy ? 0.5 : 1,
+                      }}
+                    >{busy ? '…' : 'Verbinden'}</button>
+                  )}
+                </div>
+              </Card>
+            );
+          })}
+        </div>
+      )}
+
+      <div className="v5-ani" style={{ fontSize: 10, color: 'var(--v5-mut)', marginTop: 6 }}>
+        Hinweis: OAuth-Flows für neue Provider werden in einer Folge-PR ergänzt.
+      </div>
+    </div>
+  );
+}

--- a/parkhub-web/src/design-v5/screens/Lobby.test.tsx
+++ b/parkhub-web/src/design-v5/screens/Lobby.test.tsx
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+const mockGet = vi.fn();
+const mockUpdate = vi.fn();
+vi.mock('../../api/client', () => ({
+  api: {
+    getLobbyConfig: (...a: unknown[]) => mockGet(...a),
+    updateLobbyConfig: (...a: unknown[]) => mockUpdate(...a),
+  },
+}));
+
+const mockToast = vi.fn();
+vi.mock('../Toast', () => ({
+  useV5Toast: () => mockToast,
+  V5ToastProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+import { LobbyV5 } from './Lobby';
+
+const CFG = {
+  active_screen: 'queue' as const,
+  rotate_interval_seconds: 30,
+  show_clock: true,
+  show_weather: false,
+};
+
+function renderScreen() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <LobbyV5 navigate={vi.fn()} />
+    </QueryClientProvider>
+  );
+}
+
+describe('LobbyV5', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('renders error state when config fails', async () => {
+    mockGet.mockResolvedValue({ success: false, data: null, error: { code: 'X', message: 'fail' } });
+    renderScreen();
+    await waitFor(() => expect(screen.getByText('Fehler beim Laden')).toBeInTheDocument());
+  });
+
+  it('renders preview with active screen label', async () => {
+    mockGet.mockResolvedValue({ success: true, data: CFG });
+    renderScreen();
+    await waitFor(() => expect(screen.getByTestId('lobby-preview')).toBeInTheDocument());
+    expect(screen.getAllByText('Warteschlange').length).toBeGreaterThan(0);
+  });
+
+  it('selecting a different screen calls updateLobbyConfig', async () => {
+    mockGet.mockResolvedValue({ success: true, data: CFG });
+    mockUpdate.mockResolvedValue({ success: true, data: { ...CFG, active_screen: 'map' } });
+    renderScreen();
+    await waitFor(() => expect(screen.getByText('Karte')).toBeInTheDocument());
+    fireEvent.click(screen.getByText('Karte'));
+    await waitFor(() => {
+      expect(mockUpdate).toHaveBeenCalledWith({ active_screen: 'map' });
+      expect(mockToast).toHaveBeenCalledWith('Lobby aktualisiert', 'success');
+    });
+  });
+
+  it('update error surfaces via toast', async () => {
+    mockGet.mockResolvedValue({ success: true, data: CFG });
+    mockUpdate.mockResolvedValue({ success: false, data: null, error: { code: 'X', message: 'denied' } });
+    renderScreen();
+    await waitFor(() => expect(screen.getByText('Karte')).toBeInTheDocument());
+    fireEvent.click(screen.getByText('Karte'));
+    await waitFor(() => expect(mockToast).toHaveBeenCalledWith('denied', 'error'));
+  });
+
+  it('toggling clock fires update', async () => {
+    mockGet.mockResolvedValue({ success: true, data: CFG });
+    mockUpdate.mockResolvedValue({ success: true, data: { ...CFG, show_clock: false } });
+    renderScreen();
+    await waitFor(() => expect(screen.getByText('Uhr anzeigen')).toBeInTheDocument());
+    const toggles = screen.getAllByRole('switch');
+    fireEvent.click(toggles[0]);
+    await waitFor(() => expect(mockUpdate).toHaveBeenCalledWith({ show_clock: false }));
+  });
+
+  it('changing rotate interval commits on blur', async () => {
+    mockGet.mockResolvedValue({ success: true, data: CFG });
+    mockUpdate.mockResolvedValue({ success: true, data: { ...CFG, rotate_interval_seconds: 60 } });
+    renderScreen();
+    await waitFor(() => expect(screen.getByTestId('lobby-interval')).toBeInTheDocument());
+    fireEvent.change(screen.getByTestId('lobby-interval'), { target: { value: '60' } });
+    fireEvent.blur(screen.getByTestId('lobby-interval'));
+    await waitFor(() => expect(mockUpdate).toHaveBeenCalledWith({ rotate_interval_seconds: 60 }));
+  });
+});

--- a/parkhub-web/src/design-v5/screens/Lobby.tsx
+++ b/parkhub-web/src/design-v5/screens/Lobby.tsx
@@ -1,0 +1,146 @@
+import { useEffect, useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { Card, SectionLabel, Toggle, V5NamedIcon } from '../primitives';
+import { useV5Toast } from '../Toast';
+import { api, type LobbyConfig, type LobbyScreenKey } from '../../api/client';
+import type { ScreenId } from '../nav';
+
+const SCREEN_OPTIONS: { key: LobbyScreenKey; label: string; hint: string }[] = [
+  { key: 'queue', label: 'Warteschlange', hint: 'Nächste Einfahrten' },
+  { key: 'map', label: 'Karte', hint: 'Live-Auslastung' },
+  { key: 'announcements', label: 'Ankündigungen', hint: 'Aktive Hinweise' },
+  { key: 'welcome', label: 'Willkommen', hint: 'Logo + Begrüßung' },
+];
+
+export function LobbyV5({ navigate: _navigate }: { navigate: (id: ScreenId) => void }) {
+  const toast = useV5Toast();
+  const qc = useQueryClient();
+
+  const { data: cfg, isLoading, isError } = useQuery({
+    queryKey: ['lobby'],
+    queryFn: async () => {
+      const res = await api.getLobbyConfig();
+      if (!res.success) throw new Error(res.error?.message ?? 'Lobby konnte nicht geladen werden');
+      return res.data;
+    },
+    staleTime: 30_000,
+  });
+
+  const [local, setLocal] = useState<LobbyConfig | null>(null);
+  useEffect(() => { if (cfg) setLocal(cfg); }, [cfg]);
+
+  const save = useMutation({
+    mutationFn: async (payload: Partial<LobbyConfig>) => {
+      const res = await api.updateLobbyConfig(payload);
+      if (!res.success) throw new Error(res.error?.message ?? 'Speichern fehlgeschlagen');
+      return res.data;
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['lobby'] });
+      toast('Lobby aktualisiert', 'success');
+    },
+    onError: (err: Error) => toast(err.message || 'Speichern fehlgeschlagen', 'error'),
+  });
+
+  if (isLoading) {
+    return (
+      <div style={{ padding: 16, flex: 1, overflow: 'auto', display: 'flex', flexDirection: 'column', gap: 12 }}>
+        {[200, 160, 140].map((h, i) => (
+          <div key={i} style={{ height: h, borderRadius: 14, background: 'var(--v5-sur2)', animation: 'ph-v5-pulse 1.6s ease infinite', animationDelay: `${i * 0.1}s` }} />
+        ))}
+      </div>
+    );
+  }
+
+  if (isError || !local) {
+    return (
+      <div style={{ padding: 16, flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+        <Card className="v5-ani" style={{ padding: 28, textAlign: 'center', maxWidth: 360 }}>
+          <V5NamedIcon name="x" size={26} color="var(--v5-err)" />
+          <div style={{ marginTop: 10, fontWeight: 600, color: 'var(--v5-txt)' }}>Fehler beim Laden</div>
+        </Card>
+      </div>
+    );
+  }
+
+  function update<K extends keyof LobbyConfig>(key: K, value: LobbyConfig[K]) {
+    if (!local) return;
+    const next = { ...local, [key]: value };
+    setLocal(next);
+    save.mutate({ [key]: value } as Partial<LobbyConfig>);
+  }
+
+  return (
+    <div style={{ padding: 16, flex: 1, overflow: 'auto', display: 'flex', flexDirection: 'column', gap: 12 }}>
+      <div className="v5-ani" style={{ fontWeight: 700, fontSize: 15, color: 'var(--v5-txt)' }}>Lobby-Display</div>
+
+      <Card className="v5-ani" style={{ padding: 18, animationDelay: '0.06s' }}>
+        <SectionLabel>Vorschau</SectionLabel>
+        <div
+          data-testid="lobby-preview"
+          style={{
+            aspectRatio: '16 / 9', width: '100%', borderRadius: 12,
+            background: 'var(--v5-sur2)', border: '1px solid var(--v5-bor)',
+            display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: 8,
+          }}
+        >
+          <V5NamedIcon name="monitor" size={36} color="var(--v5-acc)" />
+          <div style={{ fontWeight: 600, fontSize: 14, color: 'var(--v5-txt)' }}>
+            {SCREEN_OPTIONS.find((s) => s.key === local.active_screen)?.label}
+          </div>
+          <div style={{ fontSize: 11, color: 'var(--v5-mut)' }}>
+            Wechselt alle {local.rotate_interval_seconds}s
+          </div>
+        </div>
+      </Card>
+
+      <Card className="v5-ani" style={{ padding: 18, display: 'flex', flexDirection: 'column', gap: 10, animationDelay: '0.12s' }}>
+        <SectionLabel>Aktiver Screen</SectionLabel>
+        <div role="radiogroup" aria-label="Aktiver Screen" style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(160px, 1fr))', gap: 8 }}>
+          {SCREEN_OPTIONS.map((opt) => {
+            const active = local.active_screen === opt.key;
+            return (
+              <button
+                key={opt.key} type="button" role="radio" aria-checked={active}
+                data-testid="lobby-screen"
+                onClick={() => update('active_screen', opt.key)}
+                style={{
+                  padding: '12px 14px', borderRadius: 10, textAlign: 'left', cursor: 'pointer',
+                  border: `1.5px solid ${active ? 'var(--v5-acc)' : 'var(--v5-bor)'}`,
+                  background: active ? 'var(--v5-acc-muted)' : 'var(--v5-sur2)',
+                  color: active ? 'var(--v5-acc)' : 'var(--v5-txt)',
+                }}
+              >
+                <div style={{ fontSize: 12, fontWeight: 600 }}>{opt.label}</div>
+                <div style={{ fontSize: 10, color: 'var(--v5-mut)', marginTop: 2 }}>{opt.hint}</div>
+              </button>
+            );
+          })}
+        </div>
+      </Card>
+
+      <Card className="v5-ani" style={{ padding: 18, display: 'flex', flexDirection: 'column', gap: 10, animationDelay: '0.18s' }}>
+        <SectionLabel>Optionen</SectionLabel>
+        <label style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+          <span style={{ fontSize: 11, color: 'var(--v5-mut)' }}>Rotationsintervall (Sekunden)</span>
+          <input
+            type="number" min="5" max="600" step="5"
+            data-testid="lobby-interval"
+            value={local.rotate_interval_seconds}
+            onChange={(e) => setLocal({ ...local, rotate_interval_seconds: Number(e.target.value) })}
+            onBlur={() => update('rotate_interval_seconds', Math.max(5, Number(local.rotate_interval_seconds)))}
+            style={{ padding: '8px 11px', borderRadius: 9, background: 'var(--v5-sur2)', border: '1px solid var(--v5-bor)', color: 'var(--v5-txt)', fontSize: 12, outline: 'none', fontFamily: 'inherit', maxWidth: 160 }}
+          />
+        </label>
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+          <span style={{ fontSize: 12, color: 'var(--v5-txt)' }}>Uhr anzeigen</span>
+          <Toggle checked={local.show_clock} onChange={(v) => update('show_clock', v)} ariaLabel="Uhr anzeigen" />
+        </div>
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+          <span style={{ fontSize: 12, color: 'var(--v5-txt)' }}>Wetter anzeigen</span>
+          <Toggle checked={local.show_weather} onChange={(v) => update('show_weather', v)} ariaLabel="Wetter anzeigen" />
+        </div>
+      </Card>
+    </div>
+  );
+}

--- a/parkhub-web/src/design-v5/screens/Nutzer.test.tsx
+++ b/parkhub-web/src/design-v5/screens/Nutzer.test.tsx
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+const mockList = vi.fn();
+const mockUpdate = vi.fn();
+vi.mock('../../api/client', () => ({
+  api: {
+    adminUsers: (...a: unknown[]) => mockList(...a),
+    adminUpdateUser: (...a: unknown[]) => mockUpdate(...a),
+  },
+}));
+
+vi.mock('@number-flow/react', () => ({
+  default: ({ value }: { value: number }) => <span>{value}</span>,
+}));
+
+const mockToast = vi.fn();
+vi.mock('../Toast', () => ({
+  useV5Toast: () => mockToast,
+  V5ToastProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+import { NutzerV5 } from './Nutzer';
+
+const U1 = { id: 'u1', username: 'flo', email: 'flo@e', name: 'Flo', role: 'admin' as const, preferences: {}, is_active: true, credits_balance: 0, credits_monthly_quota: 0 };
+const U2 = { id: 'u2', username: 'anna', email: 'anna@e', name: 'Anna', role: 'user' as const, preferences: {}, is_active: false, credits_balance: 0, credits_monthly_quota: 0 };
+
+function renderScreen() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <NutzerV5 navigate={vi.fn()} />
+    </QueryClientProvider>
+  );
+}
+
+describe('NutzerV5', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('renders empty state', async () => {
+    mockList.mockResolvedValue({ success: true, data: [] });
+    renderScreen();
+    await waitFor(() => expect(screen.getByText('Keine Nutzer gefunden')).toBeInTheDocument());
+  });
+
+  it('renders error state when query fails', async () => {
+    mockList.mockResolvedValue({ success: false, data: null, error: { code: 'X', message: 'denied' } });
+    renderScreen();
+    await waitFor(() => expect(screen.getByText('Fehler beim Laden')).toBeInTheDocument());
+  });
+
+  it('renders rows with role and status badges', async () => {
+    mockList.mockResolvedValue({ success: true, data: [U1, U2] });
+    renderScreen();
+    await waitFor(() => expect(screen.getAllByTestId('nutzer-row')).toHaveLength(2));
+    expect(screen.getByText('Flo')).toBeInTheDocument();
+    // "Gesperrt" appears as badge + filter chip — ensure at least one occurrence
+    expect(screen.getAllByText('Gesperrt').length).toBeGreaterThan(0);
+  });
+
+  it('filters to admins', async () => {
+    mockList.mockResolvedValue({ success: true, data: [U1, U2] });
+    renderScreen();
+    await waitFor(() => expect(screen.getAllByTestId('nutzer-row')).toHaveLength(2));
+    fireEvent.click(screen.getByRole('button', { name: 'Admins' }));
+    await waitFor(() => expect(screen.getAllByTestId('nutzer-row')).toHaveLength(1));
+  });
+
+  it('suspend button calls update with is_active:false', async () => {
+    mockList.mockResolvedValue({ success: true, data: [U1] });
+    mockUpdate.mockResolvedValue({ success: true, data: { ...U1, is_active: false } });
+    renderScreen();
+    await waitFor(() => expect(screen.getByText('Sperren')).toBeInTheDocument());
+    fireEvent.click(screen.getByText('Sperren'));
+    await waitFor(() => {
+      expect(mockUpdate).toHaveBeenCalledWith('u1', { is_active: false });
+      expect(mockToast).toHaveBeenCalledWith('Nutzer gesperrt', 'success');
+    });
+  });
+
+  it('activate mutation error surfaces via toast', async () => {
+    mockList.mockResolvedValue({ success: true, data: [U2] });
+    mockUpdate.mockResolvedValue({ success: false, data: null, error: { code: 'X', message: 'nope' } });
+    renderScreen();
+    await waitFor(() => expect(screen.getByText('Aktivieren')).toBeInTheDocument());
+    fireEvent.click(screen.getByText('Aktivieren'));
+    await waitFor(() => expect(mockToast).toHaveBeenCalledWith('nope', 'error'));
+  });
+
+  it('search filters by name', async () => {
+    mockList.mockResolvedValue({ success: true, data: [U1, U2] });
+    renderScreen();
+    await waitFor(() => expect(screen.getAllByTestId('nutzer-row')).toHaveLength(2));
+    fireEvent.change(screen.getByTestId('nutzer-search'), { target: { value: 'anna' } });
+    await waitFor(() => expect(screen.getAllByTestId('nutzer-row')).toHaveLength(1));
+  });
+});

--- a/parkhub-web/src/design-v5/screens/Nutzer.tsx
+++ b/parkhub-web/src/design-v5/screens/Nutzer.tsx
@@ -1,0 +1,187 @@
+import { useState } from 'react';
+import NumberFlow from '@number-flow/react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { Badge, Card, V5NamedIcon, type BadgeVariant } from '../primitives';
+import { useV5Toast } from '../Toast';
+import { api, type User } from '../../api/client';
+import type { ScreenId } from '../nav';
+
+type FilterKey = 'alle' | 'active' | 'suspended' | 'admin';
+
+const FILTERS: { key: FilterKey; label: string }[] = [
+  { key: 'alle', label: 'Alle' },
+  { key: 'active', label: 'Aktiv' },
+  { key: 'suspended', label: 'Gesperrt' },
+  { key: 'admin', label: 'Admins' },
+];
+
+function roleVariant(role: User['role']): BadgeVariant {
+  switch (role) {
+    case 'superadmin': return 'purple';
+    case 'admin': return 'info';
+    case 'premium': return 'warning';
+    default: return 'gray';
+  }
+}
+
+export function NutzerV5({ navigate: _navigate }: { navigate: (id: ScreenId) => void }) {
+  const toast = useV5Toast();
+  const qc = useQueryClient();
+  const [filter, setFilter] = useState<FilterKey>('alle');
+  const [query, setQuery] = useState('');
+
+  const { data: users = [], isLoading, isError } = useQuery({
+    queryKey: ['nutzer'],
+    queryFn: async () => {
+      const res = await api.adminUsers();
+      if (!res.success) throw new Error(res.error?.message ?? 'Nutzer konnten nicht geladen werden');
+      return res.data ?? [];
+    },
+    staleTime: 30_000,
+  });
+
+  const toggleActive = useMutation({
+    mutationFn: async (payload: { id: string; is_active: boolean }) => {
+      const res = await api.adminUpdateUser(payload.id, { is_active: payload.is_active });
+      if (!res.success) throw new Error(res.error?.message ?? 'Aktualisierung fehlgeschlagen');
+      return res.data;
+    },
+    onSuccess: (_data, vars) => {
+      qc.invalidateQueries({ queryKey: ['nutzer'] });
+      toast(vars.is_active ? 'Nutzer aktiviert' : 'Nutzer gesperrt', 'success');
+    },
+    onError: (err: Error) => toast(err.message || 'Aktualisierung fehlgeschlagen', 'error'),
+  });
+
+  const filtered = users
+    .filter((u) => {
+      if (filter === 'active') return u.is_active;
+      if (filter === 'suspended') return !u.is_active;
+      if (filter === 'admin') return u.role === 'admin' || u.role === 'superadmin';
+      return true;
+    })
+    .filter((u) =>
+      !query.trim() ? true : [u.name, u.email, u.username].some((s) => s?.toLowerCase().includes(query.trim().toLowerCase()))
+    );
+
+  if (isLoading) {
+    return (
+      <div style={{ padding: 16, flex: 1, overflow: 'auto' }}>
+        <div style={{ height: 32, width: 220, borderRadius: 8, background: 'var(--v5-sur2)', marginBottom: 14, animation: 'ph-v5-pulse 1.6s ease infinite' }} />
+        {[0, 1, 2].map((i) => (
+          <div key={i} style={{ height: 60, borderRadius: 12, background: 'var(--v5-sur2)', marginBottom: 8, animation: 'ph-v5-pulse 1.6s ease infinite', animationDelay: `${i * 0.1}s` }} />
+        ))}
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div style={{ padding: 16, flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+        <Card className="v5-ani" style={{ padding: 28, textAlign: 'center', maxWidth: 360 }}>
+          <V5NamedIcon name="x" size={26} color="var(--v5-err)" />
+          <div style={{ marginTop: 10, fontWeight: 600, color: 'var(--v5-txt)' }}>Fehler beim Laden</div>
+          <div style={{ fontSize: 12, color: 'var(--v5-mut)', marginTop: 4 }}>Nutzer konnten nicht geladen werden.</div>
+        </Card>
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ padding: 16, flex: 1, overflow: 'auto', display: 'flex', flexDirection: 'column', gap: 12 }}>
+      <div className="v5-ani" style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <span style={{ fontWeight: 700, fontSize: 15, color: 'var(--v5-txt)' }}>Nutzer</span>
+          <Badge variant="gray"><NumberFlow value={filtered.length} /></Badge>
+        </div>
+        <input
+          type="search"
+          placeholder="Suchen …"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          data-testid="nutzer-search"
+          style={{
+            padding: '7px 12px', borderRadius: 9, background: 'var(--v5-sur2)',
+            border: '1px solid var(--v5-bor)', color: 'var(--v5-txt)', fontSize: 12,
+            outline: 'none', minWidth: 200, fontFamily: 'inherit',
+          }}
+        />
+      </div>
+
+      <div className="v5-ani" role="group" aria-label="Filter" style={{ display: 'flex', gap: 6, flexWrap: 'wrap', animationDelay: '0.06s' }}>
+        {FILTERS.map((f) => {
+          const active = filter === f.key;
+          return (
+            <button
+              key={f.key} type="button" aria-pressed={active} onClick={() => setFilter(f.key)}
+              style={{
+                padding: '5px 12px', borderRadius: 999, fontSize: 11, fontWeight: 500, cursor: 'pointer',
+                border: `1.5px solid ${active ? 'var(--v5-acc)' : 'var(--v5-bor)'}`,
+                background: active ? 'var(--v5-acc-muted)' : 'transparent',
+                color: active ? 'var(--v5-acc)' : 'var(--v5-mut)',
+              }}
+            >{f.label}</button>
+          );
+        })}
+      </div>
+
+      {filtered.length === 0 ? (
+        <Card className="v5-ani" style={{ padding: 36, textAlign: 'center', animationDelay: '0.12s' }}>
+          <V5NamedIcon name="users" size={20} color="var(--v5-mut)" />
+          <div style={{ marginTop: 10, fontWeight: 600, color: 'var(--v5-txt)' }}>Keine Nutzer gefunden</div>
+        </Card>
+      ) : (
+        <Card className="v5-ani" style={{ overflow: 'hidden', animationDelay: '0.12s' }}>
+          <div className="v5-mono" style={{
+            display: 'grid', gridTemplateColumns: '1fr 1.3fr 110px 110px 120px',
+            padding: '8px 16px', fontSize: 9, letterSpacing: 1.2, textTransform: 'uppercase',
+            color: 'var(--v5-mut)', borderBottom: '1px solid var(--v5-bor)',
+          }}>
+            <span>Name</span><span>E-Mail</span><span>Rolle</span><span>Status</span><span>Aktion</span>
+          </div>
+          {filtered.map((u, i) => {
+            const isBusy = toggleActive.isPending && toggleActive.variables?.id === u.id;
+            return (
+              <div
+                key={u.id} data-testid="nutzer-row"
+                style={{
+                  display: 'grid', gridTemplateColumns: '1fr 1.3fr 110px 110px 120px',
+                  padding: '10px 16px', alignItems: 'center',
+                  borderBottom: i < filtered.length - 1 ? '1px solid var(--v5-bor)' : 'none',
+                  gap: 4,
+                }}
+              >
+                <div>
+                  <div style={{ fontSize: 12, fontWeight: 500, color: 'var(--v5-txt)' }}>{u.name}</div>
+                  <div style={{ fontSize: 10, color: 'var(--v5-mut)' }}>@{u.username}</div>
+                </div>
+                <span style={{ fontSize: 11, color: 'var(--v5-txt)' }}>{u.email}</span>
+                <Badge variant={roleVariant(u.role)}>{u.role}</Badge>
+                <Badge variant={u.is_active ? 'success' : 'error'} dot>
+                  {u.is_active ? 'Aktiv' : 'Gesperrt'}
+                </Badge>
+                <button
+                  type="button"
+                  disabled={isBusy}
+                  onClick={() => toggleActive.mutate({ id: u.id, is_active: !u.is_active })}
+                  aria-label={u.is_active ? `Nutzer ${u.name} sperren` : `Nutzer ${u.name} aktivieren`}
+                  style={{
+                    padding: '4px 10px', borderRadius: 7,
+                    background: u.is_active
+                      ? 'color-mix(in oklch, var(--v5-err) 8%, transparent)'
+                      : 'var(--v5-acc-muted)',
+                    border: 'none', fontSize: 10, fontWeight: 500,
+                    color: u.is_active ? 'var(--v5-err)' : 'var(--v5-acc)',
+                    cursor: isBusy ? 'default' : 'pointer', opacity: isBusy ? 0.5 : 1,
+                  }}
+                >
+                  {isBusy ? '…' : u.is_active ? 'Sperren' : 'Aktivieren'}
+                </button>
+              </div>
+            );
+          })}
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/parkhub-web/src/design-v5/screens/Policies.test.tsx
+++ b/parkhub-web/src/design-v5/screens/Policies.test.tsx
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+const mockList = vi.fn();
+const mockUpdate = vi.fn();
+vi.mock('../../api/client', () => ({
+  api: {
+    getPolicies: (...a: unknown[]) => mockList(...a),
+    updatePolicy: (...a: unknown[]) => mockUpdate(...a),
+  },
+}));
+
+const mockToast = vi.fn();
+vi.mock('../Toast', () => ({
+  useV5Toast: () => mockToast,
+  V5ToastProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+import { PoliciesV5 } from './Policies';
+
+const P1 = { id: 'p1', title: 'AGB', slug: 'agb', body: 'Alter Text', updated_at: '2026-04-01T10:00:00Z' };
+const P2 = { id: 'p2', title: 'Datenschutz', slug: 'dsg', body: 'DSGVO', updated_at: '2026-04-02T10:00:00Z' };
+
+function renderScreen() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <PoliciesV5 navigate={vi.fn()} />
+    </QueryClientProvider>
+  );
+}
+
+describe('PoliciesV5', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('renders empty state', async () => {
+    mockList.mockResolvedValue({ success: true, data: [] });
+    renderScreen();
+    await waitFor(() => expect(screen.getByText('Keine Richtlinien')).toBeInTheDocument());
+  });
+
+  it('renders error state', async () => {
+    mockList.mockResolvedValue({ success: false, data: null, error: { code: 'X', message: 'fail' } });
+    renderScreen();
+    await waitFor(() => expect(screen.getByText('Fehler beim Laden')).toBeInTheDocument());
+  });
+
+  it('selects first policy into editor', async () => {
+    mockList.mockResolvedValue({ success: true, data: [P1, P2] });
+    renderScreen();
+    await waitFor(() => expect((screen.getByTestId('policies-editor') as HTMLTextAreaElement).value).toBe('Alter Text'));
+  });
+
+  it('clicking another policy switches editor content', async () => {
+    mockList.mockResolvedValue({ success: true, data: [P1, P2] });
+    renderScreen();
+    await waitFor(() => expect(screen.getByText('Datenschutz')).toBeInTheDocument());
+    fireEvent.click(screen.getByText('Datenschutz'));
+    await waitFor(() => expect((screen.getByTestId('policies-editor') as HTMLTextAreaElement).value).toBe('DSGVO'));
+  });
+
+  it('save mutation fires with updated body', async () => {
+    mockList.mockResolvedValue({ success: true, data: [P1] });
+    mockUpdate.mockResolvedValue({ success: true, data: { ...P1, body: 'Neu' } });
+    renderScreen();
+    await waitFor(() => expect(screen.getByTestId('policies-editor')).toBeInTheDocument());
+    fireEvent.change(screen.getByTestId('policies-editor'), { target: { value: 'Neu' } });
+    fireEvent.click(screen.getByTestId('policies-save'));
+    await waitFor(() => {
+      expect(mockUpdate).toHaveBeenCalledWith('p1', 'Neu');
+      expect(mockToast).toHaveBeenCalledWith('Richtlinie gespeichert', 'success');
+    });
+  });
+
+  it('save error surfaces via toast', async () => {
+    mockList.mockResolvedValue({ success: true, data: [P1] });
+    mockUpdate.mockResolvedValue({ success: false, data: null, error: { code: 'X', message: 'denied' } });
+    renderScreen();
+    await waitFor(() => expect(screen.getByTestId('policies-editor')).toBeInTheDocument());
+    fireEvent.change(screen.getByTestId('policies-editor'), { target: { value: 'Neu' } });
+    fireEvent.click(screen.getByTestId('policies-save'));
+    await waitFor(() => expect(mockToast).toHaveBeenCalledWith('denied', 'error'));
+  });
+
+  it('preview toggle flips editor ↔ preview', async () => {
+    mockList.mockResolvedValue({ success: true, data: [P1] });
+    renderScreen();
+    await waitFor(() => expect(screen.getByTestId('policies-editor')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('policies-preview-toggle'));
+    await waitFor(() => expect(screen.getByTestId('policies-preview')).toBeInTheDocument());
+    expect(screen.queryByTestId('policies-editor')).toBeNull();
+  });
+});

--- a/parkhub-web/src/design-v5/screens/Policies.tsx
+++ b/parkhub-web/src/design-v5/screens/Policies.tsx
@@ -1,0 +1,176 @@
+import { useEffect, useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { Card, SectionLabel, V5NamedIcon } from '../primitives';
+import { useV5Toast } from '../Toast';
+import { api, type Policy } from '../../api/client';
+import type { ScreenId } from '../nav';
+
+function formatWhen(iso: string): string {
+  return new Date(iso).toLocaleString('de-DE', {
+    day: '2-digit', month: '2-digit', year: 'numeric',
+    hour: '2-digit', minute: '2-digit',
+  });
+}
+
+export function PoliciesV5({ navigate: _navigate }: { navigate: (id: ScreenId) => void }) {
+  const toast = useV5Toast();
+  const qc = useQueryClient();
+  const [activeId, setActiveId] = useState<string | null>(null);
+  const [draft, setDraft] = useState('');
+  const [preview, setPreview] = useState(false);
+
+  const { data: policies = [], isLoading, isError } = useQuery({
+    queryKey: ['policies'],
+    queryFn: async () => {
+      const res = await api.getPolicies();
+      if (!res.success) throw new Error(res.error?.message ?? 'Richtlinien konnten nicht geladen werden');
+      return res.data ?? [];
+    },
+    staleTime: 30_000,
+  });
+
+  useEffect(() => {
+    if (!activeId && policies.length > 0) setActiveId(policies[0].id);
+  }, [policies, activeId]);
+
+  const active = policies.find((p) => p.id === activeId) ?? null;
+
+  useEffect(() => {
+    if (active) { setDraft(active.body); setPreview(false); }
+  }, [active]);
+
+  const save = useMutation({
+    mutationFn: async (payload: { id: string; body: string }) => {
+      const res = await api.updatePolicy(payload.id, payload.body);
+      if (!res.success) throw new Error(res.error?.message ?? 'Speichern fehlgeschlagen');
+      return res.data;
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['policies'] });
+      toast('Richtlinie gespeichert', 'success');
+    },
+    onError: (err: Error) => toast(err.message || 'Speichern fehlgeschlagen', 'error'),
+  });
+
+  if (isLoading) {
+    return (
+      <div style={{ padding: 16, flex: 1, overflow: 'auto' }}>
+        <div style={{ height: 400, borderRadius: 14, background: 'var(--v5-sur2)', animation: 'ph-v5-pulse 1.6s ease infinite' }} />
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div style={{ padding: 16, flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+        <Card className="v5-ani" style={{ padding: 28, textAlign: 'center', maxWidth: 360 }}>
+          <V5NamedIcon name="x" size={26} color="var(--v5-err)" />
+          <div style={{ marginTop: 10, fontWeight: 600, color: 'var(--v5-txt)' }}>Fehler beim Laden</div>
+        </Card>
+      </div>
+    );
+  }
+
+  const isDirty = active && draft !== active.body;
+
+  return (
+    <div style={{ padding: 16, flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column', gap: 12 }}>
+      <div className="v5-ani" style={{ fontWeight: 700, fontSize: 15, color: 'var(--v5-txt)' }}>Richtlinien</div>
+
+      {policies.length === 0 ? (
+        <Card className="v5-ani" style={{ padding: 36, textAlign: 'center' }}>
+          <V5NamedIcon name="shield" size={20} color="var(--v5-mut)" />
+          <div style={{ marginTop: 10, fontWeight: 600, color: 'var(--v5-txt)' }}>Keine Richtlinien</div>
+        </Card>
+      ) : (
+        <div style={{ display: 'grid', gridTemplateColumns: '220px 1fr', gap: 12, flex: 1, minHeight: 0 }}>
+          <Card className="v5-ani" style={{ padding: 8, overflow: 'auto' }}>
+            <SectionLabel>Dokumente</SectionLabel>
+            {policies.map((p: Policy) => {
+              const isActive = p.id === activeId;
+              return (
+                <button
+                  key={p.id} type="button"
+                  onClick={() => setActiveId(p.id)}
+                  data-testid="policies-nav"
+                  style={{
+                    display: 'block', width: '100%', textAlign: 'left',
+                    padding: '8px 10px', borderRadius: 8, marginBottom: 3,
+                    background: isActive ? 'var(--v5-acc-muted)' : 'transparent',
+                    color: isActive ? 'var(--v5-acc)' : 'var(--v5-txt)',
+                    border: 'none', cursor: 'pointer', fontSize: 12, fontWeight: isActive ? 600 : 500,
+                  }}
+                >{p.title}</button>
+              );
+            })}
+          </Card>
+
+          <Card className="v5-ani" style={{ padding: 16, display: 'flex', flexDirection: 'column', gap: 10, minHeight: 0 }}>
+            {active ? (
+              <>
+                <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+                  <div>
+                    <div style={{ fontWeight: 600, fontSize: 14, color: 'var(--v5-txt)' }}>{active.title}</div>
+                    <div style={{ fontSize: 10, color: 'var(--v5-mut)' }}>
+                      Zuletzt aktualisiert: {formatWhen(active.updated_at)}
+                    </div>
+                  </div>
+                  <div style={{ display: 'flex', gap: 6 }}>
+                    <button
+                      type="button"
+                      onClick={() => setPreview((p) => !p)}
+                      data-testid="policies-preview-toggle"
+                      aria-pressed={preview}
+                      style={{ padding: '6px 12px', borderRadius: 8, background: preview ? 'var(--v5-acc-muted)' : 'var(--v5-sur2)', border: `1px solid ${preview ? 'var(--v5-acc)' : 'var(--v5-bor)'}`, color: preview ? 'var(--v5-acc)' : 'var(--v5-txt)', fontSize: 11, fontWeight: 500, cursor: 'pointer' }}
+                    >{preview ? 'Bearbeiten' : 'Vorschau'}</button>
+                    <button
+                      type="button"
+                      disabled={!isDirty || save.isPending}
+                      onClick={() => save.mutate({ id: active.id, body: draft })}
+                      data-testid="policies-save"
+                      style={{
+                        padding: '6px 14px', borderRadius: 8, background: 'var(--v5-acc)', color: 'var(--v5-accent-fg)',
+                        border: 'none', fontSize: 11, fontWeight: 600,
+                        cursor: isDirty && !save.isPending ? 'pointer' : 'not-allowed',
+                        opacity: isDirty && !save.isPending ? 1 : 0.5,
+                      }}
+                    >{save.isPending ? 'Speichert …' : 'Speichern'}</button>
+                  </div>
+                </div>
+
+                {preview ? (
+                  <div
+                    data-testid="policies-preview"
+                    style={{
+                      flex: 1, overflow: 'auto', padding: 14, borderRadius: 9,
+                      background: 'var(--v5-sur2)', border: '1px solid var(--v5-bor)',
+                      fontSize: 12, color: 'var(--v5-txt)', whiteSpace: 'pre-wrap',
+                      fontFamily: 'inherit', lineHeight: 1.55,
+                    }}
+                  >{draft || '(leer)'}</div>
+                ) : (
+                  <textarea
+                    data-testid="policies-editor"
+                    value={draft}
+                    onChange={(e) => setDraft(e.target.value)}
+                    style={{
+                      flex: 1, padding: 12, borderRadius: 9,
+                      background: 'var(--v5-sur2)', border: '1px solid var(--v5-bor)',
+                      color: 'var(--v5-txt)', fontSize: 12, lineHeight: 1.55,
+                      outline: 'none', resize: 'none',
+                      fontFamily: "ui-monospace, 'SFMono-Regular', Menlo, monospace",
+                    }}
+                  />
+                )}
+
+                <div style={{ fontSize: 10, color: 'var(--v5-mut)' }}>
+                  Hinweis: Markdown-Renderer folgt in separater PR; aktuell Klartext-Vorschau.
+                </div>
+              </>
+            ) : null}
+          </Card>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/parkhub-web/src/design-v5/screens/Standorte.test.tsx
+++ b/parkhub-web/src/design-v5/screens/Standorte.test.tsx
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+const mockList = vi.fn();
+const mockCreate = vi.fn();
+const mockUpdate = vi.fn();
+const mockDelete = vi.fn();
+vi.mock('../../api/client', () => ({
+  api: {
+    getLots: (...a: unknown[]) => mockList(...a),
+    createLot: (...a: unknown[]) => mockCreate(...a),
+    updateLot: (...a: unknown[]) => mockUpdate(...a),
+    deleteLot: (...a: unknown[]) => mockDelete(...a),
+  },
+}));
+
+vi.mock('@number-flow/react', () => ({
+  default: ({ value }: { value: number }) => <span>{value}</span>,
+}));
+
+const mockToast = vi.fn();
+vi.mock('../Toast', () => ({
+  useV5Toast: () => mockToast,
+  V5ToastProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+import { StandorteV5 } from './Standorte';
+
+const L1 = { id: 'l1', name: 'Parkhaus Nord', total_slots: 100, available_slots: 60, status: 'open' };
+const L2 = { id: 'l2', name: 'Garage Süd', total_slots: 50, available_slots: 0, status: 'full' };
+
+function renderScreen() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <StandorteV5 navigate={vi.fn()} />
+    </QueryClientProvider>
+  );
+}
+
+describe('StandorteV5', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('renders empty state', async () => {
+    mockList.mockResolvedValue({ success: true, data: [] });
+    renderScreen();
+    await waitFor(() => expect(screen.getByText('Keine Standorte')).toBeInTheDocument());
+  });
+
+  it('renders error state', async () => {
+    mockList.mockResolvedValue({ success: false, data: null, error: { code: 'X', message: 'fail' } });
+    renderScreen();
+    await waitFor(() => expect(screen.getByText('Fehler beim Laden')).toBeInTheDocument());
+  });
+
+  it('lists lots with status badges', async () => {
+    mockList.mockResolvedValue({ success: true, data: [L1, L2] });
+    renderScreen();
+    await waitFor(() => expect(screen.getAllByTestId('standorte-row')).toHaveLength(2));
+    expect(screen.getByText('Parkhaus Nord')).toBeInTheDocument();
+    // "Voll" appears as badge + option — at least one occurrence is required
+    expect(screen.getAllByText('Voll').length).toBeGreaterThan(0);
+  });
+
+  it('create mutation calls createLot', async () => {
+    mockList.mockResolvedValue({ success: true, data: [] });
+    mockCreate.mockResolvedValue({ success: true, data: { ...L1, id: 'new', name: 'Neu', total_slots: 30, available_slots: 30 } });
+    renderScreen();
+    await waitFor(() => expect(screen.getByTestId('standorte-toggle-form')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('standorte-toggle-form'));
+    fireEvent.change(screen.getByTestId('standorte-name'), { target: { value: 'Neu' } });
+    fireEvent.change(screen.getByTestId('standorte-slots'), { target: { value: '30' } });
+    fireEvent.click(screen.getByTestId('standorte-create'));
+    await waitFor(() => {
+      expect(mockCreate).toHaveBeenCalledWith({ name: 'Neu', total_slots: 30 });
+      expect(mockToast).toHaveBeenCalledWith('Standort angelegt', 'success');
+    });
+  });
+
+  it('create error surfaces via toast', async () => {
+    mockList.mockResolvedValue({ success: true, data: [] });
+    mockCreate.mockResolvedValue({ success: false, data: null, error: { code: 'X', message: 'duplicate' } });
+    renderScreen();
+    await waitFor(() => expect(screen.getByTestId('standorte-toggle-form')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('standorte-toggle-form'));
+    fireEvent.change(screen.getByTestId('standorte-name'), { target: { value: 'Neu' } });
+    fireEvent.change(screen.getByTestId('standorte-slots'), { target: { value: '30' } });
+    fireEvent.click(screen.getByTestId('standorte-create'));
+    await waitFor(() => expect(mockToast).toHaveBeenCalledWith('duplicate', 'error'));
+  });
+
+  it('status change calls updateLot', async () => {
+    mockList.mockResolvedValue({ success: true, data: [L1] });
+    mockUpdate.mockResolvedValue({ success: true, data: { ...L1, status: 'closed' } });
+    renderScreen();
+    await waitFor(() => expect(screen.getByTestId('standorte-status')).toBeInTheDocument());
+    fireEvent.change(screen.getByTestId('standorte-status'), { target: { value: 'closed' } });
+    await waitFor(() => {
+      expect(mockUpdate).toHaveBeenCalledWith('l1', { status: 'closed' });
+      expect(mockToast).toHaveBeenCalledWith('Status aktualisiert', 'success');
+    });
+  });
+
+  it('delete calls deleteLot', async () => {
+    mockList.mockResolvedValue({ success: true, data: [L1] });
+    mockDelete.mockResolvedValue({ success: true, data: null });
+    renderScreen();
+    await waitFor(() => expect(screen.getByText('Löschen')).toBeInTheDocument());
+    fireEvent.click(screen.getByText('Löschen'));
+    await waitFor(() => {
+      expect(mockDelete).toHaveBeenCalledWith('l1');
+      expect(mockToast).toHaveBeenCalledWith('Standort gelöscht', 'success');
+    });
+  });
+});

--- a/parkhub-web/src/design-v5/screens/Standorte.tsx
+++ b/parkhub-web/src/design-v5/screens/Standorte.tsx
@@ -1,0 +1,220 @@
+import { useState } from 'react';
+import NumberFlow from '@number-flow/react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { Badge, Card, SectionLabel, V5NamedIcon, type BadgeVariant } from '../primitives';
+import { useV5Toast } from '../Toast';
+import { api, type ParkingLot, type LotStatus } from '../../api/client';
+import type { ScreenId } from '../nav';
+
+function statusVariant(s: string): BadgeVariant {
+  switch (s) {
+    case 'open': return 'success';
+    case 'closed': return 'gray';
+    case 'full': return 'warning';
+    case 'maintenance': return 'error';
+    default: return 'gray';
+  }
+}
+
+const STATUS_LABEL: Record<string, string> = {
+  open: 'Offen', closed: 'Geschlossen', full: 'Voll', maintenance: 'Wartung',
+};
+
+export function StandorteV5({ navigate: _navigate }: { navigate: (id: ScreenId) => void }) {
+  const toast = useV5Toast();
+  const qc = useQueryClient();
+  const [formOpen, setFormOpen] = useState(false);
+  const [newName, setNewName] = useState('');
+  const [newSlots, setNewSlots] = useState('');
+
+  const { data: lots = [], isLoading, isError } = useQuery({
+    queryKey: ['standorte'],
+    queryFn: async () => {
+      const res = await api.getLots();
+      if (!res.success) throw new Error(res.error?.message ?? 'Standorte konnten nicht geladen werden');
+      return res.data ?? [];
+    },
+    staleTime: 30_000,
+  });
+
+  const createLot = useMutation({
+    mutationFn: async (payload: { name: string; total_slots: number }) => {
+      const res = await api.createLot({ name: payload.name, total_slots: payload.total_slots });
+      if (!res.success) throw new Error(res.error?.message ?? 'Anlegen fehlgeschlagen');
+      return res.data;
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['standorte'] });
+      toast('Standort angelegt', 'success');
+      setFormOpen(false); setNewName(''); setNewSlots('');
+    },
+    onError: (err: Error) => toast(err.message || 'Anlegen fehlgeschlagen', 'error'),
+  });
+
+  const updateStatus = useMutation({
+    mutationFn: async (payload: { id: string; status: LotStatus }) => {
+      const res = await api.updateLot(payload.id, { status: payload.status });
+      if (!res.success) throw new Error(res.error?.message ?? 'Speichern fehlgeschlagen');
+      return res.data;
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['standorte'] });
+      toast('Status aktualisiert', 'success');
+    },
+    onError: (err: Error) => toast(err.message || 'Speichern fehlgeschlagen', 'error'),
+  });
+
+  const deleteLot = useMutation({
+    mutationFn: async (id: string) => {
+      const res = await api.deleteLot(id);
+      if (!res.success) throw new Error(res.error?.message ?? 'Löschen fehlgeschlagen');
+      return res.data;
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['standorte'] });
+      toast('Standort gelöscht', 'success');
+    },
+    onError: (err: Error) => toast(err.message || 'Löschen fehlgeschlagen', 'error'),
+  });
+
+  const canCreate = newName.trim().length > 1 && Number(newSlots) > 0;
+
+  if (isLoading) {
+    return (
+      <div style={{ padding: 16, flex: 1, overflow: 'auto' }}>
+        {[0, 1, 2].map((i) => (
+          <div key={i} style={{ height: 60, borderRadius: 12, background: 'var(--v5-sur2)', marginBottom: 8, animation: 'ph-v5-pulse 1.6s ease infinite', animationDelay: `${i * 0.1}s` }} />
+        ))}
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div style={{ padding: 16, flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+        <Card className="v5-ani" style={{ padding: 28, textAlign: 'center', maxWidth: 360 }}>
+          <V5NamedIcon name="x" size={26} color="var(--v5-err)" />
+          <div style={{ marginTop: 10, fontWeight: 600, color: 'var(--v5-txt)' }}>Fehler beim Laden</div>
+        </Card>
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ padding: 16, flex: 1, overflow: 'auto', display: 'flex', flexDirection: 'column', gap: 12 }}>
+      <div className="v5-ani" style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <span style={{ fontWeight: 700, fontSize: 15, color: 'var(--v5-txt)' }}>Standorte</span>
+          <Badge variant="gray"><NumberFlow value={lots.length} /></Badge>
+        </div>
+        <button
+          type="button" onClick={() => setFormOpen((o) => !o)} data-testid="standorte-toggle-form"
+          style={{
+            padding: '7px 14px', borderRadius: 9, background: 'var(--v5-acc)', color: 'var(--v5-accent-fg)',
+            border: 'none', fontSize: 11, fontWeight: 600, cursor: 'pointer',
+            display: 'flex', alignItems: 'center', gap: 5,
+          }}
+        >
+          <V5NamedIcon name="plus" size={12} />{formOpen ? 'Schließen' : 'Neuer Standort'}
+        </button>
+      </div>
+
+      {formOpen && (
+        <Card className="v5-ani" style={{ padding: 16, display: 'flex', flexDirection: 'column', gap: 10 }}>
+          <SectionLabel>Neuer Standort</SectionLabel>
+          <div style={{ display: 'grid', gridTemplateColumns: '2fr 1fr', gap: 10 }}>
+            <label style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+              <span style={{ fontSize: 11, color: 'var(--v5-mut)' }}>Name</span>
+              <input
+                data-testid="standorte-name"
+                value={newName} onChange={(e) => setNewName(e.target.value)}
+                style={{ padding: '8px 11px', borderRadius: 9, background: 'var(--v5-sur2)', border: '1px solid var(--v5-bor)', color: 'var(--v5-txt)', fontSize: 12, outline: 'none', fontFamily: 'inherit' }}
+              />
+            </label>
+            <label style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+              <span style={{ fontSize: 11, color: 'var(--v5-mut)' }}>Kapazität</span>
+              <input
+                data-testid="standorte-slots"
+                type="number" min="1"
+                value={newSlots} onChange={(e) => setNewSlots(e.target.value)}
+                style={{ padding: '8px 11px', borderRadius: 9, background: 'var(--v5-sur2)', border: '1px solid var(--v5-bor)', color: 'var(--v5-txt)', fontSize: 12, outline: 'none', fontFamily: 'inherit' }}
+              />
+            </label>
+          </div>
+          <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 6 }}>
+            <button
+              type="button"
+              disabled={!canCreate || createLot.isPending}
+              onClick={() => createLot.mutate({ name: newName.trim(), total_slots: Number(newSlots) })}
+              data-testid="standorte-create"
+              style={{
+                padding: '8px 16px', borderRadius: 9, background: 'var(--v5-acc)', color: 'var(--v5-accent-fg)',
+                border: 'none', fontSize: 12, fontWeight: 600,
+                cursor: canCreate && !createLot.isPending ? 'pointer' : 'not-allowed',
+                opacity: canCreate && !createLot.isPending ? 1 : 0.5,
+              }}
+            >{createLot.isPending ? 'Legt an …' : 'Anlegen'}</button>
+          </div>
+        </Card>
+      )}
+
+      {lots.length === 0 ? (
+        <Card className="v5-ani" style={{ padding: 36, textAlign: 'center', animationDelay: '0.12s' }}>
+          <V5NamedIcon name="map" size={20} color="var(--v5-mut)" />
+          <div style={{ marginTop: 10, fontWeight: 600, color: 'var(--v5-txt)' }}>Keine Standorte</div>
+        </Card>
+      ) : (
+        <Card className="v5-ani" style={{ overflow: 'hidden', animationDelay: '0.12s' }}>
+          {lots.map((l: ParkingLot, i) => {
+            const delBusy = deleteLot.isPending && deleteLot.variables === l.id;
+            const statBusy = updateStatus.isPending && updateStatus.variables?.id === l.id;
+            return (
+              <div key={l.id} data-testid="standorte-row" style={{
+                display: 'grid', gridTemplateColumns: '1fr 100px 110px 140px 100px',
+                padding: '12px 16px', alignItems: 'center', gap: 8,
+                borderBottom: i < lots.length - 1 ? '1px solid var(--v5-bor)' : 'none',
+              }}>
+                <div>
+                  <div style={{ fontSize: 12, fontWeight: 500, color: 'var(--v5-txt)' }}>{l.name}</div>
+                  {l.address && <div style={{ fontSize: 10, color: 'var(--v5-mut)' }}>{l.address}</div>}
+                </div>
+                <span className="v5-mono" style={{ fontSize: 11, color: 'var(--v5-txt)' }}>
+                  {l.available_slots} / {l.total_slots}
+                </span>
+                <Badge variant={statusVariant(l.status)} dot>{STATUS_LABEL[l.status] ?? l.status}</Badge>
+                <select
+                  data-testid="standorte-status"
+                  disabled={statBusy}
+                  value={l.status}
+                  onChange={(e) => updateStatus.mutate({ id: l.id, status: e.target.value as LotStatus })}
+                  aria-label={`Status für ${l.name}`}
+                  style={{
+                    padding: '5px 8px', borderRadius: 7, background: 'var(--v5-sur2)',
+                    border: '1px solid var(--v5-bor)', color: 'var(--v5-txt)', fontSize: 11,
+                    outline: 'none', fontFamily: 'inherit',
+                  }}
+                >
+                  <option value="open">Offen</option>
+                  <option value="closed">Geschlossen</option>
+                  <option value="full">Voll</option>
+                  <option value="maintenance">Wartung</option>
+                </select>
+                <button
+                  type="button" disabled={delBusy}
+                  aria-label={`Standort ${l.name} löschen`}
+                  onClick={() => deleteLot.mutate(l.id)}
+                  style={{
+                    padding: '4px 10px', borderRadius: 7,
+                    background: 'color-mix(in oklch, var(--v5-err) 8%, transparent)',
+                    border: 'none', fontSize: 10, fontWeight: 500, color: 'var(--v5-err)',
+                    cursor: delBusy ? 'default' : 'pointer', opacity: delBusy ? 0.5 : 1,
+                  }}
+                >{delBusy ? '…' : 'Löschen'}</button>
+              </div>
+            );
+          })}
+        </Card>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Byte-identical mirror of parkhub-php PR [#337](https://github.com/nash87/parkhub-php/pull/337) (merged 2026-04-24). Completes v5 screen-level parity for the rust runtime: every `nav.ts` admin entry now has a real v5 screen; `PlaceholderV5` no longer rendered in production.

**Screens ported (11):** Analytics, Nutzer, Billing, Lobby, Benachrichtigungen, Einstellungen, Standorte, Integrations, Apikeys, Audit, Policies.

## Client extensions

**Methods:** `getAdminStatsExtended`, `getApiKeys`, `createApiKey`, `rotateApiKey`, `revokeApiKey`, `getIntegrations`, `connectIntegration`, `disconnectIntegration`, `getPolicies`, `updatePolicy`, `getLobbyConfig`, `updateLobbyConfig`.

**Types:** `AdminStatsExtended`, `UserBookingStats`, `DayOccupancy`, `ApiKey`, `CreatedApiKey`, `Integration`, `Policy`, `LobbyConfig`, `LobbyScreenKey`.

## Primitives

`Card` now forwards `data-testid` (matches the PHP Wave 3 primitives).

## Backend endpoints

Screens follow the same `ApiResponse` envelope as the PHP repo. The following admin endpoints are **not yet implemented** on the rust backend and will return 404/no-route — screens gracefully render their error states (mirrored PHP behaviour) until server handlers land as a follow-up:

- `GET /api/v1/admin/stats` (extended fields — base endpoint exists, extended aggregates optional)
- `GET / POST / DELETE /api/v1/admin/api-keys[/:id[/rotate]]`
- `GET /api/v1/admin/integrations` + `POST /:id/connect`, `POST /:id/disconnect`
- `GET /api/v1/admin/policies`, `PUT /api/v1/admin/policies/:id`
- `GET / PUT /api/v1/admin/lobby`

Endpoints that **already exist** on the rust backend and are used by the ported screens: `GET /api/v1/admin/users`, `PUT /api/v1/admin/users/:id`, `GET/POST/PUT/DELETE /api/v1/lots`, `GET /api/v1/admin/audit-log`, `GET /api/v1/notifications`, `GET /api/v1/payments/history`, `GET /api/v1/payments/config`, `GET /api/v1/users/me`, `PUT /api/v1/users/me`, `GET/PUT /api/v1/preferences/notifications`.

## Test plan

- [x] `npm test -- --run src/design-v5/screens` — 18/18 files, 132/132 tests pass
- [x] Full `npm test` — 150/150 files, 2274/2274 tests pass
- [x] `astro build` clean (static output, 2 pages)
- [ ] CI passes
- [ ] Render deploy verifies at https://parkhub-rust-demo.onrender.com/

Closes T-1939.