### PR TITLE
fix(v5/admin): unwrap PaginatedResponse so NutzerV5 renders (T-1954)

### DIFF
--- a/parkhub-web/e2e/v5-happy-paths.spec.ts
+++ b/parkhub-web/e2e/v5-happy-paths.spec.ts
@@ -220,11 +220,11 @@ test.describe('v5 happy paths', () => {
     await loginAsAdmin(page);
   });
 
-  // KNOWN_BROKEN: screens whose React tree throws during hydration on
-  // github/main and never emit <header><h1>. Surfaced by this PR; tracked
-  // as a follow-up fix. Tests stay declared (not deleted) so the moment
-  // the screen is repaired the anchor reactivates without a diff here.
-  const KNOWN_BROKEN = new Set<V5Screen>(['nutzer']);
+  // KNOWN_BROKEN: screens whose React tree throws during render on
+  // github/main and never emit <header><h1>. Tests stay declared (not
+  // deleted) so the moment the screen is repaired the anchor reactivates
+  // without a diff here. Empty once all v5 screens render.
+  const KNOWN_BROKEN = new Set<V5Screen>([]);
 
   for (const [screen, anchor] of Object.entries(ANCHORS) as Array<[V5Screen, Anchor]>) {
     test(`${screen} — ${anchor.note}`, async ({ page }) => {

--- a/parkhub-web/src/api/client.ts
+++ b/parkhub-web/src/api/client.ts
@@ -25,6 +25,9 @@ import type { SwapRequestStatus as GeneratedSwapRequestStatus } from '../generat
 import type { AnnouncementSeverity as GeneratedAnnouncementSeverity } from '../generated/types/AnnouncementSeverity';
 import type { VehicleType as GeneratedVehicleType } from '../generated/types/VehicleType';
 import type { FuelType as GeneratedFuelType } from '../generated/types/FuelType';
+import type { PaginatedResponse } from '../generated/types/PaginatedResponse';
+
+export type { PaginatedResponse };
 
 /**
  * Standard API response wrapper.
@@ -394,7 +397,7 @@ export const api = {
 
   // ── Admin ──
   adminStats: () => request<AdminStats>('/api/v1/admin/stats'),
-  adminUsers: () => request<User[]>('/api/v1/admin/users'),
+  adminUsers: () => request<PaginatedResponse<User>>('/api/v1/admin/users'),
   adminUpdateUser: (id: string, data: UpdateUserPayload) => request<User>(`/api/v1/admin/users/${id}`, { method: 'PUT', body: JSON.stringify(data) }),
   adminDeleteUser: (id: string) => request<void>(`/api/v1/admin/users/${id}`, { method: 'DELETE' }),
   adminUpdateUserRole: (id: string, role: string) =>

--- a/parkhub-web/src/design-v5/screens/Nutzer.test.tsx
+++ b/parkhub-web/src/design-v5/screens/Nutzer.test.tsx
@@ -26,6 +26,15 @@ import { NutzerV5 } from './Nutzer';
 const U1 = { id: 'u1', username: 'flo', email: 'flo@e', name: 'Flo', role: 'admin' as const, preferences: {}, is_active: true, credits_balance: 0, credits_monthly_quota: 0 };
 const U2 = { id: 'u2', username: 'anna', email: 'anna@e', name: 'Anna', role: 'user' as const, preferences: {}, is_active: false, credits_balance: 0, credits_monthly_quota: 0 };
 
+// Wire shape matches parkhub-common::protocol::PaginatedResponse<T>.
+const paginated = <T,>(items: T[]) => ({
+  items,
+  page: 1,
+  per_page: 50,
+  total: items.length,
+  total_pages: items.length === 0 ? 0 : 1,
+});
+
 function renderScreen() {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   return render(
@@ -39,7 +48,7 @@ describe('NutzerV5', () => {
   beforeEach(() => vi.clearAllMocks());
 
   it('renders empty state', async () => {
-    mockList.mockResolvedValue({ success: true, data: [] });
+    mockList.mockResolvedValue({ success: true, data: paginated([]) });
     renderScreen();
     await waitFor(() => expect(screen.getByText('Keine Nutzer gefunden')).toBeInTheDocument());
   });
@@ -51,7 +60,7 @@ describe('NutzerV5', () => {
   });
 
   it('renders rows with role and status badges', async () => {
-    mockList.mockResolvedValue({ success: true, data: [U1, U2] });
+    mockList.mockResolvedValue({ success: true, data: paginated([U1, U2]) });
     renderScreen();
     await waitFor(() => expect(screen.getAllByTestId('nutzer-row')).toHaveLength(2));
     expect(screen.getByText('Flo')).toBeInTheDocument();
@@ -60,7 +69,7 @@ describe('NutzerV5', () => {
   });
 
   it('filters to admins', async () => {
-    mockList.mockResolvedValue({ success: true, data: [U1, U2] });
+    mockList.mockResolvedValue({ success: true, data: paginated([U1, U2]) });
     renderScreen();
     await waitFor(() => expect(screen.getAllByTestId('nutzer-row')).toHaveLength(2));
     fireEvent.click(screen.getByRole('button', { name: 'Admins' }));
@@ -68,7 +77,7 @@ describe('NutzerV5', () => {
   });
 
   it('suspend button calls update with is_active:false', async () => {
-    mockList.mockResolvedValue({ success: true, data: [U1] });
+    mockList.mockResolvedValue({ success: true, data: paginated([U1]) });
     mockUpdate.mockResolvedValue({ success: true, data: { ...U1, is_active: false } });
     renderScreen();
     await waitFor(() => expect(screen.getByText('Sperren')).toBeInTheDocument());
@@ -80,7 +89,7 @@ describe('NutzerV5', () => {
   });
 
   it('activate mutation error surfaces via toast', async () => {
-    mockList.mockResolvedValue({ success: true, data: [U2] });
+    mockList.mockResolvedValue({ success: true, data: paginated([U2]) });
     mockUpdate.mockResolvedValue({ success: false, data: null, error: { code: 'X', message: 'nope' } });
     renderScreen();
     await waitFor(() => expect(screen.getByText('Aktivieren')).toBeInTheDocument());
@@ -89,7 +98,7 @@ describe('NutzerV5', () => {
   });
 
   it('search filters by name', async () => {
-    mockList.mockResolvedValue({ success: true, data: [U1, U2] });
+    mockList.mockResolvedValue({ success: true, data: paginated([U1, U2]) });
     renderScreen();
     await waitFor(() => expect(screen.getAllByTestId('nutzer-row')).toHaveLength(2));
     fireEvent.change(screen.getByTestId('nutzer-search'), { target: { value: 'anna' } });

--- a/parkhub-web/src/design-v5/screens/Nutzer.tsx
+++ b/parkhub-web/src/design-v5/screens/Nutzer.tsx
@@ -35,7 +35,7 @@ export function NutzerV5({ navigate: _navigate }: { navigate: (id: ScreenId) => 
     queryFn: async () => {
       const res = await api.adminUsers();
       if (!res.success) throw new Error(res.error?.message ?? 'Nutzer konnten nicht geladen werden');
-      return res.data ?? [];
+      return res.data?.items ?? [];
     },
     staleTime: 30_000,
   });

--- a/parkhub-web/src/views/AdminUsers.test.tsx
+++ b/parkhub-web/src/views/AdminUsers.test.tsx
@@ -138,10 +138,19 @@ const sampleUsers = [
   { id: 'u-2', name: 'Bob', email: 'bob@test.com', role: 'user', credits_balance: 3, credits_monthly_quota: 5, is_active: false },
 ];
 
+// Wire shape matches parkhub-common::protocol::PaginatedResponse<T>.
+const paginated = <T,>(items: T[]) => ({
+  items,
+  page: 1,
+  per_page: 50,
+  total: items.length,
+  total_pages: items.length === 0 ? 0 : 1,
+});
+
 describe('AdminUsersPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockAdminUsers.mockResolvedValue({ success: true, data: sampleUsers });
+    mockAdminUsers.mockResolvedValue({ success: true, data: paginated(sampleUsers) });
   });
 
   afterEach(() => {
@@ -389,10 +398,10 @@ describe('AdminUsersPage', () => {
   it('shows role badges with correct text', async () => {
     mockAdminUsers.mockResolvedValue({
       success: true,
-      data: [
+      data: paginated([
         { id: 'u-3', name: 'Super', email: 's@test.com', role: 'superadmin', credits_balance: 0, credits_monthly_quota: 5, is_active: true },
         ...sampleUsers,
-      ],
+      ]),
     });
     render(<AdminUsersPage />);
     await waitFor(() => {
@@ -586,7 +595,7 @@ describe('AdminUsersPage', () => {
   });
 
   it('shows empty state with no search when no users', async () => {
-    mockAdminUsers.mockResolvedValue({ success: true, data: [] });
+    mockAdminUsers.mockResolvedValue({ success: true, data: paginated([]) });
     render(<AdminUsersPage />);
     await waitFor(() => {
       expect(screen.getByText('No users found.')).toBeInTheDocument();

--- a/parkhub-web/src/views/AdminUsers.tsx
+++ b/parkhub-web/src/views/AdminUsers.tsx
@@ -49,7 +49,7 @@ export function AdminUsersPage() {
   async function loadUsers() {
     try {
       const res = await api.adminUsers();
-      if (res.success && res.data) setUsers(res.data);
+      if (res.success && res.data) setUsers(res.data.items);
     } finally {
       setLoading(false);
     }


### PR DESCRIPTION
## Summary
- NutzerV5 crashed in production with `h.filter is not a function` (minified form of `users.filter(...)`).
- Root cause: TS client declared `adminUsers: () => request<User[]>` but the Rust handler returns `ApiResponse<PaginatedResponse<User>>` — a `{items, page, per_page, total, total_pages}` object, not an array.
- Aligned the client signature + both consumers (Nutzer.tsx v5, AdminUsers.tsx legacy) + test mocks, flipped the E2E `KNOWN_BROKEN` anchor so the live screen is covered again.

## Why the bug slipped through
Vitest mocks returned `{ success: true, data: [...] }` (array), which hid the drift. Added a `paginated()` helper in both test files so mocks now match the real wire shape — future drift fails tests rather than hiding.

## Framing correction
The original ticket called this a hydration mismatch. It isn't: `v5.astro` is `output: 'static'` + client-only `createRoot`. The crash is a pure runtime render error after the useQuery promise resolves. Updated the `KNOWN_BROKEN` comment in `v5-happy-paths.spec.ts` accordingly.

## Test plan
- [x] `vitest run src/design-v5/screens/Nutzer.test.tsx src/views/AdminUsers.test.tsx` — 55 tests pass.
- [x] Full `vitest run` — only pre-existing T-1947 uPlot/Analytics failures remain (unrelated; they fail on main too).
- [ ] Playwright v5-happy-paths `nutzer — page header` re-arms once this lands (no longer in `KNOWN_BROKEN`).
- [ ] Manual smoke: log in as admin, visit `/v5` → Nutzer, confirm the table renders, filters work, search filters by name.

## Files
- `parkhub-web/src/api/client.ts` — type + re-export of `PaginatedResponse`.
- `parkhub-web/src/design-v5/screens/Nutzer.tsx` — `res.data?.items ?? []`.
- `parkhub-web/src/views/AdminUsers.tsx` — `res.data.items`.
- `parkhub-web/src/design-v5/screens/Nutzer.test.tsx` — paginated mocks.
- `parkhub-web/src/views/AdminUsers.test.tsx` — paginated mocks.
- `parkhub-web/e2e/v5-happy-paths.spec.ts` — empty `KNOWN_BROKEN` set.

## Follow-ups (out of scope)
- `parkhub-common` should emit a generated `AdminUsersList` / `PaginatedResponse<User>` DTO via ts-rs so the client import can replace the hand-written `User[]` shape entirely (T-1941 follow-up).