### PR TITLE
feat(v5): Tier-1 2026 UX quick-wins (T-1977)

### DIFF
--- a/parkhub-web/package-lock.json
+++ b/parkhub-web/package-lock.json
@@ -28,6 +28,7 @@
         "i18next": "^26.0.3",
         "i18next-browser-languagedetector": "^8.2.1",
         "leaflet": "^1.9.4",
+        "qrcode.react": "^4.2.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "react-hook-form": "^7.72.1",
@@ -7447,6 +7448,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/qrcode.react": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/qrcode.react/-/qrcode.react-4.2.0.tgz",
+      "integrity": "sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/radix3": {

--- a/parkhub-web/package.json
+++ b/parkhub-web/package.json
@@ -45,6 +45,7 @@
     "i18next": "^26.0.3",
     "i18next-browser-languagedetector": "^8.2.1",
     "leaflet": "^1.9.4",
+    "qrcode.react": "^4.2.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "react-hook-form": "^7.72.1",

--- a/parkhub-web/src/design-v5/App.test.tsx
+++ b/parkhub-web/src/design-v5/App.test.tsx
@@ -3,9 +3,12 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 /**
- * All 26 navigation entries ship as real v5 screens — the PlaceholderV5
- * fallback component and its import are dead code. This guard keeps it
- * that way so we don't silently reintroduce a placeholder path.
+ * Static guards over `App.tsx`.
+ *
+ *  - All 26 navigation entries ship as real v5 screens; PlaceholderV5 is
+ *    retired (#383) so its import + file must not come back.
+ *  - URL-based deep-linking + View Transitions + keyboard-shortcut hook
+ *    must stay wired into the shell (Tier-1 UX #386).
  */
 describe('design-v5/App', () => {
   const appSrc = fs.readFileSync(
@@ -20,5 +23,21 @@ describe('design-v5/App', () => {
   it('has no Placeholder screen file on disk', () => {
     const placeholderPath = path.resolve(__dirname, './screens/Placeholder.tsx');
     expect(fs.existsSync(placeholderPath)).toBe(false);
+  });
+
+  it('imports startViewTransition for cross-screen fades', () => {
+    expect(appSrc).toMatch(/from '\.\/viewTransitions'/);
+    expect(appSrc).toMatch(/startViewTransition\(/);
+  });
+
+  it('wires deep-link hooks so /v5/<id> round-trips', () => {
+    expect(appSrc).toMatch(/from '\.\/useDeepLink'/);
+    expect(appSrc).toMatch(/useSyncScreenToUrl/);
+    expect(appSrc).toMatch(/readScreenFromUrl/);
+  });
+
+  it('wires the shared keyboard-shortcut hook', () => {
+    expect(appSrc).toMatch(/from '\.\/useKeyboardShortcuts'/);
+    expect(appSrc).toMatch(/useKeyboardShortcuts\(/);
   });
 });

--- a/parkhub-web/src/design-v5/App.tsx
+++ b/parkhub-web/src/design-v5/App.tsx
@@ -33,6 +33,9 @@ import { IntegrationsV5 } from './screens/Integrations';
 import { ApikeysV5 } from './screens/Apikeys';
 import { AuditV5 } from './screens/Audit';
 import { PoliciesV5 } from './screens/Policies';
+import { startViewTransition } from './viewTransitions';
+import { readScreenFromUrl, useSyncScreenToUrl } from './useDeepLink';
+import { useKeyboardShortcuts } from './useKeyboardShortcuts';
 
 import './fonts';
 import './tokens.css';
@@ -92,10 +95,14 @@ function makeQueryClient() {
 }
 
 function V5Shell() {
+  // URL is source of truth; localStorage is a back-compat cache for users
+  // who load `/v5` bare. Priority: URL → localStorage → default.
   const [screen, setScreen] = useState<ScreenId>(() => {
     if (typeof window === 'undefined') return DEFAULT_SCREEN;
     const stored = window.localStorage.getItem(STORAGE_KEY) as ScreenId | null;
-    return stored && byId.has(stored) ? stored : DEFAULT_SCREEN;
+    const storedFallback: ScreenId =
+      stored && byId.has(stored) ? stored : DEFAULT_SCREEN;
+    return readScreenFromUrl(storedFallback);
   });
   const [cmdOpen, setCmdOpen] = useState(false);
   const [aiOpen, setAiOpen] = useState(false);
@@ -104,27 +111,46 @@ function V5Shell() {
     window.localStorage.setItem(STORAGE_KEY, screen);
   }, [screen]);
 
-  // Keyboard shortcuts: ⌘K / Ctrl+K for palette, ? for AI panel.
+  // Keep browser URL + localStorage in lockstep with the in-memory screen,
+  // and restore screen state on back/forward.
+  useSyncScreenToUrl(screen, setScreen);
+
+  // Legacy shortcuts kept in a raw listener so Ctrl+K can intercept
+  // browser default. The new per-screen shortcut hook covers single-key
+  // bindings (n, /, Escape, ?) with input-focus safeguards.
   useEffect(() => {
     const h = (e: KeyboardEvent) => {
       const mod = e.metaKey || e.ctrlKey;
       if (mod && e.key.toLowerCase() === 'k') {
         e.preventDefault();
         setCmdOpen((o) => !o);
-        return;
-      }
-      // Don't steal ? while the user is typing in a form
-      if (e.key === '?' && !(e.target instanceof HTMLInputElement) && !(e.target instanceof HTMLTextAreaElement) && !(e.target instanceof HTMLSelectElement)) {
-        setAiOpen((o) => !o);
       }
     };
     window.addEventListener('keydown', h);
     return () => window.removeEventListener('keydown', h);
   }, []);
 
+  // Global single-key shortcuts (opt-in per screen via future hook calls).
+  useKeyboardShortcuts({
+    '?': () => setAiOpen((o) => !o),
+    '/': (e) => {
+      e.preventDefault();
+      setCmdOpen(true);
+    },
+    Escape: () => {
+      setCmdOpen(false);
+      setAiOpen(false);
+    },
+  });
+
   const navigate = useCallback((id: ScreenId) => {
-    setScreen(id);
-    setCmdOpen(false);
+    // Wrap the state update in a View Transition so the browser
+    // cross-fades the old and new screen. Gracefully no-ops on
+    // Safari <18 / Firefox and under prefers-reduced-motion.
+    startViewTransition(() => {
+      setScreen(id);
+      setCmdOpen(false);
+    });
   }, []);
 
   const meta = byId.get(screen);

--- a/parkhub-web/src/design-v5/lastUsed.test.ts
+++ b/parkhub-web/src/design-v5/lastUsed.test.ts
@@ -1,0 +1,28 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { readLastUsed, writeLastUsed } from './lastUsed';
+
+describe('lastUsed', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('returns null when no value has been stored yet', () => {
+    expect(readLastUsed('lot')).toBeNull();
+  });
+
+  it('round-trips a value through the namespaced key', () => {
+    writeLastUsed('lot', 'lot-42');
+    expect(readLastUsed('lot')).toBe('lot-42');
+    // Stored under the ph-v5-last: prefix so it's debuggable in devtools
+    expect(window.localStorage.getItem('ph-v5-last:lot')).toBe('lot-42');
+  });
+
+  it('clears the key when writing null or empty string', () => {
+    writeLastUsed('lot', 'lot-42');
+    writeLastUsed('lot', null);
+    expect(readLastUsed('lot')).toBeNull();
+    writeLastUsed('lot', 'lot-42');
+    writeLastUsed('lot', '');
+    expect(readLastUsed('lot')).toBeNull();
+  });
+});

--- a/parkhub-web/src/design-v5/lastUsed.ts
+++ b/parkhub-web/src/design-v5/lastUsed.ts
@@ -1,0 +1,42 @@
+/**
+ * Tiny localStorage-backed "last-used value" helper.
+ *
+ * Centralises the repeated pattern of
+ *
+ *   useState(() => window.localStorage.getItem(KEY) ?? '')
+ *   useEffect(() => window.localStorage.setItem(KEY, value), [value])
+ *
+ * into `readLastUsed(key)` / `writeLastUsed(key, value)`.
+ *
+ * Why we do this: screens like Buchen and Fahrzeuge want to
+ * pre-select the lot and vehicle the user picked last time.
+ * Admin screens want to resume on the last tab they opened.
+ * All of this lives under the `ph-v5-` key namespace so we
+ * don't clash with other apps on the same origin.
+ */
+
+const NAMESPACE = 'ph-v5-last:';
+
+export function readLastUsed(key: string): string | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    return window.localStorage.getItem(`${NAMESPACE}${key}`);
+  } catch {
+    return null;
+  }
+}
+
+export function writeLastUsed(key: string, value: string | null | undefined): void {
+  if (typeof window === 'undefined') return;
+  try {
+    const full = `${NAMESPACE}${key}`;
+    if (value == null || value === '') {
+      window.localStorage.removeItem(full);
+    } else {
+      window.localStorage.setItem(full, value);
+    }
+  } catch {
+    // Private-mode / quota errors are non-fatal — smart defaults
+    // are a UX nicety, not a correctness requirement.
+  }
+}

--- a/parkhub-web/src/design-v5/screens/Buchen.test.tsx
+++ b/parkhub-web/src/design-v5/screens/Buchen.test.tsx
@@ -71,6 +71,10 @@ const SLOT_OCCUPIED = { id: 's-3', lot_id: 'lot-1', slot_number: 'A03', status: 
 describe('BuchenV5', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Smart defaults persist last-used lot + vehicle in localStorage.
+    // Clear between tests so the auto-advance to Step 2 doesn't leak
+    // between tests that need to start on the lot picker (Step 1).
+    window.localStorage.clear();
     mockGetVehicles.mockResolvedValue({ success: true, data: [] });
   });
 

--- a/parkhub-web/src/design-v5/screens/Buchen.test.tsx
+++ b/parkhub-web/src/design-v5/screens/Buchen.test.tsx
@@ -213,6 +213,82 @@ describe('BuchenV5', () => {
     expect(new Date(payload.end_time).valueOf()).not.toBeNaN();
   });
 
+  it('clears stale persisted vehicle id when it no longer matches the loaded vehicles list', async () => {
+    // Regression: useState(() => readLastUsed('buchen:vehicle')) can hold a
+    // vehicle id that was since deleted server-side. Reconcile it against
+    // the vehicles query result, and clear when no match is found, so we
+    // never submit a stale vehicle_id to createBooking.
+    window.localStorage.setItem('ph-v5-last:buchen:vehicle', 'ghost-vehicle-999');
+
+    mockGetLots.mockResolvedValue({ success: true, data: [LOT_OPEN] });
+    mockGetLotSlots.mockResolvedValue({ success: true, data: [SLOT_A] });
+    mockGetVehicles.mockResolvedValue({
+      success: true,
+      data: [{ id: 'v-1', plate: 'B-AA-1', make: 'VW' }],
+    });
+    mockCreateBooking.mockResolvedValue({ success: true, data: { id: 'b-new' } });
+    renderScreen();
+
+    await waitFor(() => expect(screen.getByText('Parkhaus Nord')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('buchen-lot-card'));
+    await waitFor(() => expect(screen.getByTestId('buchen-slot')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('buchen-slot'));
+
+    // The Fahrzeug <select> must reflect the cleared state — not the stale
+    // ghost id — once the vehicles query resolves.
+    const vehicleSelect = document.getElementById('buchen-vehicle') as HTMLSelectElement;
+    await waitFor(() => expect(vehicleSelect).toBeTruthy());
+    await waitFor(() => expect(vehicleSelect.value).toBe(''));
+
+    fireEvent.click(screen.getByRole('button', { name: /Weiter/ }));
+    await waitFor(() => expect(screen.getByTestId('buchen-confirm')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('buchen-confirm'));
+
+    await waitFor(() => expect(mockCreateBooking).toHaveBeenCalledTimes(1));
+    const payload = mockCreateBooking.mock.calls[0][0];
+    expect(payload.vehicle_id).toBeUndefined();
+  });
+
+  it('does not leave a phantom booking in cache when createBooking fails and ["buchungen"] was never fetched', async () => {
+    // Regression: onMutate inserts an optimistic booking even when
+    // queryClient.getQueryData(['buchungen']) is undefined. onError only
+    // restores when ctx.previous is truthy, so a first-time failure leaves
+    // a phantom optimistic row cached until a later refetch replaces it.
+    // Fix: skip the optimistic insert when no prior cache exists; the cache
+    // must remain undefined after the failure.
+    mockGetLots.mockResolvedValue({ success: true, data: [LOT_OPEN] });
+    mockGetLotSlots.mockResolvedValue({ success: true, data: [SLOT_A] });
+    mockCreateBooking.mockRejectedValue(new Error('boom'));
+
+    // Capture the QueryClient so we can assert its cache state after failure.
+    let captured: QueryClient | null = null;
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    captured = qc;
+    render(
+      <QueryClientProvider client={qc}>
+        <BuchenV5 navigate={vi.fn()} />
+      </QueryClientProvider>
+    );
+
+    await waitFor(() => expect(screen.getByText('Parkhaus Nord')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('buchen-lot-card'));
+    await waitFor(() => expect(screen.getByTestId('buchen-slot')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('buchen-slot'));
+    fireEvent.click(screen.getByRole('button', { name: /Weiter/ }));
+    await waitFor(() => expect(screen.getByTestId('buchen-confirm')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('buchen-confirm'));
+
+    await waitFor(() => expect(mockToast).toHaveBeenCalledWith('boom', 'error'));
+
+    // Cache must either be undefined (never fetched) or empty — NOT contain
+    // the phantom optimistic row.
+    const bookings = captured!.getQueryData(['buchungen']);
+    if (bookings !== undefined) {
+      expect(Array.isArray(bookings)).toBe(true);
+      expect((bookings as unknown[]).length).toBe(0);
+    }
+  });
+
   it('calls onError (no success toast) when createBooking responds success:false with INSUFFICIENT_CREDITS', async () => {
     mockGetLots.mockResolvedValue({ success: true, data: [LOT_OPEN] });
     mockGetLotSlots.mockResolvedValue({ success: true, data: [SLOT_A] });

--- a/parkhub-web/src/design-v5/screens/Buchen.tsx
+++ b/parkhub-web/src/design-v5/screens/Buchen.tsx
@@ -120,6 +120,20 @@ export function BuchenV5({ navigate }: { navigate: (id: ScreenId) => void }) {
   const lots = useMemo(() => (lotsResp ?? []).filter((l) => l.status === 'open'), [lotsResp]);
   const vehicles: Vehicle[] = vehiclesResp ?? [];
 
+  // Reconcile persisted vehicle id against the freshly loaded vehicles.
+  // A stale id left over in localStorage (the vehicle was deleted or is
+  // no longer returned by getVehicles) would otherwise silently end up
+  // on the createBooking payload even though the <select> shows nothing
+  // selected — causing confusing server-side booking failures. Clear
+  // once the vehicles query has resolved and the id doesn't match.
+  useEffect(() => {
+    if (vehiclesResp === undefined) return; // query still loading
+    if (!selectedVehicle) return;
+    if (vehicles.some((v) => v.id === selectedVehicle)) return;
+    setSelectedVehicle('');
+    writeLastUsed('buchen:vehicle', null);
+  }, [vehiclesResp, vehicles, selectedVehicle]);
+
   // Smart default: auto-advance to Step 2 if the user's last-used lot is
   // still open. Silent no-op when the lot has been removed / closed /
   // no prior selection exists. Only fires once (step === 1 guard) so
@@ -167,6 +181,16 @@ export function BuchenV5({ navigate }: { navigate: (id: ScreenId) => void }) {
     onMutate: async (payload: CreateBookingPayload) => {
       await qc.cancelQueries({ queryKey: ['buchungen'] });
       const previous = qc.getQueryData<Booking[]>(['buchungen']);
+      // Only insert the optimistic row when the list was already
+      // fetched. When `previous` is undefined (the user hasn't opened
+      // Buchungen yet), skipping the optimistic write avoids leaving
+      // a phantom row in cache on failure — onError can only restore
+      // `previous`, so a seeded `undefined` -> `[optimistic]` path
+      // would survive the rollback. onSettled's invalidate covers the
+      // refetch once Buchungen is opened.
+      if (previous === undefined) {
+        return { previous };
+      }
       const optimistic: Booking = {
         id: `optimistic-${Date.now()}`,
         user_id: '',
@@ -178,7 +202,7 @@ export function BuchenV5({ navigate }: { navigate: (id: ScreenId) => void }) {
         end_time: payload.end_time,
         status: 'confirmed',
       };
-      qc.setQueryData<Booking[]>(['buchungen'], [optimistic, ...(previous ?? [])]);
+      qc.setQueryData<Booking[]>(['buchungen'], [optimistic, ...previous]);
       return { previous };
     },
     onSuccess: (_data, payload) => {
@@ -190,7 +214,11 @@ export function BuchenV5({ navigate }: { navigate: (id: ScreenId) => void }) {
       navigate('buchungen');
     },
     onError: (err: Error, _payload, ctx) => {
-      if (ctx?.previous) qc.setQueryData(['buchungen'], ctx.previous);
+      // Always restore to the snapshot we took in onMutate — including
+      // the `undefined` case. Explicitly writing undefined to the cache
+      // is a no-op for cache that was never seeded, and wipes any
+      // optimistic row we set when prior data did exist.
+      qc.setQueryData(['buchungen'], ctx?.previous);
       toast(err.message || 'Buchung fehlgeschlagen', 'error');
     },
     onSettled: () => {

--- a/parkhub-web/src/design-v5/screens/Buchen.tsx
+++ b/parkhub-web/src/design-v5/screens/Buchen.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState, type CSSProperties, type ReactNode } from 'react';
+import { useEffect, useMemo, useState, type CSSProperties, type ReactNode } from 'react';
 import NumberFlow from '@number-flow/react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { Badge, Card, SectionLabel, V5NamedIcon } from '../primitives';
@@ -11,6 +11,7 @@ import {
   type CreateBookingPayload,
 } from '../../api/client';
 import type { ScreenId } from '../nav';
+import { readLastUsed, writeLastUsed } from '../lastUsed';
 
 type Step = 1 | 2 | 3;
 
@@ -56,7 +57,7 @@ function defaultStart(): string {
  * A `datetime-local` input can be cleared to an empty string, and
  * `new Date("").toISOString()` throws `RangeError: Invalid time value`.
  * Guard the confirm path so the mutation is never called with an
- * unparseable value (silent-fail bug surfaced by Codex on PR #373).
+ * unparseable value (silent-fail bug surfaced by Codex on parkhub-rust PR #373).
  */
 function isValidDt(s: string | undefined | null): s is string {
   if (!s) return false;
@@ -81,7 +82,12 @@ export function BuchenV5({ navigate }: { navigate: (id: ScreenId) => void }) {
   const [step, setStep] = useState<Step>(1);
   const [selectedLot, setSelectedLot] = useState<ParkingLot | null>(null);
   const [selectedSlot, setSelectedSlot] = useState<ParkingSlot | null>(null);
-  const [selectedVehicle, setSelectedVehicle] = useState<string>('');
+  // Smart default: pre-fill the vehicle the user last booked with. The
+  // lot pre-select happens further down once the lots query resolves
+  // (we can't construct the ParkingLot object from an id alone).
+  const [selectedVehicle, setSelectedVehicle] = useState<string>(
+    () => readLastUsed('buchen:vehicle') ?? '',
+  );
   const [startDate, setStartDate] = useState<string>(defaultStart);
   const [duration, setDuration] = useState<number>(2);
 
@@ -114,6 +120,22 @@ export function BuchenV5({ navigate }: { navigate: (id: ScreenId) => void }) {
   const lots = useMemo(() => (lotsResp ?? []).filter((l) => l.status === 'open'), [lotsResp]);
   const vehicles: Vehicle[] = vehiclesResp ?? [];
 
+  // Smart default: auto-advance to Step 2 if the user's last-used lot is
+  // still open. Silent no-op when the lot has been removed / closed /
+  // no prior selection exists. Only fires once (step === 1 guard) so
+  // hitting "← Zurück" doesn't bounce the user forward again.
+  useEffect(() => {
+    if (step !== 1) return;
+    if (selectedLot) return;
+    if (lots.length === 0) return;
+    const lastLotId = readLastUsed('buchen:lot');
+    if (!lastLotId) return;
+    const match = lots.find((l) => l.id === lastLotId);
+    if (!match) return;
+    setSelectedLot(match);
+    setStep(2);
+  }, [lots, step, selectedLot]);
+
   const { data: slotsResp, isLoading: slotsLoading } = useQuery({
     queryKey: ['buchen-slots', selectedLot?.id],
     enabled: !!selectedLot,
@@ -126,6 +148,11 @@ export function BuchenV5({ navigate }: { navigate: (id: ScreenId) => void }) {
   });
   const slots = slotsResp ?? [];
 
+  // Optimistic create: insert a pending placeholder into the bookings
+  // cache as soon as the user taps "Buchung bestätigen" so the list on
+  // /buchungen already shows the new row when we navigate there. The
+  // server response replaces the placeholder on invalidation; onError
+  // rolls back.
   const createMutation = useMutation({
     mutationFn: async (payload: CreateBookingPayload) => {
       const res = await api.createBooking(payload);
@@ -137,12 +164,38 @@ export function BuchenV5({ navigate }: { navigate: (id: ScreenId) => void }) {
       }
       return res.data;
     },
-    onSuccess: () => {
-      qc.invalidateQueries({ queryKey: ['buchungen'] });
+    onMutate: async (payload: CreateBookingPayload) => {
+      await qc.cancelQueries({ queryKey: ['buchungen'] });
+      const previous = qc.getQueryData<Booking[]>(['buchungen']);
+      const optimistic: Booking = {
+        id: `optimistic-${Date.now()}`,
+        user_id: '',
+        lot_id: payload.lot_id,
+        slot_id: payload.slot_id,
+        lot_name: selectedLot?.name ?? '',
+        slot_number: selectedSlot?.slot_number ?? '',
+        start_time: payload.start_time,
+        end_time: payload.end_time,
+        status: 'confirmed',
+      };
+      qc.setQueryData<Booking[]>(['buchungen'], [optimistic, ...(previous ?? [])]);
+      return { previous };
+    },
+    onSuccess: (_data, payload) => {
+      // Persist smart defaults only on confirmed success — we don't
+      // want to pre-select a lot the server rejected.
+      writeLastUsed('buchen:lot', payload.lot_id);
+      if (payload.vehicle_id) writeLastUsed('buchen:vehicle', payload.vehicle_id);
       toast('Buchung bestätigt', 'success');
       navigate('buchungen');
     },
-    onError: (err: Error) => toast(err.message || 'Buchung fehlgeschlagen', 'error'),
+    onError: (err: Error, _payload, ctx) => {
+      if (ctx?.previous) qc.setQueryData(['buchungen'], ctx.previous);
+      toast(err.message || 'Buchung fehlgeschlagen', 'error');
+    },
+    onSettled: () => {
+      qc.invalidateQueries({ queryKey: ['buchungen'] });
+    },
   });
 
   if (lotsLoading) {

--- a/parkhub-web/src/design-v5/screens/Buchungen.tsx
+++ b/parkhub-web/src/design-v5/screens/Buchungen.tsx
@@ -62,17 +62,36 @@ export function BuchungenV5({ navigate }: { navigate: (id: ScreenId) => void }) 
     refetchOnWindowFocus: true,
   });
 
+  // Optimistic cancel: flip the booking to `cancelled` in the cache before
+  // the network round-trip completes so the badge + filter counts update
+  // instantly. If the server rejects, restore the pre-mutation snapshot.
   const cancelMutation = useMutation({
     mutationFn: async (id: string) => {
       const res = await api.cancelBooking(id);
       if (!res.success) throw new Error(res.error?.message ?? 'Stornierung fehlgeschlagen');
       return res.data;
     },
+    onMutate: async (id: string) => {
+      await qc.cancelQueries({ queryKey: ['buchungen'] });
+      const previous = qc.getQueryData<Booking[]>(['buchungen']);
+      if (previous) {
+        qc.setQueryData<Booking[]>(
+          ['buchungen'],
+          previous.map((b) => (b.id === id ? { ...b, status: 'cancelled' } : b)),
+        );
+      }
+      return { previous };
+    },
+    onError: (_err, _id, ctx) => {
+      if (ctx?.previous) qc.setQueryData(['buchungen'], ctx.previous);
+      toast('Stornierung fehlgeschlagen', 'error');
+    },
     onSuccess: () => {
-      qc.invalidateQueries({ queryKey: ['buchungen'] });
       toast('Buchung storniert', 'success');
     },
-    onError: () => toast('Stornierung fehlgeschlagen', 'error'),
+    onSettled: () => {
+      qc.invalidateQueries({ queryKey: ['buchungen'] });
+    },
   });
 
   const filtered = filter === 'alle' ? bookings : bookings.filter((b) => b.status === filter);

--- a/parkhub-web/src/design-v5/screens/Einchecken.test.tsx
+++ b/parkhub-web/src/design-v5/screens/Einchecken.test.tsx
@@ -147,4 +147,31 @@ describe('EincheckenV5', () => {
     const allKeys = Object.values(opts.invalidate).flat() as unknown[][];
     expect(allKeys.some((k) => k?.[0] === 'einchecken-bookings')).toBe(true);
   });
+
+  it('renders a QR code with the parkhub://check-in/<id> deep-link on the ready card', async () => {
+    mockGetBookings.mockResolvedValue({ success: true, data: [activeBooking()] });
+    mockGetStatus.mockResolvedValue({
+      success: true,
+      data: { checked_in: false, checked_in_at: null, checked_out_at: null },
+    });
+    renderScreen();
+    const holder = await waitFor(() => screen.getByTestId('checkin-qr'));
+    // qrcode.react renders an <svg role="img"> labelled by our aria-label.
+    const svg = holder.querySelector('svg');
+    expect(svg).toBeTruthy();
+    expect(svg?.getAttribute('aria-label')).toBe('QR-Code für Buchung b1');
+    // Manual fallback button is still reachable.
+    expect(screen.getByTestId('checkin-btn')).toHaveTextContent('Manuell einchecken');
+  });
+
+  it('does not render the QR card once the user has checked in', async () => {
+    mockGetBookings.mockResolvedValue({ success: true, data: [activeBooking()] });
+    mockGetStatus.mockResolvedValue({
+      success: true,
+      data: { checked_in: true, checked_in_at: new Date().toISOString(), checked_out_at: null },
+    });
+    renderScreen();
+    await waitFor(() => expect(screen.getByTestId('checked-in-card')).toBeInTheDocument());
+    expect(screen.queryByTestId('checkin-qr')).not.toBeInTheDocument();
+  });
 });

--- a/parkhub-web/src/design-v5/screens/Einchecken.tsx
+++ b/parkhub-web/src/design-v5/screens/Einchecken.tsx
@@ -1,10 +1,22 @@
 import { useEffect, useMemo, useState } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { QRCodeSVG } from 'qrcode.react';
 import { Badge, Card, V5NamedIcon } from '../primitives';
 import { useV5Toast } from '../Toast';
 import { api, type Booking } from '../../api/client';
 import type { ScreenId } from '../nav';
 import { useFleetEvents } from '../../hooks/useFleetEvents';
+
+/**
+ * Deep-link schema the terminal/kiosk app reads via camera scan.
+ * `parkhub://check-in/<booking-id>` is parsed by the paired native
+ * app (or any QR-reader that recognises the custom scheme). We keep
+ * it stable as a public contract — don't rename without rolling out
+ * a terminal firmware update.
+ */
+function checkInDeepLink(bookingId: string): string {
+  return `parkhub://check-in/${bookingId}`;
+}
 
 function formatDate(iso: string): string {
   return new Date(iso).toLocaleDateString('de-DE', { day: '2-digit', month: '2-digit', year: 'numeric' });
@@ -230,12 +242,38 @@ export function EincheckenV5({ navigate }: { navigate: (id: ScreenId) => void })
         </Card>
       ) : (
         <Card className="v5-ani" style={{ padding: 18, animationDelay: '0.12s', textAlign: 'center' }} data-testid="checkin-card">
-          <V5NamedIcon name="check" size={36} color="var(--v5-acc)" />
-          <div style={{ marginTop: 8, fontSize: 13, fontWeight: 600, color: 'var(--v5-txt)' }}>
+          <div style={{ display: 'flex', justifyContent: 'center' }}>
+            <div
+              data-testid="checkin-qr"
+              style={{
+                padding: 12,
+                borderRadius: 12,
+                background: 'var(--v5-sur)',
+                border: '1px solid var(--v5-bor)',
+                boxShadow: 'var(--v5-shadow-card)',
+                display: 'inline-flex',
+              }}
+            >
+              <QRCodeSVG
+                value={checkInDeepLink(activeBooking.id)}
+                size={240}
+                level="M"
+                marginSize={0}
+                // SVG renderer: scales crisply on retina and avoids the
+                // jsdom `getContext` warnings we'd get from <canvas>.
+                // Hex values only — qrcode.react does not resolve CSS
+                // custom properties (v5 tokens like var(--v5-txt)).
+                fgColor="#0f1013"
+                bgColor="#ffffff"
+                aria-label={`QR-Code für Buchung ${activeBooking.id}`}
+              />
+            </div>
+          </div>
+          <div style={{ marginTop: 12, fontSize: 13, fontWeight: 600, color: 'var(--v5-txt)' }}>
             Bereit zum Einchecken
           </div>
           <div style={{ fontSize: 11, color: 'var(--v5-mut)', marginTop: 4 }}>
-            Scannen Sie den QR-Code am Stellplatz oder tippen Sie auf Einchecken.
+            Scannen Sie mit der Terminal-App zum Einchecken oder tippen Sie unten auf Manuell einchecken.
           </div>
           <button
             type="button"
@@ -256,7 +294,7 @@ export function EincheckenV5({ navigate }: { navigate: (id: ScreenId) => void })
             }}
             data-testid="checkin-btn"
           >
-            {checkInMutation.isPending ? 'Einchecken…' : 'Einchecken'}
+            {checkInMutation.isPending ? 'Einchecken…' : 'Manuell einchecken'}
           </button>
         </Card>
       )}

--- a/parkhub-web/src/design-v5/screens/Fahrzeuge.test.tsx
+++ b/parkhub-web/src/design-v5/screens/Fahrzeuge.test.tsx
@@ -140,4 +140,31 @@ describe('FahrzeugeV5', () => {
     });
     expect(mockToast).not.toHaveBeenCalledWith('Fahrzeug entfernt', 'success');
   });
+
+  it('optimistically removes the vehicle card before deleteVehicle resolves', async () => {
+    mockGetVehicles.mockResolvedValue({ success: true, data: [VEHICLE_BMW, VEHICLE_EV] });
+    let resolveDelete: (v: unknown) => void = () => {};
+    mockDeleteVehicle.mockImplementation(
+      () => new Promise((resolve) => { resolveDelete = resolve; }),
+    );
+    renderScreen();
+    await waitFor(() => screen.getByText('M-AB 123'));
+    expect(screen.getAllByTestId('fahrzeug-card')).toHaveLength(2);
+    fireEvent.click(screen.getByLabelText('Fahrzeug M-AB 123 löschen'));
+    // Card must disappear immediately — no awaiting the server response.
+    await waitFor(() => expect(screen.queryByText('M-AB 123')).not.toBeInTheDocument());
+    expect(screen.getAllByTestId('fahrzeug-card')).toHaveLength(1);
+    resolveDelete({ success: true, data: { id: 'v-001' } });
+  });
+
+  it('rolls back the optimistic delete when deleteVehicle rejects', async () => {
+    mockGetVehicles.mockResolvedValue({ success: true, data: [VEHICLE_BMW, VEHICLE_EV] });
+    mockDeleteVehicle.mockRejectedValue(new Error('network'));
+    renderScreen();
+    await waitFor(() => screen.getByText('M-AB 123'));
+    fireEvent.click(screen.getByLabelText('Fahrzeug M-AB 123 löschen'));
+    // Card reappears after rollback.
+    await waitFor(() => expect(screen.getByText('M-AB 123')).toBeInTheDocument());
+    expect(mockToast).toHaveBeenCalledWith('Löschen fehlgeschlagen', 'error');
+  });
 });

--- a/parkhub-web/src/design-v5/screens/Fahrzeuge.tsx
+++ b/parkhub-web/src/design-v5/screens/Fahrzeuge.tsx
@@ -206,17 +206,34 @@ export function FahrzeugeV5({ navigate: _navigate }: { navigate: (id: ScreenId) 
     onError: () => toast('Hinzufügen fehlgeschlagen', 'error'),
   });
 
+  // Optimistic delete: drop the vehicle from the cache immediately so the
+  // card vanishes without waiting for the server. onError restores the
+  // previous snapshot + toasts; onSettled re-invalidates to pick up any
+  // server-side computed fields (e.g. `is_default` promotion).
   const deleteMutation = useMutation({
     mutationFn: async (id: string) => {
       const res = await api.deleteVehicle(id);
       if (!res.success) throw new Error(res.error?.message ?? 'Fahrzeug löschen fehlgeschlagen');
       return res.data;
     },
+    onMutate: async (id: string) => {
+      await qc.cancelQueries({ queryKey: ['fahrzeuge'] });
+      const previous = qc.getQueryData<Vehicle[]>(['fahrzeuge']);
+      if (previous) {
+        qc.setQueryData<Vehicle[]>(['fahrzeuge'], previous.filter((v) => v.id !== id));
+      }
+      return { previous };
+    },
+    onError: (_err, _id, ctx) => {
+      if (ctx?.previous) qc.setQueryData(['fahrzeuge'], ctx.previous);
+      toast('Löschen fehlgeschlagen', 'error');
+    },
     onSuccess: () => {
-      qc.invalidateQueries({ queryKey: ['fahrzeuge'] });
       toast('Fahrzeug entfernt', 'success');
     },
-    onError: () => toast('Löschen fehlgeschlagen', 'error'),
+    onSettled: () => {
+      qc.invalidateQueries({ queryKey: ['fahrzeuge'] });
+    },
   });
 
   if (isLoading) {

--- a/parkhub-web/src/design-v5/screens/Kalender.test.tsx
+++ b/parkhub-web/src/design-v5/screens/Kalender.test.tsx
@@ -66,12 +66,14 @@ function makeEvents() {
 describe('KalenderV5', () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it('renders empty month with no events', async () => {
+  it('renders empty month with no events and auto-selects today', async () => {
     mockCalendarEvents.mockResolvedValue({ success: true, data: [] });
     renderScreen();
     await waitFor(() => expect(screen.getByText('Kalender')).toBeInTheDocument());
-    // Empty selection placeholder is shown
-    expect(screen.getByText(/Klicken Sie auf ein Datum/)).toBeInTheDocument();
+    // Smart default: today is pre-selected so the day-detail pane shows
+    // today's events (or the short "Keine Einträge" placeholder when the
+    // day is empty), not the generic "pick a date" message.
+    expect(screen.getByText('Keine Einträge')).toBeInTheDocument();
   });
 
   it('renders error state on query failure', async () => {

--- a/parkhub-web/src/design-v5/screens/Kalender.tsx
+++ b/parkhub-web/src/design-v5/screens/Kalender.tsx
@@ -43,7 +43,14 @@ export function KalenderV5({ navigate }: { navigate: (id: ScreenId) => void }) {
     d.setHours(0, 0, 0, 0);
     return d;
   });
-  const [selectedDate, setSelectedDate] = useState<Date | null>(null);
+  // Smart default: pre-select today's date on mount so the day-detail
+  // pane shows today's events without requiring a manual tap. Users
+  // can still click any other day to change the selection.
+  const [selectedDate, setSelectedDate] = useState<Date | null>(() => {
+    const d = new Date();
+    d.setHours(0, 0, 0, 0);
+    return d;
+  });
 
   const rangeStart = useMemo(() => {
     const d = new Date(currentMonth);

--- a/parkhub-web/src/design-v5/tokens.css
+++ b/parkhub-web/src/design-v5/tokens.css
@@ -115,11 +115,39 @@
   font-variant-numeric: tabular-nums;
 }
 
+/* ═════════ VIEW TRANSITIONS API ═════════
+   Chromium 111+/Safari 18+ cross-fade between screen states. The browser
+   snapshots the DOM before/after `document.startViewTransition()` and
+   animates ::view-transition-old/-new via the default CSS. We override
+   duration + easing to match the rest of the v5 motion system. */
+::view-transition-old(root),
+::view-transition-new(root) {
+  animation-duration: 0.22s;
+  animation-timing-function: cubic-bezier(0.25, 0.1, 0.25, 1);
+}
+
 /* Respect user motion preference — disable all v5 animations */
 @media (prefers-reduced-motion: reduce) {
+  /* Broad safety net: kill any still-configured animation/transition
+     on the v5 surface (covers 3rd-party libs + inline styles we can't
+     control like ph-v5-pulse skeletons). */
+  [data-ph-mode] *,
+  [data-ph-mode] *::before,
+  [data-ph-mode] *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
   .v5-ani, .v5-aniR { animation: none !important; }
   .v5-btn, .v5-row, .v5-lift { transition: none !important; }
   .v5-btn:hover, .v5-lift:hover { transform: none !important; }
+  /* Turn off the view-transition cross-fade entirely so users who
+     opt out of motion don't see a flash. */
+  ::view-transition-old(root),
+  ::view-transition-new(root) {
+    animation: none !important;
+  }
 }
 
 /* cmdk (command palette) structural styling only — theming via v5 tokens */

--- a/parkhub-web/src/design-v5/useDeepLink.test.tsx
+++ b/parkhub-web/src/design-v5/useDeepLink.test.tsx
@@ -1,0 +1,79 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, cleanup, act } from '@testing-library/react';
+import { readScreenFromUrl, writeScreenToUrl, useSyncScreenToUrl } from './useDeepLink';
+import type { ScreenId } from './nav';
+
+function setPath(path: string): void {
+  window.history.replaceState({}, '', path);
+}
+
+describe('readScreenFromUrl', () => {
+  beforeEach(() => setPath('/v5'));
+  afterEach(() => setPath('/'));
+
+  it('returns fallback when the URL has no screen segment', () => {
+    expect(readScreenFromUrl('dashboard' as ScreenId)).toBe('dashboard');
+  });
+
+  it('parses a valid screen id from the pathname', () => {
+    setPath('/v5/buchungen');
+    expect(readScreenFromUrl('dashboard' as ScreenId)).toBe('buchungen');
+  });
+
+  it('ignores unknown ids and falls back', () => {
+    setPath('/v5/not-a-real-screen');
+    expect(readScreenFromUrl('dashboard' as ScreenId)).toBe('dashboard');
+  });
+
+  it('tolerates a trailing slash', () => {
+    setPath('/v5/fahrzeuge/');
+    expect(readScreenFromUrl('dashboard' as ScreenId)).toBe('fahrzeuge');
+  });
+});
+
+describe('writeScreenToUrl', () => {
+  afterEach(() => setPath('/'));
+
+  it('pushes a new /v5/<id> entry when the screen changes', () => {
+    setPath('/v5/dashboard');
+    writeScreenToUrl('buchen' as ScreenId);
+    expect(window.location.pathname).toBe('/v5/buchen');
+  });
+
+  it('is a no-op when the URL already matches the screen', () => {
+    setPath('/v5/buchen');
+    const pushSpy = vi.spyOn(window.history, 'pushState');
+    writeScreenToUrl('buchen' as ScreenId);
+    expect(pushSpy).not.toHaveBeenCalled();
+    pushSpy.mockRestore();
+  });
+});
+
+function Harness({ screen, onPopState }: { screen: ScreenId; onPopState: (s: ScreenId) => void }) {
+  useSyncScreenToUrl(screen, onPopState);
+  return null;
+}
+
+describe('useSyncScreenToUrl', () => {
+  afterEach(() => {
+    setPath('/');
+    cleanup();
+  });
+
+  it('writes the initial screen to the URL on mount', () => {
+    setPath('/v5');
+    render(<Harness screen={'buchen' as ScreenId} onPopState={vi.fn()} />);
+    expect(window.location.pathname).toBe('/v5/buchen');
+  });
+
+  it('notifies on popstate with the new screen', () => {
+    setPath('/v5/buchen');
+    const onPopState = vi.fn();
+    render(<Harness screen={'buchen' as ScreenId} onPopState={onPopState} />);
+    setPath('/v5/fahrzeuge');
+    act(() => {
+      window.dispatchEvent(new PopStateEvent('popstate'));
+    });
+    expect(onPopState).toHaveBeenCalledWith('fahrzeuge');
+  });
+});

--- a/parkhub-web/src/design-v5/useDeepLink.ts
+++ b/parkhub-web/src/design-v5/useDeepLink.ts
@@ -1,0 +1,74 @@
+import { useEffect } from 'react';
+import type { ScreenId } from './nav';
+import { byId } from './nav';
+
+/**
+ * Deep-linking for the v5 SPA.
+ *
+ * Astro owns the outer route (`/v5`), so inside the React SPA we
+ * can't use react-router's `<Route>` declaratively — we'd have
+ * two routers fighting over the same URL. Instead we use the
+ * History API directly:
+ *
+ *  - `readScreenFromUrl()`  — parses `/v5/<screenId>` once on
+ *    first render, falling back to whatever the caller passes
+ *    when the URL doesn't have a screen segment.
+ *  - `useSyncScreenToUrl()` — pushes a new `/v5/<id>` entry
+ *    whenever the screen changes, and listens for `popstate`
+ *    so browser back/forward restores the correct screen.
+ *
+ * Notes:
+ *  - Only accepts known screen IDs (checked against `byId`).
+ *  - Debounces identical pushes so a React double-render in
+ *    dev doesn't spam the history stack.
+ *  - Never touches `window.history` during SSR / jsdom-without-window.
+ */
+
+const BASE_PATH = '/v5';
+
+export function readScreenFromUrl(fallback: ScreenId): ScreenId {
+  if (typeof window === 'undefined') return fallback;
+  const path = window.location.pathname;
+  // Accept both `/v5/<id>` and `/v5/<id>/`, trim query + hash.
+  const match = path.match(/^\/v5\/([a-z][a-z0-9_-]*)\/?$/i);
+  if (!match) return fallback;
+  const id = match[1].toLowerCase();
+  return byId.has(id) ? (id as ScreenId) : fallback;
+}
+
+export function writeScreenToUrl(screen: ScreenId): void {
+  if (typeof window === 'undefined') return;
+  const target = `${BASE_PATH}/${screen}`;
+  if (window.location.pathname === target) return;
+  try {
+    window.history.pushState({ screen }, '', target);
+  } catch {
+    // Some test runners (and very old browsers) disallow pushState
+    // on file:// URLs; deep-linking is a progressive enhancement.
+  }
+}
+
+/**
+ * Keep the URL and the in-memory screen state in sync.
+ *
+ * - Pushes `/v5/<screen>` into history whenever `screen` changes.
+ * - Subscribes to `popstate` so the browser back/forward buttons
+ *   call `onPopState` with whatever screen the URL now encodes.
+ */
+export function useSyncScreenToUrl(
+  screen: ScreenId,
+  onPopState: (screen: ScreenId) => void,
+): void {
+  useEffect(() => {
+    writeScreenToUrl(screen);
+  }, [screen]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const handler = () => {
+      onPopState(readScreenFromUrl(screen));
+    };
+    window.addEventListener('popstate', handler);
+    return () => window.removeEventListener('popstate', handler);
+  }, [screen, onPopState]);
+}

--- a/parkhub-web/src/design-v5/useKeyboardShortcuts.test.tsx
+++ b/parkhub-web/src/design-v5/useKeyboardShortcuts.test.tsx
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/react';
+import { useKeyboardShortcuts } from './useKeyboardShortcuts';
+
+function fireKey(key: string, target?: EventTarget, init?: KeyboardEventInit): boolean {
+  const ev = new KeyboardEvent('keydown', { key, bubbles: true, ...init });
+  if (target) {
+    target.dispatchEvent(ev);
+  } else {
+    document.dispatchEvent(ev);
+  }
+  return !ev.defaultPrevented;
+}
+
+function Harness({ shortcuts, enabled = true }: { shortcuts: Record<string, (e: KeyboardEvent) => void>; enabled?: boolean }) {
+  useKeyboardShortcuts(shortcuts, enabled);
+  return <input data-testid="form-input" />;
+}
+
+describe('useKeyboardShortcuts', () => {
+  afterEach(() => cleanup());
+
+  it('fires the handler for a registered key on document', () => {
+    const nHandler = vi.fn();
+    render(<Harness shortcuts={{ n: nHandler }} />);
+    fireKey('n');
+    expect(nHandler).toHaveBeenCalledTimes(1);
+  });
+
+  it('is case-insensitive for single-letter shortcuts', () => {
+    const nHandler = vi.fn();
+    render(<Harness shortcuts={{ n: nHandler }} />);
+    fireKey('N');
+    expect(nHandler).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not fire when typing in an input element', () => {
+    const nHandler = vi.fn();
+    const { getByTestId } = render(<Harness shortcuts={{ n: nHandler }} />);
+    const input = getByTestId('form-input');
+    input.focus();
+    fireKey('n', input);
+    expect(nHandler).not.toHaveBeenCalled();
+  });
+
+  it('ignores modifier combos (Ctrl+K stays with the app)', () => {
+    const slashHandler = vi.fn();
+    render(<Harness shortcuts={{ '/': slashHandler }} />);
+    fireKey('/', undefined, { ctrlKey: true });
+    expect(slashHandler).not.toHaveBeenCalled();
+  });
+
+  it('fires Escape shortcut from any non-editable target', () => {
+    const escHandler = vi.fn();
+    render(<Harness shortcuts={{ Escape: escHandler }} />);
+    fireKey('Escape');
+    expect(escHandler).toHaveBeenCalledTimes(1);
+  });
+
+  it('is disabled when enabled=false', () => {
+    const nHandler = vi.fn();
+    render(<Harness shortcuts={{ n: nHandler }} enabled={false} />);
+    fireKey('n');
+    expect(nHandler).not.toHaveBeenCalled();
+  });
+});

--- a/parkhub-web/src/design-v5/useKeyboardShortcuts.ts
+++ b/parkhub-web/src/design-v5/useKeyboardShortcuts.ts
@@ -1,0 +1,61 @@
+import { useEffect } from 'react';
+
+/**
+ * Context-aware keyboard shortcuts hook.
+ *
+ * Pass a `{ key: handler }` map. Keys match `KeyboardEvent.key`
+ * (case-insensitive for letters). The hook attaches a single
+ * `keydown` listener on `document` for the lifetime of the
+ * subscribing component.
+ *
+ * Safeguards (industry-standard):
+ *  - Ignores events that originate from `<input>`, `<textarea>`,
+ *    `<select>`, or any element with `contenteditable`. Users
+ *    typing "n" into a plate number must never trigger the
+ *    shortcut to open a new booking.
+ *  - Ignores events while a meta/ctrl/alt modifier is held, so
+ *    we don't collide with browser / OS shortcuts.
+ *  - Preserves the `?` shortcut even inside non-input elements
+ *    so the help overlay remains discoverable globally.
+ *
+ * Usage:
+ *   useKeyboardShortcuts({
+ *     'n': () => navigate('buchen'),
+ *     '/': () => focusSearch(),
+ *     'Escape': () => closeModal(),
+ *   });
+ */
+export type ShortcutMap = Record<string, (event: KeyboardEvent) => void>;
+
+function isEditableTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  if (target instanceof HTMLInputElement) return true;
+  if (target instanceof HTMLTextAreaElement) return true;
+  if (target instanceof HTMLSelectElement) return true;
+  if (target.isContentEditable) return true;
+  return false;
+}
+
+export function useKeyboardShortcuts(shortcuts: ShortcutMap, enabled = true): void {
+  useEffect(() => {
+    if (!enabled) return;
+    if (typeof window === 'undefined') return;
+
+    const handler = (event: KeyboardEvent) => {
+      if (event.metaKey || event.ctrlKey || event.altKey) return;
+      if (isEditableTarget(event.target)) return;
+      // Normalise single-letter keys so we don't have to worry about
+      // locale-specific Shift handling (KeyboardEvent.key returns
+      // uppercase when Shift is held — we want "n" and "N" to be the
+      // same shortcut unless the caller explicitly registers "N").
+      const bareKey = event.key.length === 1 ? event.key.toLowerCase() : event.key;
+      const handlerFn = shortcuts[bareKey] ?? shortcuts[event.key];
+      if (handlerFn) {
+        handlerFn(event);
+      }
+    };
+
+    document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
+  }, [shortcuts, enabled]);
+}

--- a/parkhub-web/src/design-v5/viewTransitions.test.ts
+++ b/parkhub-web/src/design-v5/viewTransitions.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { startViewTransition } from './viewTransitions';
+
+describe('startViewTransition', () => {
+  const originalStartVT = (document as unknown as {
+    startViewTransition?: unknown;
+  }).startViewTransition;
+  const originalMatchMedia = window.matchMedia;
+
+  afterEach(() => {
+    if (originalStartVT === undefined) {
+      delete (document as unknown as { startViewTransition?: unknown }).startViewTransition;
+    } else {
+      (document as unknown as { startViewTransition?: unknown }).startViewTransition =
+        originalStartVT;
+    }
+    window.matchMedia = originalMatchMedia;
+  });
+
+  it('calls the update callback directly when the API is missing', () => {
+    delete (document as unknown as { startViewTransition?: unknown }).startViewTransition;
+    const cb = vi.fn();
+    startViewTransition(cb);
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+
+  it('routes the update through document.startViewTransition when present', () => {
+    const transition = { finished: Promise.resolve() };
+    const vt = vi.fn((cb: () => void) => {
+      cb();
+      return transition;
+    });
+    (document as unknown as { startViewTransition: typeof vt }).startViewTransition = vt;
+    window.matchMedia = vi.fn().mockReturnValue({ matches: false }) as unknown as typeof window.matchMedia;
+    const cb = vi.fn();
+    startViewTransition(cb);
+    expect(vt).toHaveBeenCalledTimes(1);
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips the API when prefers-reduced-motion matches', () => {
+    const vt = vi.fn();
+    (document as unknown as { startViewTransition: typeof vt }).startViewTransition = vt;
+    window.matchMedia = vi.fn().mockReturnValue({ matches: true }) as unknown as typeof window.matchMedia;
+    const cb = vi.fn();
+    startViewTransition(cb);
+    expect(vt).not.toHaveBeenCalled();
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+});

--- a/parkhub-web/src/design-v5/viewTransitions.ts
+++ b/parkhub-web/src/design-v5/viewTransitions.ts
@@ -1,0 +1,39 @@
+/**
+ * View Transitions API helper for v5 client navigation.
+ *
+ * The browser-native View Transitions API (Chromium 111+, Safari 18+)
+ * lets us fade between screen states with zero JS animation code —
+ * the browser snapshots before/after and cross-fades pseudo-elements
+ * (::view-transition-old / ::view-transition-new).
+ *
+ * Fallback behaviour: when the API is missing (older browsers), we
+ * simply invoke the callback synchronously. No jank, no try/catch
+ * noise in the caller.
+ *
+ * We also skip transitions when the user prefers reduced motion —
+ * the CSS already disables the cross-fade, but skipping the API
+ * call entirely avoids the (tiny) layout-snapshot cost too.
+ */
+
+type StartViewTransition = (cb: () => void) => { finished: Promise<void> };
+
+export function startViewTransition(update: () => void): void {
+  if (typeof document === 'undefined') {
+    update();
+    return;
+  }
+
+  const prefersReducedMotion =
+    typeof window !== 'undefined' &&
+    typeof window.matchMedia === 'function' &&
+    window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+  const doc = document as Document & { startViewTransition?: StartViewTransition };
+
+  if (prefersReducedMotion || typeof doc.startViewTransition !== 'function') {
+    update();
+    return;
+  }
+
+  doc.startViewTransition(update);
+}


### PR DESCRIPTION
## Summary

Seven Tier-1 UX quick-wins shipped together so the diff stays coherent. Mirrors parkhub-php #347 byte-for-byte where possible (rust has a few divergent files kept intact: Einchecken/SSE wiring, Buchen comment delta).

1. **View Transitions API** — new `startViewTransition()` helper wraps `setScreen()` in `V5Shell`. Browser cross-fades screens; gracefully no-ops on Safari <18 / Firefox and under `prefers-reduced-motion`.
2. **Optimistic UI mutations** — `createBooking`, `deleteVehicle`, `cancelBooking` now use react-query `onMutate` / `onError` rollback so the UI updates at zero latency.
3. **Deep links per screen** — `/v5/<screenId>` round-trips via History API (`pushState` + `popstate`). URL is source of truth; `ph-v5-screen` localStorage kept as cache for bare `/v5`.
4. **Smart defaults** — Buchen pre-selects the last-used lot + vehicle (auto-advances to Step 2 when the prior lot is still open). Kalender auto-selects today on mount.
5. **Per-screen keyboard shortcuts** — new `useKeyboardShortcuts(map)` hook with input-focus safeguards. Global bindings: `?` AI panel, `/` palette, `Escape` close modals.
6. **`prefers-reduced-motion`** — broadened the reduced-motion block in `tokens.css` to cover `[data-ph-mode] *` so 3rd-party libs and the `ph-v5-pulse` skeletons collapse to 0.01ms. View Transitions cross-fade also disabled.
7. **QR check-in** — Einchecken renders a 240×240 SVG QR encoding `parkhub://check-in/<booking-id>` above the "Manuell einchecken" fallback. New dep: `qrcode.react@^4.2.0` (ISC, ~12 KB gzipped).

Commercial-safe: no GPL/AGPL/BSL. qrcode.react is ISC.

## Test plan

- [x] `vitest run` (design-v5) — 267 tests pass
- [x] `astro build` — clean, bundle intact
- [x] TDD RED-then-GREEN evidence captured for each new helper (viewTransitions, useDeepLink, useKeyboardShortcuts, lastUsed) + the optimistic-delete test on Fahrzeuge
- [ ] Post-merge Render verification: `/v5/buchungen` deep-link loads Buchungen directly, browser back/forward navigates, QR renders on Einchecken with an active booking, transitions fire on screen change