### PR TITLE
feat(v5/assistent): Lokal badge + Vorschläge eyebrow + privacy footer

### DIFF
--- a/parkhub-web/src/design-v5/AIPanel.test.tsx
+++ b/parkhub-web/src/design-v5/AIPanel.test.tsx
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { V5AIPanel } from './AIPanel';
+import { V5ToastProvider } from './Toast';
+
+function renderPanel(open = true) {
+  return render(
+    <V5ToastProvider>
+      <V5AIPanel open={open} />
+    </V5ToastProvider>,
+  );
+}
+
+describe('V5AIPanel — privacy-first design bundle', () => {
+  it('renders nothing when closed', () => {
+    renderPanel(false);
+    expect(screen.queryByText('KI-Assistent')).not.toBeInTheDocument();
+    expect(screen.queryByText('Lokal')).not.toBeInTheDocument();
+  });
+
+  describe('header', () => {
+    it('renders the Assistent title', () => {
+      renderPanel();
+      expect(screen.getByText('KI-Assistent')).toBeInTheDocument();
+    });
+
+    it('renders the "Lokal" privacy badge in the header', () => {
+      renderPanel();
+      expect(screen.getByText('Lokal')).toBeInTheDocument();
+    });
+  });
+
+  describe('section eyebrows', () => {
+    it('renders the "Vorschläge" eyebrow above the suggestions', () => {
+      renderPanel();
+      const eyebrow = screen.getByText('Vorschläge');
+      expect(eyebrow).toBeInTheDocument();
+      expect(eyebrow).toHaveStyle({ textTransform: 'uppercase' });
+    });
+
+    it('renders the "Statistiken" eyebrow above the stats', () => {
+      renderPanel();
+      const eyebrow = screen.getByText('Statistiken');
+      expect(eyebrow).toBeInTheDocument();
+      expect(eyebrow).toHaveStyle({ textTransform: 'uppercase' });
+    });
+  });
+
+  describe('privacy footer', () => {
+    it('anchors a "Keine Daten verlassen den Server" footer at the bottom', () => {
+      renderPanel();
+      expect(
+        screen.getByText(/Keine Daten verlassen den Server/i),
+      ).toBeInTheDocument();
+    });
+
+    it('footer is rendered with uppercase styling', () => {
+      renderPanel();
+      const footer = screen.getByText(/Keine Daten verlassen den Server/i);
+      expect(footer).toHaveStyle({ textTransform: 'uppercase' });
+    });
+  });
+});

--- a/parkhub-web/src/design-v5/AIPanel.tsx
+++ b/parkhub-web/src/design-v5/AIPanel.tsx
@@ -98,6 +98,9 @@ export function V5AIPanel({
           KI-Assistent
         </span>
         <Badge variant="primary">Beta</Badge>
+        <span style={{ marginLeft: 'auto' }}>
+          <Badge variant="purple">Lokal</Badge>
+        </span>
       </div>
 
       <div
@@ -120,7 +123,7 @@ export function V5AIPanel({
             marginBottom: 2,
           }}
         >
-          Empfehlungen
+          Vorschläge
         </div>
         {suggestions.map((s, i) => {
           const color = TYPE_COLOR[s.type];
@@ -216,6 +219,22 @@ export function V5AIPanel({
           </div>
         ))}
       </div>
+
+      <footer
+        style={{
+          padding: '12px 18px',
+          borderTop: '1px solid var(--v5-bor)',
+          fontSize: 9,
+          fontWeight: 500,
+          color: 'var(--v5-mut)',
+          letterSpacing: '0.06em',
+          textTransform: 'uppercase',
+          textAlign: 'center',
+          flexShrink: 0,
+        }}
+      >
+        Lokal · Keine Daten verlassen den Server
+      </footer>
     </aside>
   );
 }


### PR DESCRIPTION
## Summary

Mirror of nash87/parkhub-php. Adds 3 design-bundle elements to the Assistent panel (`AIPanel.tsx`) communicating the platform's no-cloud, local-first privacy stance:

1. **"Lokal" purple badge** — right-anchored in the header next to the title.
2. **"Vorschläge" eyebrow** — renamed from "Empfehlungen" above the suggestions section (no "AI" / "KI" branding). "Statistiken" eyebrow was already present.
3. **Privacy footer** — uppercase `Lokal · Keine Daten verlassen den Server` anchored at the bottom of the panel.

Branding rule enforced: no new "AI" / "KI" strings introduced. DE text only.

`AIPanel.tsx` + `AIPanel.test.tsx` are byte-identical to the parkhub-php branch.

## Test plan

- [x] `npx vitest --run src/design-v5/AIPanel` — 7/7 pass
- [x] `npx vitest --run src/design-v5/` — 259/262 (3 pre-existing failures on `main`: `UPlotChart`, `Analytics`, `Einchecken` — verified unrelated)
- [ ] E2E visual baselines: no v5 visual-regression spec exists; skipped. Follow-up: `parkhub-site` `dashboard-hero.png` refresh.

## Coordination

A separate agent is renaming `KI-Assistent → Assistent` + `AIPanel.tsx → AssistantPanel.tsx`. As of this PR no rename branch exists in either repo. This PR is intentionally based on `main` with the **current** `KI-Assistent` string untouched so the rename patch applies cleanly on rebase.

Mirror PR: nash87/parkhub-php.

Task: T-2006