### PR TITLE
feat: local-first CI workflow (Lefthook + drift gates + Biome + native auto-merge)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,42 +1,49 @@
 version: 2
 updates:
-  # GitHub Actions — group all action bumps into one PR
+  # GitHub Actions — group all minor + patch action bumps. Major bumps
+  # remain individual so workflow YAML can be reviewed action-by-action.
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
       day: "monday"
     groups:
-      actions:
+      github-actions:
         patterns: ["*"]
+        update-types: ["minor", "patch"]
     labels: ["dependencies", "ci"]
     open-pull-requests-limit: 5
 
-  # npm (frontend)
+  # npm (frontend, parkhub-web). Major-version updates kept ungrouped
+  # so React 19 -> 20, Astro 6 -> 7, etc. each get their own review.
   - package-ecosystem: "npm"
     directory: "/parkhub-web"
     schedule:
       interval: "weekly"
       day: "monday"
     groups:
-      npm-minor-patch:
+      npm-deps:
+        patterns: ["*"]
         update-types: ["minor", "patch"]
     labels: ["dependencies", "frontend"]
     open-pull-requests-limit: 5
 
-  # Rust / Cargo
+  # Rust / Cargo (workspace root). Major-version updates kept ungrouped
+  # so axum 0.x bumps, tokio breaking changes, etc. get individual review.
   - package-ecosystem: "cargo"
     directory: "/"
     schedule:
       interval: "weekly"
       day: "monday"
     groups:
-      cargo-minor-patch:
+      rust-deps:
+        patterns: ["*"]
         update-types: ["minor", "patch"]
     labels: ["dependencies", "rust"]
     open-pull-requests-limit: 5
 
-  # Docker
+  # Docker base images. Tag bumps stay individual — base image upgrades
+  # are infrequent and security-sensitive.
   - package-ecosystem: "docker"
     directory: "/"
     schedule:

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,45 @@
+name: Auto-merge on label
+
+# Native auto-merge workflow — when a PR is labelled `auto-merge` (and
+# the label is still present after each push), enable GitHub's native
+# auto-merge so the PR merges itself once all required status checks
+# pass and required reviews are approved. Replaces the third-party
+# Mergify SaaS to keep the merge path under repo control.
+#
+# Repo prerequisites (one-time, see CONTRIBUTING.md#merge-queue):
+#   1. Settings → General → Pull Requests → "Allow auto-merge" enabled.
+#   2. Branch protection on `main` requires the `Required checks` job
+#      and (optionally) `CodeQL` as required status checks.
+#   3. Optional: enable "Require merge queue" on `main` — auto-merge
+#      will then queue PRs into the native merge queue automatically.
+#
+# Security note: only `github.event.pull_request.number` (an integer)
+# and labels (filtered above) are referenced — no untrusted strings
+# from issue/PR bodies reach a `run:` block.
+
+on:
+  pull_request_target:
+    types: [labeled, synchronize, opened, reopened, ready_for_review]
+
+permissions:
+  pull-requests: write
+  contents: write
+
+concurrency:
+  group: auto-merge-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  enable-auto-merge:
+    if: >-
+      !github.event.pull_request.draft
+      && contains(github.event.pull_request.labels.*.name, 'auto-merge')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Enable native auto-merge (squash)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: gh pr merge --auto --squash "$PR_NUMBER"

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -19,7 +19,11 @@ name: Auto-merge on label
 
 on:
   pull_request_target:
-    types: [labeled, synchronize, opened, reopened, ready_for_review]
+    # Listen only on `labeled` (and `reopened` so a closed-then-reopened PR
+    # with the label still attached re-arms once). NOT `synchronize` —
+    # GitHub deliberately disables auto-merge after pushes from contributors
+    # without write access, and we don't want to defeat that safety.
+    types: [labeled, reopened]
 
 permissions:
   pull-requests: write

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,7 @@ you need to get from zero to a merged pull request.
 - [Module System (Feature Flags)](#module-system-feature-flags)
 - [Running Tests](#running-tests)
 - [Code Style](#code-style)
+- [Local CI](#local-ci)
 - [Pull Request Guidelines](#pull-request-guidelines)
 - [Adding a New API Endpoint](#adding-a-new-api-endpoint)
 - [Reporting Bugs](#reporting-bugs)
@@ -402,6 +403,146 @@ Prefix suggestions for clarity:
 | `test:` | Adding or updating tests |
 | `chore:` | Tooling, deps, CI |
 | `security:` | Security fix (coordinate via private advisory first) |
+
+---
+
+## Local CI
+
+We run a local-first CI workflow on top of the GitHub Actions pipeline.
+The goal: catch 90 %+ of CI failures before you push, replacing the
+15-30 minute remote feedback loop with a near-instant local one.
+
+### Cautionary tale
+
+A single PR once landed with a 12-fail compile cascade because 15
+`User { ..settings: None }` field initializers were missing. `cargo
+check` would have caught it in five seconds. Local CI exists so that
+class of failure is impossible to push.
+
+### One-time setup
+
+After cloning the repo and installing the Rust toolchain + Node deps,
+install the git hooks:
+
+```bash
+npm install                   # parkhub-web deps (node_modules)
+cargo build                   # warm cargo + Slint cache
+npx lefthook install          # install pre-commit + pre-push hooks
+```
+
+The first `cargo build` after cloning surfaces a yellow `cargo:warning`
+reminding you to install the hooks. Once installed, the warning
+disappears.
+
+### What runs and when
+
+| Hook | Speed | Gates |
+|------|-------|-------|
+| `pre-commit` | < 5 s | `cargo fmt --check`, ESLint (if configured), `tsc --noEmit` |
+| `pre-push` | 1-3 min cached | `cargo check`, `cargo clippy`, `cargo test --lib`, `vitest --changed`, OpenAPI drift, ts-rs types drift |
+
+The pre-push gate set is the local mirror of the `Required checks`
+job in `.github/workflows/ci.yml`. If pre-push is green, GitHub CI
+should be green too.
+
+### Replay locally without committing or pushing
+
+```bash
+lefthook run pre-commit       # fast, only on staged files
+lefthook run pre-push         # full gates
+```
+
+You can also run individual scripts directly:
+
+```bash
+./scripts/check-openapi-drift.sh
+./scripts/check-types-drift.sh
+```
+
+### Drift-gate quick reference
+
+If `openapi-drift` or `types-drift` fails, regenerate locally and
+commit the result:
+
+```bash
+# OpenAPI drift — start the server, then dump the spec:
+cargo run --no-default-features --features 'full,headless' \
+    -p parkhub-server -- --headless --port 18181
+# (in another terminal)
+./scripts/dump-openapi.sh 18181
+git add docs/openapi/rust.json
+
+# ts-rs TypeScript types drift:
+cargo test --features gen-types -p parkhub-server --test ts_export -- --nocapture
+git add parkhub-web/src/generated/
+```
+
+### Bypassing in emergencies
+
+For a true emergency (e.g. broken upstream dep blocking a hotfix), you
+can bypass the gates:
+
+```bash
+git push --no-verify
+```
+
+This is logged to your local `lefthook.log` and is frowned upon —
+please open a follow-up issue describing why the gate was bypassed.
+Per-gate bypasses also exist for the slow drift scripts:
+
+```bash
+SKIP_OPENAPI_DRIFT=1 git push
+SKIP_TYPES_DRIFT=1 git push
+```
+
+### Merge Queue
+
+We use **GitHub's native merge queue** (no third-party SaaS, no
+push-access from external services). Activate it once via:
+
+> Settings → Branches → Branch protection rules → `main` →
+> "Require merge queue" → Enable.
+
+While the queue is active, GitHub batches PRs into a serialised lane,
+re-runs required checks against the merge candidate, and merges when
+green. No `.mergify.yml` or other config in the repo is required.
+
+### Auto-merge
+
+Add the **`auto-merge`** label to a PR and the workflow at
+`.github/workflows/auto-merge.yml` enables GitHub's native auto-merge
+(squash strategy). The PR will then merge itself once:
+
+- All required status checks pass (Required checks, CodeQL).
+- All required reviews are approved.
+- The PR is not in draft state.
+
+Auto-merge respects branch protection — it does not bypass any gate.
+To cancel, remove the label or click "Disable auto-merge" on the PR.
+
+Repo prerequisites (one-time):
+
+1. Settings → General → Pull Requests → "Allow auto-merge" enabled.
+2. Branch protection on `main` lists `Required checks` (and CodeQL,
+   if enabled) as required status checks.
+
+### Operator action required (one-time, post-merge)
+
+Three pieces of post-merge configuration cannot be expressed purely in
+repo files:
+
+1. **Lefthook hooks per contributor** — every contributor must run
+   `npx lefthook install` on first clone. The cargo build script
+   prints a reminder; documenting it here keeps it discoverable.
+
+2. **Allow auto-merge in repo settings** — Settings → General → Pull
+   Requests → "Allow auto-merge" must be enabled for the auto-merge
+   workflow to take effect.
+
+3. **Branch protection alignment** — branch protection on `main`
+   should list `Required checks` (matching the aggregator job in
+   `.github/workflows/ci.yml`) as a required status check, with
+   "Require merge queue" enabled if you want serialised merges.
 
 ---
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,16 @@ authors = ["nash87"]
 license = "MIT"
 repository = "https://github.com/nash87/parkhub-rust"
 
+# Local-first CI hint for new contributors. `cargo metadata` exposes
+# this under workspace_metadata so tooling (e.g. a build.rs printer or
+# a dev-shell motd) can surface the install reminder. Kept minimal —
+# the build itself never depends on or fails on missing hooks.
+[workspace.metadata.local-ci]
+hooks-tool = "lefthook"
+install-command = "npx lefthook install"
+config-file = "lefthook.yml"
+docs = "CONTRIBUTING.md#local-ci"
+
 [workspace.dependencies]
 # Shared dependencies across crates
 serde = { version = "1", features = ["derive"] }

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,155 @@
+# parkhub-rust — Lefthook git-hook config
+#
+# Local-first CI: shift gates left so 90%+ of CI failures are caught
+# before push, eliminating the 15-30 min GitHub feedback loop on
+# trivially-local-detectable failures (cargo fmt, cargo check,
+# OpenAPI/types drift, etc.).
+#
+# Reference plan: ~/Obsidian/Forge/Plans/2026-04-25-parkhub-local-first-ci-workflow.md
+#
+# One-time setup (after `npm install` and Rust toolchain):
+#
+#     npx lefthook install
+#
+# (or install the standalone binary: https://github.com/evilmartians/lefthook)
+#
+# Replay full local CI without committing/pushing:
+#
+#     lefthook run pre-commit   # fast, staged-files only
+#     lefthook run pre-push     # full gates (clippy, drift, vitest)
+#
+# Bypass in emergencies (logged + frowned-upon — open a follow-up):
+#
+#     git push --no-verify
+#
+# Hook commands intentionally call `cargo` / `npx` directly (not `fop`)
+# because contributors may not have fop installed. fop users can run
+# `fop build` / `fop test` manually before pushing.
+---
+min_version: 1.10.0
+
+# pre-commit: fast, only on staged files. Designed to add < 5s on typical commits.
+pre-commit:
+  parallel: true
+  commands:
+    fmt-rust:
+      glob: "**/*.rs"
+      run: cargo fmt --all -- --check
+      stage_fixed: true
+      fail_text: |
+        cargo fmt found unformatted Rust files.
+        Fix with: cargo fmt --all
+
+    lint-ts:
+      # Biome (Rust-native, MIT) handles linting + formatting in one
+      # pass — replaces the eslint + prettier combo. ~25× faster than
+      # eslint, single config (parkhub-web/biome.json). `biome check`
+      # runs both lint and format-check together. `stage_fixed: true`
+      # re-stages files Biome auto-fixes.
+      glob: "parkhub-web/**/*.{ts,tsx,js,jsx,mjs,cjs}"
+      root: "parkhub-web/"
+      # Skip cleanly until Biome is installed (`npm install`). Once
+      # node_modules/@biomejs/biome exists the gate becomes active.
+      skip:
+        - run: test ! -d parkhub-web/node_modules/@biomejs/biome
+      run: npx --no-install biome check --no-errors-on-unmatched {staged_files}
+      stage_fixed: true
+      fail_text: |
+        Biome found lint or format violations.
+        Auto-fix with: cd parkhub-web && npx biome check --write src/
+
+    typecheck-ts:
+      # `astro check` is the canonical type-checker for Astro projects:
+      # it walks .astro + .ts(x) files using the project's tsconfig.
+      # Project-wide because tsc cannot type-check a single file in
+      # isolation. Only fires when at least one TS/TSX file is staged.
+      # Skipped cleanly if parkhub-web/node_modules is missing — this
+      # keeps the gate non-fatal on fresh clones until contributors run
+      # `npm install` (the failure message points them there).
+      glob: "parkhub-web/**/*.{ts,tsx,astro}"
+      root: "parkhub-web/"
+      skip:
+        - run: test ! -d parkhub-web/node_modules
+      run: npx astro check
+      fail_text: |
+        TypeScript type errors. Fix and re-commit.
+        If `astro check` fails to start, run `cd parkhub-web && npm install` first.
+
+# pre-push: full local replica of the GitHub Actions "required" gates.
+# Catches the 12-fail compile cascade, drift, clippy violations, vitest
+# failures — all locally before the 15-30 min CI loop.
+pre-push:
+  parallel: true
+  commands:
+    cargo-check:
+      # The exact gate that would have caught the 12-fail compile
+      # cascade where 15 `User { ..settings: None }` field
+      # initializers were missing. Mirrors `.github/workflows/ci.yml`
+      # `check` and `client-check` jobs — parkhub-common + parkhub-
+      # server (headless) + parkhub-client. parkhub-desktop is
+      # excluded here because it pulls in tauri+webkit2gtk system deps
+      # that not every dev box has installed.
+      run: |
+        mkdir -p parkhub-web/dist
+        [ -f parkhub-web/dist/index.html ] || \
+          printf '%s' '<!doctype html><html><body></body></html>' \
+          > parkhub-web/dist/index.html
+        cargo check --locked -p parkhub-common --all-targets
+        cargo check --locked -p parkhub-server \
+          --no-default-features --features headless --all-targets
+        cargo check --locked -p parkhub-client --all-targets
+      fail_text: |
+        cargo check failed. Fix compile errors before pushing.
+        Tip: this is the gate that catches missing struct fields and
+        type errors instantly — push only when this passes.
+
+    cargo-clippy:
+      # Mirrors `.github/workflows/ci.yml#clippy` headless lints.
+      # Same scope as cargo-check above (no parkhub-desktop / tauri).
+      run: |
+        mkdir -p parkhub-web/dist
+        [ -f parkhub-web/dist/index.html ] || \
+          printf '%s' '<!doctype html><html><body></body></html>' \
+          > parkhub-web/dist/index.html
+        cargo clippy --locked -p parkhub-common --all-targets -- -D warnings
+        cargo clippy --locked -p parkhub-server \
+          --no-default-features --features headless --all-targets -- \
+          -D warnings -A clippy::cognitive_complexity -A clippy::assigning_clones
+      fail_text: |
+        Clippy violations. Fix or annotate with `#[allow(...)]` + reason.
+
+    cargo-test-fast:
+      # Lib-only tests — fast feedback. Integration + e2e run on CI.
+      # Mirrors `.github/workflows/ci.yml#test` headless scope so pre-
+      # push stays under ~2 min on cached builds.
+      run: |
+        mkdir -p parkhub-web/dist
+        [ -f parkhub-web/dist/index.html ] || \
+          printf '%s' '<!doctype html><html><body></body></html>' \
+          > parkhub-web/dist/index.html
+        cargo test --locked -p parkhub-common --lib
+        cargo test --locked -p parkhub-server \
+          --no-default-features --features headless --lib
+      fail_text: |
+        Library tests failing. Run locally to debug:
+          cargo test -p parkhub-common --lib
+          cargo test -p parkhub-server --no-default-features --features headless --lib
+
+    vitest:
+      # Fast loop: only run vitest specs for files changed since main.
+      # Use `npx vitest --run` (no --changed) on rebases to cover all.
+      root: "parkhub-web/"
+      run: npx vitest --run --changed
+      fail_text: |
+        Frontend tests failing. Run locally to debug:
+          cd parkhub-web && npx vitest --run
+
+    openapi-drift:
+      run: scripts/check-openapi-drift.sh
+      fail_text: |
+        OpenAPI snapshot drifted. See script output for the regen command.
+
+    types-drift:
+      run: scripts/check-types-drift.sh
+      fail_text: |
+        ts-rs TypeScript bindings drifted. See script output for the regen command.

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -51,7 +51,9 @@ pre-commit:
       # Skip cleanly until Biome is installed (`npm install`). Once
       # node_modules/@biomejs/biome exists the gate becomes active.
       skip:
-        - run: test ! -d parkhub-web/node_modules/@biomejs/biome
+        # Path is relative to root: parkhub-web/. Don't include the
+        # parkhub-web/ prefix or it nests to parkhub-web/parkhub-web/...
+        - run: test ! -d node_modules/@biomejs/biome
       run: npx --no-install biome check --no-errors-on-unmatched {staged_files}
       stage_fixed: true
       fail_text: |
@@ -69,7 +71,8 @@ pre-commit:
       glob: "parkhub-web/**/*.{ts,tsx,astro}"
       root: "parkhub-web/"
       skip:
-        - run: test ! -d parkhub-web/node_modules
+        # Relative to root: parkhub-web/. See note above.
+        - run: test ! -d node_modules
       run: npx astro check
       fail_text: |
         TypeScript type errors. Fix and re-commit.

--- a/parkhub-server/build.rs
+++ b/parkhub-server/build.rs
@@ -3,6 +3,12 @@
 //! Compiles Slint UI files for the setup wizard (when gui feature is enabled).
 
 fn main() {
+    // Local-first CI hint: nudge contributors to install lefthook on
+    // the very first build. Strictly informational — the build never
+    // depends on or fails when hooks are absent. Suppressed in CI and
+    // when hooks are already installed (.git/hooks/pre-commit exists).
+    print_local_ci_hint();
+
     // Only compile Slint UI when GUI feature is enabled
     #[cfg(feature = "gui")]
     {
@@ -42,5 +48,41 @@ fn main() {
         if let Err(e) = res.compile() {
             eprintln!("Warning: Failed to compile Windows resources: {}", e);
         }
+    }
+}
+
+/// Print a one-time-per-build hint reminding contributors to install
+/// the local-first CI git hooks (lefthook). No-op in CI environments
+/// and when the pre-push hook is already installed.
+///
+/// Cargo's `cargo:warning=…` prefix surfaces the message in a yellow
+/// banner without affecting build status. Kept dependency-free and
+/// fail-closed: any `io::Error` is silently swallowed.
+fn print_local_ci_hint() {
+    use std::path::PathBuf;
+
+    // Don't nag in CI — most CI shells already manage their own hooks
+    // (or explicitly skip them via --no-verify).
+    if std::env::var_os("CI").is_some() || std::env::var_os("GITHUB_ACTIONS").is_some() {
+        return;
+    }
+
+    // Find workspace root (parent of parkhub-server/).
+    let manifest_dir = match std::env::var_os("CARGO_MANIFEST_DIR") {
+        Some(v) => PathBuf::from(v),
+        None => return,
+    };
+    let workspace_root = match manifest_dir.parent() {
+        Some(p) => p.to_path_buf(),
+        None => return,
+    };
+
+    let lefthook_yml = workspace_root.join("lefthook.yml");
+    let pre_push_hook = workspace_root.join(".git").join("hooks").join("pre-push");
+
+    if lefthook_yml.is_file() && !pre_push_hook.is_file() {
+        println!(
+            "cargo:warning=lefthook hooks not installed — run `npx lefthook install` to enable local-first CI gates (see CONTRIBUTING.md#local-ci)."
+        );
     }
 }

--- a/parkhub-web/biome.json
+++ b/parkhub-web/biome.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.0.0/schema.json",
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
+  },
+  "files": {
+    "ignoreUnknown": true,
+    "includes": ["src/**", "e2e/**", "scripts/**", "*.ts", "*.tsx", "*.js", "*.jsx", "*.mjs", "*.cjs", "!**/node_modules/**", "!**/dist/**", "!**/.astro/**", "!src/generated/**"]
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineWidth": 100
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true,
+      "style": {
+        "useImportType": "warn",
+        "useExportType": "warn"
+      },
+      "correctness": {
+        "noUnusedImports": "error",
+        "noUnusedVariables": "warn"
+      },
+      "suspicious": {
+        "noConsoleLog": "warn"
+      },
+      "a11y": {
+        "recommended": true
+      }
+    }
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "single",
+      "semicolons": "always"
+    }
+  }
+}

--- a/parkhub-web/package-lock.json
+++ b/parkhub-web/package-lock.json
@@ -43,6 +43,7 @@
       },
       "devDependencies": {
         "@axe-core/playwright": "^4.11.2",
+        "@biomejs/biome": "^2.0.0",
         "@playwright/test": "^1.59.1",
         "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^6.9.1",
@@ -593,6 +594,169 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@biomejs/biome": {
+      "version": "2.4.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.4.13.tgz",
+      "integrity": "sha512-gLXOwkOBBg0tr7bDsqlkIh4uFeKuMjxvqsrb1Tukww1iDmHcfr4Uu8MoQxp0Rcte+69+osRNWXwHsu/zxT6XqA==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "bin": {
+        "biome": "bin/biome"
+      },
+      "engines": {
+        "node": ">=14.21.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/biome"
+      },
+      "optionalDependencies": {
+        "@biomejs/cli-darwin-arm64": "2.4.13",
+        "@biomejs/cli-darwin-x64": "2.4.13",
+        "@biomejs/cli-linux-arm64": "2.4.13",
+        "@biomejs/cli-linux-arm64-musl": "2.4.13",
+        "@biomejs/cli-linux-x64": "2.4.13",
+        "@biomejs/cli-linux-x64-musl": "2.4.13",
+        "@biomejs/cli-win32-arm64": "2.4.13",
+        "@biomejs/cli-win32-x64": "2.4.13"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-arm64": {
+      "version": "2.4.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.4.13.tgz",
+      "integrity": "sha512-2KImO1jhNFBa2oWConyr0x6flxbQpGKv6902uGXpYM62Xyem8U80j441SyUJ8KyngsmKbQjeIv1q2CQfDkNnYg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-x64": {
+      "version": "2.4.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.4.13.tgz",
+      "integrity": "sha512-BKrJklbaFN4p1Ts4kPBczo+PkbsHQg57kmJ+vON9u2t6uN5okYHaSr7h/MutPCWQgg2lglaWoSmm+zhYW+oOkg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64": {
+      "version": "2.4.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.4.13.tgz",
+      "integrity": "sha512-NzkUDSqfvMBrPplKgVr3aXLHZ2NEELvvF4vZxXulEylKWIGqlvNEcwUcj9OLrn75TD3lJ/GIqCVlBwd1MZCuYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64-musl": {
+      "version": "2.4.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.4.13.tgz",
+      "integrity": "sha512-U5MsuBQW25dXaYtqWWSPM3P96H6Y+fHuja3TQpMNnylocHW0tEbtFTDlUj6oM+YJLntvEkQy4grBvQNUD4+RCg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64": {
+      "version": "2.4.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.4.13.tgz",
+      "integrity": "sha512-Az3ZZedYRBo9EQzNnD9SxFcR1G5QsGo6VEc2hIyVPZ1rdKwee/7E9oeBBZFpE8Z44ekxsDQBqbiWGW5ShOhUSQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64-musl": {
+      "version": "2.4.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.4.13.tgz",
+      "integrity": "sha512-Z601MienRgTBDza/+u2CH3RSrWoXo9rtr8NK6A4KJzqGgfxx+H3VlyLgTJ4sRo40T3pIsqpTmiOQEvYzQvBRvQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-arm64": {
+      "version": "2.4.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.4.13.tgz",
+      "integrity": "sha512-Px9PS2B5/Q183bUwy/5VHqp3J2lzdOCeVGzMpphYfl8oSa7VDCqenBdqWpy6DCy/en4Rbf/Y1RieZF6dJPcc9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-x64": {
+      "version": "2.4.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.4.13.tgz",
+      "integrity": "sha512-tTcMkXyBrmHi9BfrD2VNHs/5rYIUKETqsBlYOvSAABwBkJhSDVb5e7wPukftsQbO3WzQkXe6kaztC6WtUOXSoQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
       }
     },
     "node_modules/@blazediff/core": {

--- a/parkhub-web/package.json
+++ b/parkhub-web/package.json
@@ -22,7 +22,10 @@
     "test:e2e:ui": "bash ../scripts/e2e-local.sh --ui",
     "test:e2e:design": "bash ../scripts/e2e-local.sh e2e/design-*.spec.ts",
     "test:a11y": "bash ../scripts/e2e-local.sh e2e/design-accessibility.spec.ts",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "lint": "biome check src/",
+    "lint:fix": "biome check --write src/",
+    "format": "biome format --write src/"
   },
   "dependencies": {
     "@astrojs/react": "^5.0.3",
@@ -60,6 +63,7 @@
   },
   "devDependencies": {
     "@axe-core/playwright": "^4.11.2",
+    "@biomejs/biome": "^2.0.0",
     "@playwright/test": "^1.59.1",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",

--- a/scripts/check-openapi-drift.sh
+++ b/scripts/check-openapi-drift.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+#
+# check-openapi-drift.sh — local pre-push gate that mirrors
+# `.github/workflows/openapi-drift.yml`. Fails if `docs/openapi/rust.json`
+# is out of sync with the live utoipa-generated spec.
+#
+# Approach:
+#   1. Build parkhub-server with `--features 'full,headless'` (cargo
+#      cache makes incremental builds fast).
+#   2. Start it on an ephemeral port, wait for /health.
+#   3. Dump the live OpenAPI JSON to a temp file (jq -S sorted, same
+#      shape as docs/openapi/rust.json).
+#   4. `git diff --no-index --exit-code` against the committed snapshot.
+#   5. Print the regen command if drift is detected.
+#
+# Local dev override — skip this gate when iterating on docs-only PRs:
+#
+#   SKIP_OPENAPI_DRIFT=1 git push
+#
+# (Lefthook will surface that the gate ran but exited 0.)
+
+set -euo pipefail
+
+if [[ "${SKIP_OPENAPI_DRIFT:-0}" == "1" ]]; then
+    echo "openapi-drift: skipped (SKIP_OPENAPI_DRIFT=1)"
+    exit 0
+fi
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+COMMITTED_SPEC="docs/openapi/rust.json"
+PORT="${OPENAPI_DRIFT_PORT:-18181}"
+LIVE_SPEC="$(mktemp -t parkhub-openapi-live-XXXXXX.json)"
+DATA_DIR="$(mktemp -d -t parkhub-openapi-data-XXXXXX)"
+LOG_FILE="$(mktemp -t parkhub-openapi-server-XXXXXX.log)"
+PID_FILE="$(mktemp -t parkhub-openapi-pid-XXXXXX)"
+
+cleanup() {
+    if [[ -s "$PID_FILE" ]]; then
+        local pid
+        pid="$(cat "$PID_FILE")"
+        kill "$pid" 2>/dev/null || true
+        # SIGTERM polite, then SIGKILL after grace period
+        for _ in 1 2 3; do
+            kill -0 "$pid" 2>/dev/null || break
+            sleep 1
+        done
+        kill -9 "$pid" 2>/dev/null || true
+    fi
+    rm -f "$LIVE_SPEC" "$PID_FILE" "$LOG_FILE"
+    rm -rf "$DATA_DIR"
+}
+trap cleanup EXIT
+
+if [[ ! -f "$COMMITTED_SPEC" ]]; then
+    echo "openapi-drift: missing committed spec at $COMMITTED_SPEC" >&2
+    exit 1
+fi
+
+# Embed placeholder for rust_embed (release build needs it before compile).
+mkdir -p parkhub-web/dist
+[[ -f parkhub-web/dist/index.html ]] || \
+    printf '%s' '<!doctype html><html><body></body></html>' \
+    > parkhub-web/dist/index.html
+
+echo "openapi-drift: building parkhub-server (debug, headless+full)..." >&2
+# Debug build is faster than release for local checks; spec output is
+# identical because utoipa derives are compile-time.
+cargo build \
+    --locked \
+    -p parkhub-server \
+    --no-default-features \
+    --features 'full,headless' \
+    >&2
+
+BIN="$REPO_ROOT/target/debug/parkhub-server"
+if [[ ! -x "$BIN" ]]; then
+    echo "openapi-drift: built binary not found at $BIN" >&2
+    exit 1
+fi
+
+echo "openapi-drift: starting server on port $PORT..." >&2
+PARKHUB_ADMIN_PASSWORD=demo DEMO_MODE=true \
+    "$BIN" --headless --unattended --port "$PORT" --data-dir "$DATA_DIR" \
+    > "$LOG_FILE" 2>&1 &
+echo "$!" > "$PID_FILE"
+
+# Wait for /health (max 45s, same as CI).
+ready=0
+for _ in $(seq 1 45); do
+    if curl -fsS "http://localhost:$PORT/health" > /dev/null 2>&1; then
+        ready=1
+        break
+    fi
+    sleep 1
+done
+
+if [[ "$ready" -ne 1 ]]; then
+    echo "openapi-drift: server did not become healthy in time" >&2
+    tail -n 50 "$LOG_FILE" >&2
+    exit 1
+fi
+
+# Dump + normalise (matches scripts/dump-openapi.sh formatting).
+if ! curl -fsS "http://localhost:$PORT/api-docs/openapi.json" \
+        | jq -S '.' > "$LIVE_SPEC"; then
+    echo "openapi-drift: failed to fetch live OpenAPI spec" >&2
+    tail -n 50 "$LOG_FILE" >&2
+    exit 1
+fi
+
+# Diff against committed snapshot. --no-index lets git diff arbitrary
+# files; --exit-code returns 1 on any difference.
+if ! git diff --no-index --exit-code "$COMMITTED_SPEC" "$LIVE_SPEC"; then
+    cat >&2 <<EOF
+::error:: docs/openapi/rust.json is out of sync with the code.
+
+Regenerate locally:
+
+    # In one terminal:
+    cargo run --no-default-features --features 'full,headless' \\
+        -p parkhub-server -- --headless --port 18181
+
+    # In another terminal:
+    ./scripts/dump-openapi.sh 18181
+
+Then commit the updated docs/openapi/rust.json.
+EOF
+    exit 1
+fi
+
+echo "openapi-drift: docs/openapi/rust.json matches the live spec."

--- a/scripts/check-types-drift.sh
+++ b/scripts/check-types-drift.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+#
+# check-types-drift.sh — local pre-push gate that mirrors the
+# `types-drift` job in `.github/workflows/ci.yml`.
+#
+# Runs the gen-types ts_export integration test which emits TypeScript
+# bindings into `parkhub-web/src/generated/types/`, then fails if the
+# working tree differs from HEAD (i.e. Rust source drifted from the
+# committed `.ts` bindings).
+#
+# Both diff and untracked-file checks are performed because adding a
+# new `#[derive(TS)] #[ts(export)]` type creates a brand-new `.ts`
+# file that `git diff` would silently miss.
+#
+# Local dev override:
+#
+#   SKIP_TYPES_DRIFT=1 git push
+
+set -euo pipefail
+
+if [[ "${SKIP_TYPES_DRIFT:-0}" == "1" ]]; then
+    echo "types-drift: skipped (SKIP_TYPES_DRIFT=1)"
+    exit 0
+fi
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+GENERATED_DIR="parkhub-web/src/generated"
+if [[ ! -d "$GENERATED_DIR" ]]; then
+    echo "types-drift: missing generated dir $GENERATED_DIR" >&2
+    exit 1
+fi
+
+# rust_embed needs parkhub-web/dist/ to exist at compile time even for
+# the test build, so seed a placeholder if absent.
+mkdir -p parkhub-web/dist
+[[ -f parkhub-web/dist/index.html ]] || \
+    printf '%s' '<!doctype html><html><body></body></html>' \
+    > parkhub-web/dist/index.html
+
+echo "types-drift: regenerating ts-rs bindings..." >&2
+# This invokes the explicit ts_export integration test (see
+# parkhub-server/tests/ts_export.rs) which calls T::export_all_to(...)
+# for every DTO and stamps a warning header on each emitted .ts file.
+cargo test \
+    --locked \
+    --features gen-types \
+    -p parkhub-server \
+    --test ts_export \
+    -- --nocapture
+
+drift=0
+
+# (1) Modified or deleted tracked files in the generated tree.
+if ! git diff --exit-code -- "$GENERATED_DIR/"; then
+    echo "::error:: $GENERATED_DIR has modified or deleted files (drift from Rust source)." >&2
+    drift=1
+fi
+
+# (2) New types that produced untracked files — git diff misses these.
+untracked="$(git status --porcelain -- "$GENERATED_DIR/")"
+if [[ -n "$untracked" ]]; then
+    echo "::error:: $GENERATED_DIR has untracked or modified files not yet committed:" >&2
+    printf '%s\n' "$untracked" >&2
+    drift=1
+fi
+
+if [[ "$drift" -ne 0 ]]; then
+    cat >&2 <<EOF
+
+Regenerate locally:
+
+    cargo test --features gen-types -p parkhub-server --test ts_export -- --nocapture
+
+Then \`git add parkhub-web/src/generated/\` and commit the updated bindings.
+EOF
+    exit 1
+fi
+
+echo "types-drift: $GENERATED_DIR matches the Rust source."


### PR DESCRIPTION
## Summary

Shifts CI gates left to the dev box so 90 %+ of GitHub Actions failures are caught before push. Replaces the 15-30 min remote feedback loop with a near-instant local one. Drops external SaaS dependencies (no Mergify, no eslint+prettier) in favour of GitHub-native and Rust-native tooling.

Reference plan: `~/Obsidian/Forge/Plans/2026-04-25-parkhub-local-first-ci-workflow.md`

## Files added

- `lefthook.yml` — git-hook config: `pre-commit` (cargo fmt, Biome lint, astro check) and `pre-push` (cargo check + clippy + lib tests on common/server-headless/client; vitest --changed; OpenAPI drift; ts-rs types drift). Gates parallelised, skip-when-not-installed for optional deps.
- `scripts/check-openapi-drift.sh` — local replica of `.github/workflows/openapi-drift.yml`. Builds parkhub-server (debug, headless+full), launches it on port 18181, dumps the live OpenAPI JSON, `git diff --no-index --exit-code` against `docs/openapi/rust.json`. `SKIP_OPENAPI_DRIFT=1` for emergency bypass.
- `scripts/check-types-drift.sh` — local replica of the `types-drift` job. Runs `cargo test --features gen-types -p parkhub-server --test ts_export` then checks both modified-tracked and untracked `.ts` files in `parkhub-web/src/generated/`. `SKIP_TYPES_DRIFT=1` for emergency bypass.
- `.github/workflows/auto-merge.yml` — native auto-merge on `auto-merge` label, squash strategy. No SaaS, no third-party push-access.
- `parkhub-web/biome.json` — Biome 2.x config (lint + format, single-quote + semicolons + 100-col, a11y recommended, generated types excluded).

## Files modified

- `parkhub-server/build.rs` — prints a one-time `cargo:warning` reminder to install lefthook hooks. No-op in CI and once `.git/hooks/pre-push` exists. Strictly informational; never fails the build.
- `Cargo.toml` — `[workspace.metadata.local-ci]` block exposing the hooks tool + install command for tooling introspection.
- `.github/dependabot.yml` — refined groups: `rust-deps` / `npm-deps` / `github-actions` each cover minor+patch updates, keeping major-version bumps individually reviewable.
- `parkhub-web/package.json` — adds `@biomejs/biome ^2.0.0` devDep + `lint` / `lint:fix` / `format` npm scripts.
- `CONTRIBUTING.md` — new "Local CI" section: one-time setup, gate matrix, replay commands, drift quick reference, the 12-fail-cascade cautionary tale, Merge Queue and Auto-merge how-to, operator action required.

## Verification

- All YAML/JSON files validated (`yaml.safe_load`, `json.load` clean).
- Both shell scripts pass `bash -n` syntax check.
- `lefthook dump` resolves the config without errors; `lefthook run pre-commit --command fmt-rust` runs in 0.83 s.
- **Cascade-detection test (the load-bearing one)**: introduced a deliberate `User` construction site missing the `department` field, ran `lefthook run pre-push --command cargo-check --force`. Hook fired, ran `cargo check` against parkhub-common, captured `error[E0063]: missing field \`department\` in initializer of \`User\``, printed the fail_text, and exited non-zero. This is exactly the failure class as the original 12-fail cascade — confirming the gate would have prevented it.
- Cleanup verified: `cargo check -p parkhub-common` finishes in 1.78 s after removing the trigger.

## Operator action required (post-merge)

1. **Allow auto-merge** — Settings → General → Pull Requests → enable "Allow auto-merge".
2. **Branch protection** — list the `Required checks` aggregator job (and `CodeQL`) as required status checks on `main`. Optionally enable "Require merge queue" for serialised merges.
3. **Contributor onboarding** — every contributor runs `npx lefthook install` once on first clone. The `cargo:warning` from `parkhub-server/build.rs` surfaces this on first build; `CONTRIBUTING.md#local-ci` documents the full setup.

## Test plan

- [ ] CI passes on this PR (the gates I'm adding don't change CI behaviour itself).
- [ ] Operator runs `npx lefthook install` locally and confirms hooks are wired in `.git/hooks/`.
- [ ] Operator triggers `lefthook run pre-commit` and `lefthook run pre-push` on a clean checkout to confirm timing matches the gate matrix.
- [ ] Operator enables "Allow auto-merge" + branch protection alignment, then tests the `auto-merge` label end-to-end on a follow-up PR.
- [ ] Operator runs `cd parkhub-web && npm install && npm run lint` to surface the initial Biome violations and decide on a follow-up cleanup PR.