### PR TITLE
ci(deps): pin past tailwind 4.2.4 vite regression

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,6 +25,15 @@ updates:
       npm-deps:
         patterns: ["*"]
         update-types: ["minor", "patch"]
+    ignore:
+      # tailwindcss 4.2.4 / @tailwindcss/vite 4.2.4 ship a vite build
+      # regression: "Missing field tsconfigPaths on
+      # BindingViteResolvePluginConfig.resolveOptions". Pin past it
+      # until 4.2.5+ is released. Drop these entries once upstream ships.
+      - dependency-name: "tailwindcss"
+        versions: ["4.2.4"]
+      - dependency-name: "@tailwindcss/vite"
+        versions: ["4.2.4"]
     labels: ["dependencies", "frontend"]
     open-pull-requests-limit: 5
 


### PR DESCRIPTION
## Summary

`tailwindcss@4.2.4` and `@tailwindcss/vite@4.2.4` ship a vite build regression:

> Missing field `tsconfigPaths` on `BindingViteResolvePluginConfig.resolveOptions`

This breaks the `parkhub-web` vite build. Pin past it via dependabot `ignore` on the `/parkhub-web` npm ecosystem entry until 4.2.5+ is released.

## What changes

Adds an `ignore` block to the `npm` ecosystem entry for `/parkhub-web`:

```yaml
ignore:
  - dependency-name: "tailwindcss"
    versions: ["4.2.4"]
  - dependency-name: "@tailwindcss/vite"
    versions: ["4.2.4"]
```

## Follow-up

Once upstream ships 4.2.5+ (or a 4.3.x line), remove the `ignore` entries so dependabot can resume normal bumps.

## Test plan

- [ ] dependabot.yml parses (Dependabot validates on next scheduled run)
- [ ] Future tailwind 4.2.5+ PRs are still proposed (4.2.4 is the only blocked version)