### PR TITLE
ci(security): bump trivy-action 0.35.0 → v0.36.0 (verified clean)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -71,7 +71,7 @@ jobs:
           sbom: true
 
       - name: Run Trivy vulnerability scan
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         continue-on-error: true
         with:
           image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.push.outputs.digest }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -88,7 +88,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Run Trivy filesystem scan
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         continue-on-error: true
         with:
           scan-type: fs


### PR DESCRIPTION
Brings parkhub-rust into parity with parkhub-php which already pins this SHA.

## Verification (vs March 2026 supply-chain compromise — GHSA-69fq-xp46-6x23)

- v0.36.0 tag is **annotated + SSH-signed** by Aqua maintainer Nikita Pivkin, GitHub-verified, published 2026-04-22 (~33 days after incident containment) — not a force-pushed lightweight tag like the attack vectors
- Target commit `ed142fd0673e97e23eac54620cfb913e5ce36c25` is PGP-signed and verified
- Default trivy CLI in v0.36.0 `action.yaml` is **v0.70.0** (clean re-release from 2026-04-17), NOT the malicious v0.69.4–v0.69.6 range
- 0.35.0 (the version we were on) was the only original tag the attacker could not overwrite — also safe, but we want to track upstream for ongoing fixes

## Files

- `.github/workflows/security.yml` — Trivy filesystem scan
- `.github/workflows/docker-publish.yml` — Trivy image vulnerability scan

## Refs

- https://github.com/aquasecurity/trivy/security/advisories/GHSA-69fq-xp46-6x23
- https://github.com/aquasecurity/trivy/discussions/10425
- Closes follow-up from PR #406 closure