### PR TITLE
ci(deps): Dependabot cooldown + tailwind 4.2.3 ignore

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,11 @@ updates:
       github-actions:
         patterns: ["*"]
         update-types: ["minor", "patch"]
+    cooldown:
+      default-days: 5
+      semver-patch-days: 5
+      semver-minor-days: 10
+      semver-major-days: 15
     labels: ["dependencies", "ci"]
     open-pull-requests-limit: 5
 
@@ -26,14 +31,19 @@ updates:
         patterns: ["*"]
         update-types: ["minor", "patch"]
     ignore:
-      # tailwindcss 4.2.4 / @tailwindcss/vite 4.2.4 ship a vite build
+      # tailwindcss + @tailwindcss/vite 4.2.3 and 4.2.4 ship a vite build
       # regression: "Missing field tsconfigPaths on
-      # BindingViteResolvePluginConfig.resolveOptions". Pin past it
-      # until 4.2.5+ is released. Drop these entries once upstream ships.
+      # BindingViteResolvePluginConfig.resolveOptions". Pin past them
+      # until 4.2.5+ is verified green. Drop once upstream ships fix.
       - dependency-name: "tailwindcss"
-        versions: ["4.2.4"]
+        versions: [">=4.2.3 <4.2.5"]
       - dependency-name: "@tailwindcss/vite"
-        versions: ["4.2.4"]
+        versions: [">=4.2.3 <4.2.5"]
+    cooldown:
+      default-days: 5
+      semver-patch-days: 5
+      semver-minor-days: 10
+      semver-major-days: 15
     labels: ["dependencies", "frontend"]
     open-pull-requests-limit: 5
 
@@ -48,6 +58,11 @@ updates:
       rust-deps:
         patterns: ["*"]
         update-types: ["minor", "patch"]
+    cooldown:
+      default-days: 5
+      semver-patch-days: 5
+      semver-minor-days: 10
+      semver-major-days: 15
     labels: ["dependencies", "rust"]
     open-pull-requests-limit: 5
 
@@ -57,5 +72,10 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 5
+      semver-patch-days: 5
+      semver-minor-days: 10
+      semver-major-days: 15
     labels: ["dependencies", "docker"]
     open-pull-requests-limit: 5


### PR DESCRIPTION
Two small improvements to dependabot.yml driven by today's closed PRs (#405, #406).

## 1. cooldown (NEW since 2025-07)

5/10/15-day delays for patch/minor/major bumps respectively. Stops same-day-released-then-broken patches from landing in our PR queue. Security advisories ignore cooldown, so no patch-window risk.

| update-type | days |
|---|---|
| patch | 5 |
| minor | 10 |
| major | 15 |

Today's tailwind 4.2.3 regression (released and broken within hours) would have been auto-filtered by this.

## 2. Tailwind ignore range

Was: `versions: ["4.2.4"]` for both `tailwindcss` + `@tailwindcss/vite`.
Now: `versions: [">=4.2.3 <4.2.5"]` — same effect, one entry per package instead of a growing discrete list.

## Sources
- https://github.blog/changelog/2025-07-29-dependabot-expanded-cooldown-and-package-manager-support/
- https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference

Mirror PR for parkhub-php incoming.