### PR TITLE
docs: post-merge-train drift cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 ### Added
 
 - **v5 coverage**: SSE-backed Fleet event stream (`/api/v1/events/stream`), uPlot live chart primitive, ts-rs-generated `FleetEvent` types, and axe-core a11y coverage across every v5 route.
+- **Customization Framework v5** — settings, sidebar variants, density, fonts, feature toggles, `deepLinking` gate (#392).
+- **Branding alignment** — user-facing v5 strings switched from "KI"/"AI" to "Assistent" (#394).
+- **CI security swap** — trufflehog (AGPL) replaced by gitleaks binary direct (MIT) (#403).
+- **CodeQL** — actions language analysis split into its own job (#402).
+- **Deps** — tailwind pinned past 4.2.4 vite regression (#404); trivy-action SHA-pinned to v0.36 (#408).
+- **Policies fix** — `Policies.tsx` draft effect re-keyed on `activeId` only; previous dependency on the `active` object reference clobbered in-flight edits on every render (#407).
 
 ---
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -171,7 +171,7 @@ primitives ([docs.github.com/en/actions](https://docs.github.com/en/actions)):
 - **Desktop client compile check** — `ci.yml` now runs a dedicated
   `parkhub-client` compile gate on Linux PRs so Slint/UI breakage is caught
   before release packaging.
-- **Secret scan** — trufflehog on every PR.
+- **Secret scan** — `gitleaks` (MIT) on every PR over the full git history. Replaced trufflehog (AGPL) on 2026-04-25 (#403).
 - **Artifact attestations** — `docker/build-push-action@v7` chains
   `actions/attest-build-provenance@v4` to publish SLSA v1 provenance for every
   pushed image. See

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@
 | **Themes** | OKLCH tokens across `marble_light`, `marble_dark`, `void` — self-hosted Inter-Variable keeps the LCP budget green. |
 | **Command Palette** | cmdk-powered, mounted globally, reachable from every route with `⌘K` / `Ctrl+K`. |
 | **Realtime** | Live cells hydrate from `/api/v1/events/stream` (SSE) with a polling fallback; charts render via uPlot. |
-| **Accessibility** | axe-core runs in CI on every v5 route; keyboard-only nav verified for the full shell + AI panel. |
+| **Accessibility** | axe-core runs in CI on every v5 route; keyboard-only nav verified for the full shell + Assistent panel. |
 | **Types** | `ts-rs` generates `src/generated/types/*` from the Rust backend so Fleet events stay type-safe end-to-end. |
 
 Live demo: <https://parkhub-rust-demo.onrender.com>.


### PR DESCRIPTION
Three doc fixes flagged by audit after today's merge train.

- **README.md**: Accessibility row reads "shell + Assistent panel" (was "AI panel") to match #394
- **DEVELOPMENT.md**: secret-scan line points to gitleaks binary direct (#403), not trufflehog
- **CHANGELOG.md** `[Unreleased]` gains entries for #392 / #394 / #403 / #402 / #404 / #407 / #408

Doc-only, zero code changes.