### PR TITLE
fix(v5/analytics): unblock merge train — wait for lazy UPlotChart canvases

### DIFF
--- a/parkhub-web/src/design-v5/screens/Analytics.test.tsx
+++ b/parkhub-web/src/design-v5/screens/Analytics.test.tsx
@@ -82,8 +82,13 @@ describe('AnalyticsV5', () => {
       expect(screen.getByRole('img', { name: /Auslastung nach Stunde/ })).toBeInTheDocument(),
     );
     expect(screen.getByRole('img', { name: /Auslastung nach Wochentag/ })).toBeInTheDocument();
+    // UPlotChart is lazy()-loaded and the Suspense fallback shares the
+    // aria-label, so the role match alone can land on the placeholder.
+    // Wait for the actual canvases to ensure the chunk has resolved.
     // uPlot renders canvas, not inline-SVG <rect>s — guard the regression.
-    expect(container.querySelectorAll('canvas').length).toBeGreaterThanOrEqual(2);
+    await waitFor(() =>
+      expect(container.querySelectorAll('canvas').length).toBeGreaterThanOrEqual(2),
+    );
     expect(container.querySelectorAll('[data-testid="analytics-chart"] rect').length).toBe(0);
   });
 


### PR DESCRIPTION
**Unblocks all 7+ open PRs.** Currently every open PR's Frontend Build & Test job fails on the same flaky test:

`Analytics.test.tsx > AnalyticsV5 > renders both charts as uPlot canvases with aria-labels`
`AssertionError: expected 0 to be greater than or equal to 2`

## Root cause

`UPlotChart` is `lazy()`-loaded in Analytics.tsx, and the Suspense fallback (line 27) carries the SAME `aria-label` as the real chart. `getByRole('img', {name: /Auslastung nach Stunde/})` matches the FALLBACK, then the synchronous `querySelectorAll('canvas')` runs before the lazy chunk has resolved → 0 canvases.

## Fix

Wrap the canvas count assertion in a second `waitFor` so we wait for the actual chart to mount. The role/aria-label assertions stay before it (they pass on the fallback already).

## Verification

```
$ npx vitest run src/design-v5/screens/Analytics.test.tsx
Test Files  1 passed (1)
     Tests  11 passed (11)
```

Mirror PR for parkhub-php incoming.