### PR TITLE
test(views,components): -41 tsc errors in admin/EV test suites (Phase 4b)

### DIFF
--- a/parkhub-web/src/components/NotificationPreferences.test.tsx
+++ b/parkhub-web/src/components/NotificationPreferences.test.tsx
@@ -271,12 +271,12 @@ describe('NotificationPreferencesComponent', () => {
     const switches = screen.getAllByRole('switch');
 
     await user.click(switches[3]); // push_enabled
-    fireEvent.click(switches[4]); // sms_booking_confirm
-    fireEvent.click(switches[5]); // sms_booking_reminder
-    fireEvent.click(switches[6]); // sms_booking_cancelled
-    fireEvent.click(switches[7]); // whatsapp_booking_confirm
-    fireEvent.click(switches[8]); // whatsapp_booking_reminder
-    fireEvent.click(switches[9]); // whatsapp_booking_cancelled
+    fireEvent.click(switches[4]!!); // sms_booking_confirm
+    fireEvent.click(switches[5]!!); // sms_booking_reminder
+    fireEvent.click(switches[6]!!); // sms_booking_cancelled
+    fireEvent.click(switches[7]!!); // whatsapp_booking_confirm
+    fireEvent.click(switches[8]!!); // whatsapp_booking_reminder
+    fireEvent.click(switches[9]!!); // whatsapp_booking_cancelled
 
     await user.click(screen.getByText('Save Preferences'));
 

--- a/parkhub-web/src/components/NotificationPreferences.test.tsx
+++ b/parkhub-web/src/components/NotificationPreferences.test.tsx
@@ -271,12 +271,12 @@ describe('NotificationPreferencesComponent', () => {
     const switches = screen.getAllByRole('switch');
 
     await user.click(switches[3]); // push_enabled
-    fireEvent.click(switches[4]!!); // sms_booking_confirm
-    fireEvent.click(switches[5]!!); // sms_booking_reminder
-    fireEvent.click(switches[6]!!); // sms_booking_cancelled
-    fireEvent.click(switches[7]!!); // whatsapp_booking_confirm
-    fireEvent.click(switches[8]!!); // whatsapp_booking_reminder
-    fireEvent.click(switches[9]!!); // whatsapp_booking_cancelled
+    fireEvent.click(switches[4]!); // sms_booking_confirm
+    fireEvent.click(switches[5]!); // sms_booking_reminder
+    fireEvent.click(switches[6]!); // sms_booking_cancelled
+    fireEvent.click(switches[7]!); // whatsapp_booking_confirm
+    fireEvent.click(switches[8]!); // whatsapp_booking_reminder
+    fireEvent.click(switches[9]!); // whatsapp_booking_cancelled
 
     await user.click(screen.getByText('Save Preferences'));
 

--- a/parkhub-web/src/views/AdminAnnouncements.test.tsx
+++ b/parkhub-web/src/views/AdminAnnouncements.test.tsx
@@ -89,7 +89,7 @@ describe('AdminAnnouncementsPage', () => {
     render(<AdminAnnouncementsPage />);
     await waitFor(() => expect(screen.getByText('Maintenance')).toBeInTheDocument());
     const editBtns = screen.getAllByLabelText(/common.edit/);
-    fireEvent.click(editBtns[0]);
+    fireEvent.click(editBtns[0]!!);
     await waitFor(() => expect(screen.getByDisplayValue('Maintenance')).toBeInTheDocument());
   });
 
@@ -104,7 +104,7 @@ describe('AdminAnnouncementsPage', () => {
     render(<AdminAnnouncementsPage />);
     await waitFor(() => expect(screen.getByText('Maintenance')).toBeInTheDocument());
     const delBtns = screen.getAllByLabelText(/common.delete/);
-    fireEvent.click(delBtns[0]);
+    fireEvent.click(delBtns[0]!!);
     await waitFor(() => expect(screen.getByTestId('confirm-dialog')).toBeInTheDocument());
     fireEvent.click(screen.getByText('ConfirmDel'));
     await waitFor(() => expect(mockDeleteAnnouncement).toHaveBeenCalledWith('a1'));
@@ -197,11 +197,11 @@ describe('AdminAnnouncementsPage', () => {
     await waitFor(() => expect(screen.getByText('Maintenance')).toBeInTheDocument());
     // Edit the first announcement
     const editBtns = screen.getAllByLabelText(/common.edit/);
-    fireEvent.click(editBtns[0]);
+    fireEvent.click(editBtns[0]!!);
     await waitFor(() => expect(screen.getByDisplayValue('Maintenance')).toBeInTheDocument());
     // Delete it
     const delBtns = screen.getAllByLabelText(/common.delete/);
-    fireEvent.click(delBtns[0]);
+    fireEvent.click(delBtns[0]!!);
     await waitFor(() => expect(screen.getByTestId('confirm-dialog')).toBeInTheDocument());
     fireEvent.click(screen.getByText('ConfirmDel'));
     await waitFor(() => expect(mockDeleteAnnouncement).toHaveBeenCalled());

--- a/parkhub-web/src/views/AdminAnnouncements.test.tsx
+++ b/parkhub-web/src/views/AdminAnnouncements.test.tsx
@@ -89,7 +89,7 @@ describe('AdminAnnouncementsPage', () => {
     render(<AdminAnnouncementsPage />);
     await waitFor(() => expect(screen.getByText('Maintenance')).toBeInTheDocument());
     const editBtns = screen.getAllByLabelText(/common.edit/);
-    fireEvent.click(editBtns[0]!!);
+    fireEvent.click(editBtns[0]!);
     await waitFor(() => expect(screen.getByDisplayValue('Maintenance')).toBeInTheDocument());
   });
 
@@ -104,7 +104,7 @@ describe('AdminAnnouncementsPage', () => {
     render(<AdminAnnouncementsPage />);
     await waitFor(() => expect(screen.getByText('Maintenance')).toBeInTheDocument());
     const delBtns = screen.getAllByLabelText(/common.delete/);
-    fireEvent.click(delBtns[0]!!);
+    fireEvent.click(delBtns[0]!);
     await waitFor(() => expect(screen.getByTestId('confirm-dialog')).toBeInTheDocument());
     fireEvent.click(screen.getByText('ConfirmDel'));
     await waitFor(() => expect(mockDeleteAnnouncement).toHaveBeenCalledWith('a1'));
@@ -197,11 +197,11 @@ describe('AdminAnnouncementsPage', () => {
     await waitFor(() => expect(screen.getByText('Maintenance')).toBeInTheDocument());
     // Edit the first announcement
     const editBtns = screen.getAllByLabelText(/common.edit/);
-    fireEvent.click(editBtns[0]!!);
+    fireEvent.click(editBtns[0]!);
     await waitFor(() => expect(screen.getByDisplayValue('Maintenance')).toBeInTheDocument());
     // Delete it
     const delBtns = screen.getAllByLabelText(/common.delete/);
-    fireEvent.click(delBtns[0]!!);
+    fireEvent.click(delBtns[0]!);
     await waitFor(() => expect(screen.getByTestId('confirm-dialog')).toBeInTheDocument());
     fireEvent.click(screen.getByText('ConfirmDel'));
     await waitFor(() => expect(mockDeleteAnnouncement).toHaveBeenCalled());

--- a/parkhub-web/src/views/AdminSSO.test.tsx
+++ b/parkhub-web/src/views/AdminSSO.test.tsx
@@ -171,12 +171,12 @@ describe('AdminSSOPage', () => {
 
     // Fill in form fields
     const inputs = screen.getAllByRole('textbox');
-    fireEvent.change(inputs[0], { target: { value: 'test-sso' } }); // slug
-    fireEvent.change(inputs[1], { target: { value: 'Test SSO' } }); // display name
-    fireEvent.change(inputs[2], { target: { value: 'https://idp.test' } }); // entity id
-    fireEvent.change(inputs[3], { target: { value: 'https://idp.test/sso' } }); // sso url
-    fireEvent.change(inputs[4], { target: { value: 'https://idp.test/metadata' } }); // metadata url
-    fireEvent.change(inputs[5], { target: { value: 'MIIC...' } }); // certificate
+    fireEvent.change(inputs[0]!!, { target: { value: 'test-sso' } }); // slug
+    fireEvent.change(inputs[1]!!, { target: { value: 'Test SSO' } }); // display name
+    fireEvent.change(inputs[2]!!, { target: { value: 'https://idp.test' } }); // entity id
+    fireEvent.change(inputs[3]!!, { target: { value: 'https://idp.test/sso' } }); // sso url
+    fireEvent.change(inputs[4]!!, { target: { value: 'https://idp.test/metadata' } }); // metadata url
+    fireEvent.change(inputs[5]!!, { target: { value: 'MIIC...' } }); // certificate
 
     fireEvent.click(screen.getByText('Save'));
     await waitFor(() => {
@@ -275,11 +275,11 @@ describe('AdminSSOPage', () => {
     render(<AdminSSOPage />);
     await waitFor(() => fireEvent.click(screen.getByText('Add Provider')));
     const inputs = screen.getAllByRole('textbox');
-    fireEvent.change(inputs[0], { target: { value: 'test' } });
-    fireEvent.change(inputs[1], { target: { value: 'Test' } });
-    fireEvent.change(inputs[2], { target: { value: 'https://e' } });
-    fireEvent.change(inputs[3], { target: { value: 'https://s' } });
-    fireEvent.change(inputs[5], { target: { value: 'CERT' } });
+    fireEvent.change(inputs[0]!!, { target: { value: 'test' } });
+    fireEvent.change(inputs[1]!!, { target: { value: 'Test' } });
+    fireEvent.change(inputs[2]!!, { target: { value: 'https://e' } });
+    fireEvent.change(inputs[3]!!, { target: { value: 'https://s' } });
+    fireEvent.change(inputs[5]!!, { target: { value: 'CERT' } });
     fireEvent.click(screen.getByText('Save'));
     await waitFor(() => expect(mockToastError).toHaveBeenCalledWith('Duplicate slug'));
   });
@@ -293,11 +293,11 @@ describe('AdminSSOPage', () => {
     render(<AdminSSOPage />);
     await waitFor(() => fireEvent.click(screen.getByText('Add Provider')));
     const inputs = screen.getAllByRole('textbox');
-    fireEvent.change(inputs[0], { target: { value: 'test' } });
-    fireEvent.change(inputs[1], { target: { value: 'Test' } });
-    fireEvent.change(inputs[2], { target: { value: 'https://e' } });
-    fireEvent.change(inputs[3], { target: { value: 'https://s' } });
-    fireEvent.change(inputs[5], { target: { value: 'CERT' } });
+    fireEvent.change(inputs[0]!!, { target: { value: 'test' } });
+    fireEvent.change(inputs[1]!!, { target: { value: 'Test' } });
+    fireEvent.change(inputs[2]!!, { target: { value: 'https://e' } });
+    fireEvent.change(inputs[3]!!, { target: { value: 'https://s' } });
+    fireEvent.change(inputs[5]!!, { target: { value: 'CERT' } });
     fireEvent.click(screen.getByText('Save'));
     await waitFor(() => expect(mockToastError).toHaveBeenCalled());
   });

--- a/parkhub-web/src/views/AdminSSO.test.tsx
+++ b/parkhub-web/src/views/AdminSSO.test.tsx
@@ -171,12 +171,12 @@ describe('AdminSSOPage', () => {
 
     // Fill in form fields
     const inputs = screen.getAllByRole('textbox');
-    fireEvent.change(inputs[0]!!, { target: { value: 'test-sso' } }); // slug
-    fireEvent.change(inputs[1]!!, { target: { value: 'Test SSO' } }); // display name
-    fireEvent.change(inputs[2]!!, { target: { value: 'https://idp.test' } }); // entity id
-    fireEvent.change(inputs[3]!!, { target: { value: 'https://idp.test/sso' } }); // sso url
-    fireEvent.change(inputs[4]!!, { target: { value: 'https://idp.test/metadata' } }); // metadata url
-    fireEvent.change(inputs[5]!!, { target: { value: 'MIIC...' } }); // certificate
+    fireEvent.change(inputs[0]!, { target: { value: 'test-sso' } }); // slug
+    fireEvent.change(inputs[1]!, { target: { value: 'Test SSO' } }); // display name
+    fireEvent.change(inputs[2]!, { target: { value: 'https://idp.test' } }); // entity id
+    fireEvent.change(inputs[3]!, { target: { value: 'https://idp.test/sso' } }); // sso url
+    fireEvent.change(inputs[4]!, { target: { value: 'https://idp.test/metadata' } }); // metadata url
+    fireEvent.change(inputs[5]!, { target: { value: 'MIIC...' } }); // certificate
 
     fireEvent.click(screen.getByText('Save'));
     await waitFor(() => {
@@ -275,11 +275,11 @@ describe('AdminSSOPage', () => {
     render(<AdminSSOPage />);
     await waitFor(() => fireEvent.click(screen.getByText('Add Provider')));
     const inputs = screen.getAllByRole('textbox');
-    fireEvent.change(inputs[0]!!, { target: { value: 'test' } });
-    fireEvent.change(inputs[1]!!, { target: { value: 'Test' } });
-    fireEvent.change(inputs[2]!!, { target: { value: 'https://e' } });
-    fireEvent.change(inputs[3]!!, { target: { value: 'https://s' } });
-    fireEvent.change(inputs[5]!!, { target: { value: 'CERT' } });
+    fireEvent.change(inputs[0]!, { target: { value: 'test' } });
+    fireEvent.change(inputs[1]!, { target: { value: 'Test' } });
+    fireEvent.change(inputs[2]!, { target: { value: 'https://e' } });
+    fireEvent.change(inputs[3]!, { target: { value: 'https://s' } });
+    fireEvent.change(inputs[5]!, { target: { value: 'CERT' } });
     fireEvent.click(screen.getByText('Save'));
     await waitFor(() => expect(mockToastError).toHaveBeenCalledWith('Duplicate slug'));
   });
@@ -293,11 +293,11 @@ describe('AdminSSOPage', () => {
     render(<AdminSSOPage />);
     await waitFor(() => fireEvent.click(screen.getByText('Add Provider')));
     const inputs = screen.getAllByRole('textbox');
-    fireEvent.change(inputs[0]!!, { target: { value: 'test' } });
-    fireEvent.change(inputs[1]!!, { target: { value: 'Test' } });
-    fireEvent.change(inputs[2]!!, { target: { value: 'https://e' } });
-    fireEvent.change(inputs[3]!!, { target: { value: 'https://s' } });
-    fireEvent.change(inputs[5]!!, { target: { value: 'CERT' } });
+    fireEvent.change(inputs[0]!, { target: { value: 'test' } });
+    fireEvent.change(inputs[1]!, { target: { value: 'Test' } });
+    fireEvent.change(inputs[2]!, { target: { value: 'https://e' } });
+    fireEvent.change(inputs[3]!, { target: { value: 'https://s' } });
+    fireEvent.change(inputs[5]!, { target: { value: 'CERT' } });
     fireEvent.click(screen.getByText('Save'));
     await waitFor(() => expect(mockToastError).toHaveBeenCalled());
   });

--- a/parkhub-web/src/views/AdminWebhooks.test.tsx
+++ b/parkhub-web/src/views/AdminWebhooks.test.tsx
@@ -84,7 +84,7 @@ describe('AdminWebhooksPage', () => {
     render(<AdminWebhooksPage />);
     await waitFor(() => {
       const editBtns = screen.getAllByLabelText('webhooksV2.edit');
-      fireEvent.click(editBtns[0]);
+      fireEvent.click(editBtns[0]!!);
     });
     expect(screen.getByText('webhooksV2.editWebhook')).toBeInTheDocument();
   });
@@ -93,7 +93,7 @@ describe('AdminWebhooksPage', () => {
     render(<AdminWebhooksPage />);
     await waitFor(() => {
       const delBtns = screen.getAllByLabelText('webhooksV2.delete');
-      fireEvent.click(delBtns[0]);
+      fireEvent.click(delBtns[0]!!);
     });
     await waitFor(() => expect(toast.success).toHaveBeenCalledWith('webhooksV2.deleted'));
   });
@@ -102,7 +102,7 @@ describe('AdminWebhooksPage', () => {
     render(<AdminWebhooksPage />);
     await waitFor(() => {
       const testBtns = screen.getAllByLabelText('webhooksV2.test');
-      fireEvent.click(testBtns[0]);
+      fireEvent.click(testBtns[0]!!);
     });
     await waitFor(() => expect(toast.success).toHaveBeenCalledWith('webhooksV2.testSuccess'));
   });
@@ -121,7 +121,7 @@ describe('AdminWebhooksPage', () => {
     render(<AdminWebhooksPage />);
     await waitFor(() => {
       const delivBtns = screen.getAllByLabelText('webhooksV2.deliveries');
-      fireEvent.click(delivBtns[0]);
+      fireEvent.click(delivBtns[0]!!);
     });
     await waitFor(() => expect(screen.getByText('webhooksV2.deliveryLog')).toBeInTheDocument());
   });

--- a/parkhub-web/src/views/AdminWebhooks.test.tsx
+++ b/parkhub-web/src/views/AdminWebhooks.test.tsx
@@ -84,7 +84,7 @@ describe('AdminWebhooksPage', () => {
     render(<AdminWebhooksPage />);
     await waitFor(() => {
       const editBtns = screen.getAllByLabelText('webhooksV2.edit');
-      fireEvent.click(editBtns[0]!!);
+      fireEvent.click(editBtns[0]!);
     });
     expect(screen.getByText('webhooksV2.editWebhook')).toBeInTheDocument();
   });
@@ -93,7 +93,7 @@ describe('AdminWebhooksPage', () => {
     render(<AdminWebhooksPage />);
     await waitFor(() => {
       const delBtns = screen.getAllByLabelText('webhooksV2.delete');
-      fireEvent.click(delBtns[0]!!);
+      fireEvent.click(delBtns[0]!);
     });
     await waitFor(() => expect(toast.success).toHaveBeenCalledWith('webhooksV2.deleted'));
   });
@@ -102,7 +102,7 @@ describe('AdminWebhooksPage', () => {
     render(<AdminWebhooksPage />);
     await waitFor(() => {
       const testBtns = screen.getAllByLabelText('webhooksV2.test');
-      fireEvent.click(testBtns[0]!!);
+      fireEvent.click(testBtns[0]!);
     });
     await waitFor(() => expect(toast.success).toHaveBeenCalledWith('webhooksV2.testSuccess'));
   });
@@ -121,7 +121,7 @@ describe('AdminWebhooksPage', () => {
     render(<AdminWebhooksPage />);
     await waitFor(() => {
       const delivBtns = screen.getAllByLabelText('webhooksV2.deliveries');
-      fireEvent.click(delivBtns[0]!!);
+      fireEvent.click(delivBtns[0]!);
     });
     await waitFor(() => expect(screen.getByText('webhooksV2.deliveryLog')).toBeInTheDocument());
   });

--- a/parkhub-web/src/views/EVCharging.test.tsx
+++ b/parkhub-web/src/views/EVCharging.test.tsx
@@ -72,7 +72,7 @@ const sampleLots = [{ id: 'lot-1', name: 'Main Lot' }];
 
 describe('EVChargingPage', () => {
   beforeEach(() => {
-    global.fetch = vi.fn((url: string) => {
+    (global as any).fetch = vi.fn((url: string) => {
       if (typeof url === 'string' && url.includes('/chargers/sessions')) {
         return Promise.resolve({ json: () => Promise.resolve({ success: true, data: [] }) } as Response);
       }
@@ -119,7 +119,7 @@ describe('EVChargingPage', () => {
 
 describe('AdminChargersPage', () => {
   beforeEach(() => {
-    global.fetch = vi.fn(() =>
+    (global as any).fetch = vi.fn(() =>
       Promise.resolve({ json: () => Promise.resolve({ success: true, data: { total_chargers: 8, available: 5, in_use: 2, offline: 1, total_sessions: 120, total_kwh: 1500.5 } }) } as Response)
     );
   });
@@ -147,7 +147,7 @@ describe('EVChargingPage - extended', () => {
   afterEach(() => vi.restoreAllMocks());
 
   it('shows empty chargers state', async () => {
-    global.fetch = vi.fn((url: string) => {
+    (global as any).fetch = vi.fn((url: string) => {
       if (typeof url === 'string' && url.includes('/chargers/sessions')) {
         return Promise.resolve({ json: () => Promise.resolve({ success: true, data: [] }) } as Response);
       }
@@ -164,7 +164,7 @@ describe('EVChargingPage - extended', () => {
   });
 
   it('shows help text', async () => {
-    global.fetch = vi.fn((url: string) => {
+    (global as any).fetch = vi.fn((url: string) => {
       if (typeof url === 'string' && url.includes('/lots')) {
         return Promise.resolve({ json: () => Promise.resolve({ success: true, data: [{ id: 'lot-1', name: 'Main Lot' }] }) } as Response);
       }
@@ -195,7 +195,7 @@ describe('EVChargingPage - extended', () => {
       }
       return Promise.resolve({ json: () => Promise.resolve({ success: true, data: [] }) } as Response);
     });
-    global.fetch = mockFetch;
+    (global as any).fetch = mockFetch;
     render(<EVChargingPage />);
     await waitFor(() => expect(screen.getByText('Start Charging')).toBeTruthy());
     fireEvent.click(screen.getByText('Start Charging'));
@@ -204,7 +204,7 @@ describe('EVChargingPage - extended', () => {
 
   it('start charging failure', async () => {
 
-    global.fetch = vi.fn((url: string) => {
+    (global as any).fetch = vi.fn((url: string) => {
       if (typeof url === 'string' && url.includes('/start')) {
         return Promise.resolve({ json: () => Promise.resolve({ success: false, error: { message: 'Busy' } }) } as Response);
       }
@@ -229,7 +229,7 @@ describe('EVChargingPage - extended', () => {
 
   it('start charging network error', async () => {
 
-    global.fetch = vi.fn((url: string) => {
+    (global as any).fetch = vi.fn((url: string) => {
       if (typeof url === 'string' && url.includes('/start')) {
         return Promise.reject(new Error('net'));
       }
@@ -254,7 +254,7 @@ describe('EVChargingPage - extended', () => {
 
   it('stops charging with active session', async () => {
     const sessions = [{ id: 'ses1', charger_id: 'ch1', user_id: 'u1', start_time: '2026-04-10T08:00:00Z', end_time: null, kwh_consumed: 5.5, status: 'active' }];
-    global.fetch = vi.fn((url: string) => {
+    (global as any).fetch = vi.fn((url: string) => {
       if (typeof url === 'string' && url.includes('/stop')) {
         return Promise.resolve({ json: () => Promise.resolve({ success: true }) } as Response);
       }
@@ -280,7 +280,7 @@ describe('EVChargingPage - extended', () => {
   it('stop charging failure', async () => {
 
     const sessions = [{ id: 'ses1', charger_id: 'ch1', user_id: 'u1', start_time: '2026-04-10T08:00:00Z', end_time: null, kwh_consumed: 5, status: 'active' }];
-    global.fetch = vi.fn((url: string) => {
+    (global as any).fetch = vi.fn((url: string) => {
       if (typeof url === 'string' && url.includes('/stop')) {
         return Promise.resolve({ json: () => Promise.resolve({ success: false, error: { message: 'Cannot stop' } }) } as Response);
       }
@@ -307,7 +307,7 @@ describe('EVChargingPage - extended', () => {
     const sessions = [
       { id: 'ses1', charger_id: 'ch1', user_id: 'u1', start_time: '2026-04-08T08:00:00Z', end_time: '2026-04-08T10:00:00Z', kwh_consumed: 15.3, status: 'completed' },
     ];
-    global.fetch = vi.fn((url: string) => {
+    (global as any).fetch = vi.fn((url: string) => {
       if (typeof url === 'string' && url.includes('/chargers/sessions')) {
         return Promise.resolve({ json: () => Promise.resolve({ success: true, data: sessions }) } as Response);
       }
@@ -325,7 +325,7 @@ describe('EVChargingPage - extended', () => {
   });
 
   it('lot selector changes chargers', async () => {
-    global.fetch = vi.fn((url: string) => {
+    (global as any).fetch = vi.fn((url: string) => {
       if (typeof url === 'string' && url.includes('/chargers/sessions')) {
         return Promise.resolve({ json: () => Promise.resolve({ success: true, data: [] }) } as Response);
       }
@@ -349,7 +349,7 @@ describe('EVChargingPage - extended', () => {
   });
 
   it('shows location hint when present', async () => {
-    global.fetch = vi.fn((url: string) => {
+    (global as any).fetch = vi.fn((url: string) => {
       if (typeof url === 'string' && url.includes('/chargers/sessions')) {
         return Promise.resolve({ json: () => Promise.resolve({ success: true, data: [] }) } as Response);
       }


### PR DESCRIPTION
Phase 4b. Same triple-pattern as Phase 4a (#418): `(global as any).fetch` cast, `arr[N]!`, `([url,opts]:any)`. -41 errors across 6 files. 171/171 vitest pass. Mirror PR for parkhub-php incoming.