### PR TITLE
chore(version): bump to 4.15.0 — 2026-04-25 release wave + parkhub-php parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+---
+
+## [4.15.0] - 2026-04-25
+
+Minor bump landing the 2026-04-25 release wave: v5 customization framework,
+branding alignment, broad CI/security/test-infrastructure cleanup, and
+~236 fewer typecheck-ts errors via Phase 1–4b. Aligns with parkhub-php
+4.14.0 release per `docs/parity-governance.md` (parkhub-php catches the
+4.14 baseline; both runtimes ship 4.15 in lockstep next cycle).
+
 ### Changed
 
 - **Design v5 rollout complete**: all 26 navigation screens now ship as real v5 components; the `<PlaceholderV5>` fallback has been retired and `SCREENS` is typed as a total `Record<ScreenId, …>` so missing screens become compile-time errors instead of runtime fallbacks.
@@ -20,9 +30,14 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 - **Customization Framework v5** — settings, sidebar variants, density, fonts, feature toggles, `deepLinking` gate (#392).
 - **Branding alignment** — user-facing v5 strings switched from "KI"/"AI" to "Assistent" (#394).
 - **CI security swap** — trufflehog (AGPL) replaced by gitleaks binary direct (MIT) (#403).
-- **CodeQL** — actions language analysis split into its own job (#402).
-- **Deps** — tailwind pinned past 4.2.4 vite regression (#404); trivy-action SHA-pinned to v0.36 (#408).
+- **CodeQL** — actions language analysis split into its own job (#402); `required_status_checks` migrated from legacy `CodeQL` aggregate to language-specific `Analyze (rust|javascript-typescript|actions)` to eliminate the NEUTRAL-blocks-merge edge case.
+- **Deps** — tailwind pinned past 4.2.4 vite regression (#404); trivy-action SHA-pinned to v0.36 (#408); Dependabot cooldown defaults 5/10/15-day (#409).
 - **Policies fix** — `Policies.tsx` draft effect re-keyed on `activeId` only; previous dependency on the `active` object reference clobbered in-flight edits on every render (#407).
+- **Analytics test fix** — wait for lazy `UPlotChart` canvases before counting (#416).
+- **typescript devDep + @astrojs/check** installed so `npx tsc` / `astro check` actually run instead of silently passing on missing tools (#414, lefthook hardening #412).
+- **Phase 1–4b tsc cleanup** — typed `firstCall`/`nthCall` helpers in `client.test.ts` (#415), `wsAt` helper in `useWebSocket.test.ts` (#417), Phase 4a/4b view-test pattern triple `(global as any).fetch + arr[N]! + ([url,opts]:any)` across Visitors/AdminUpdates/AdminSSO/AdminWebhooks/EVCharging/AdminZones/AdminAnnouncements/NotificationPreferences (#418, #419). Drives parkhub-web tsc baseline from 558 → ~322 errors.
+- **parity-governance.md** aligned across both runtimes (#413).
+- **parkhub-web README** — replaced Astro starter boilerplate with real workspace overview (#411).
 
 ---
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6550,7 +6550,7 @@ dependencies = [
 
 [[package]]
 name = "parkhub-client"
-version = "4.14.2"
+version = "4.15.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6577,7 +6577,7 @@ dependencies = [
 
 [[package]]
 name = "parkhub-common"
-version = "4.14.2"
+version = "4.15.0"
 dependencies = [
  "chrono",
  "proptest",
@@ -6591,7 +6591,7 @@ dependencies = [
 
 [[package]]
 name = "parkhub-desktop"
-version = "4.14.2"
+version = "4.15.0"
 dependencies = [
  "directories",
  "serde",
@@ -6615,7 +6615,7 @@ dependencies = [
 
 [[package]]
 name = "parkhub-server"
-version = "4.14.2"
+version = "4.15.0"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "4.14.2"
+version = "4.15.0"
 edition = "2024"
 rust-version = "1.94"
 authors = ["nash87"]

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <p align="center">
   <a href="https://github.com/nash87/parkhub-rust/actions/workflows/ci.yml"><img src="https://github.com/nash87/parkhub-rust/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <a href="CHANGELOG.md"><img src="https://img.shields.io/badge/Release-v4.14.2-brightgreen.svg?style=flat-square" alt="v4.14.2"></a>
+  <a href="CHANGELOG.md"><img src="https://img.shields.io/badge/Release-v4.15.0-brightgreen.svg?style=flat-square" alt="v4.15.0"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square" alt="MIT License"></a>
   <a href="https://www.rust-lang.org/"><img src="https://img.shields.io/badge/Rust-1.94%2B-orange.svg?style=flat-square&logo=rust&logoColor=white" alt="Rust 1.94+"></a>
   <a href="https://astro.build/"><img src="https://img.shields.io/badge/Astro-6-BC52EE.svg?style=flat-square&logo=astro&logoColor=white" alt="Astro 6"></a>
@@ -73,7 +73,7 @@ Live demo: <https://parkhub-rust-demo.onrender.com>.
 
 ---
 
-## What's New in v4.14.2
+## What's New in v4.15.0
 
 | Feature | Description |
 |---------|-------------|


### PR DESCRIPTION
Per `docs/parity-governance.md` both runtimes publish the same version surface. parkhub-rust shipped 4.14.x quickly after the v4.13 release branch (#340 #343 #344 #346); parkhub-php caught up to 4.14.0 in parkhub-php#381 today. This stamps the 2026-04-25 release wave on rust.

Files: `Cargo.toml` workspace.package.version (4.14.2 → 4.15.0), README badge, CHANGELOG section enumerating today's PRs (#392 #394 #402 #403 #404 #407 #408 #409 #411 #412 #413 #414 #415 #416 #417 #418 #419).