### PR TITLE
chore(web): bump root + parkhub-web/package.json to 4.15.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "parkhub",
-  "version": "4.13.0",
+  "version": "4.15.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "parkhub",
-      "version": "4.13.0",
+      "version": "4.15.0",
       "license": "ISC",
       "devDependencies": {
         "@axe-core/playwright": "^4.11.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parkhub",
-  "version": "4.13.0",
+  "version": "4.15.0",
   "description": "Open source parking lot management system with client-server architecture.",
   "scripts": {
     "test:e2e": "npx playwright test",

--- a/parkhub-web/package-lock.json
+++ b/parkhub-web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "parkhub-web",
-  "version": "4.13.4",
+  "version": "4.15.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "parkhub-web",
-      "version": "4.13.4",
+      "version": "4.15.0",
       "dependencies": {
         "@astrojs/react": "^5.0.3",
         "@fontsource-variable/inter": "^5.2.8",

--- a/parkhub-web/package.json
+++ b/parkhub-web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "parkhub-web",
   "type": "module",
-  "version": "4.13.4",
+  "version": "4.15.0",
   "engines": {
     "node": ">=22.12.0"
   },


### PR DESCRIPTION
Followup to #420 (Cargo.toml 4.14.2 → 4.15.0). Root package.json (was 4.13.0) and parkhub-web/package.json (was 4.13.4) sync to 4.15.0.