### PR TITLE
ci: pilot fop local-first PR attestation

### DIFF
--- a/.github/scripts/fop-local-ci.sh
+++ b/.github/scripts/fop-local-ci.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: .github/scripts/fop-local-ci.sh [--profile pr|full|cd] [--dry-run] [--post-status]
+
+Runs ParkHub's local-first CI through fop's build queue. The optional
+--post-status flag publishes the commit status context for the selected
+profile. The GitHub PR attestation gate expects this exact command:
+
+  .github/scripts/fop-local-ci.sh --profile pr --post-status
+
+Profiles:
+  pr    Fast PR gate: format, Rust headless checks, frontend tests/build,
+        TypeScript typecheck, generated type drift.
+  full  PR gate plus OpenAPI drift and Playwright smoke/e2e.
+  cd    Release-oriented build and supply-chain preflight.
+EOF
+}
+
+profile="pr"
+dry_run=0
+post_status=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --profile)
+      profile="${2:?missing profile}"
+      shift 2
+      ;;
+    --dry-run)
+      dry_run=1
+      shift
+      ;;
+    --post-status)
+      post_status=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+case "$profile" in
+  pr|full|cd) ;;
+  *)
+    echo "invalid profile: $profile" >&2
+    exit 2
+    ;;
+esac
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+sha="$(git rev-parse HEAD)"
+context="fop/local-ci/${profile}"
+report_dir="$repo_root/.fop/reports"
+report_path="$report_dir/local-ci-${profile}-${sha}.json"
+started_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+status_repo() {
+  if [[ -n "${FOP_LOCAL_CI_STATUS_REPO:-}" ]]; then
+    printf '%s\n' "$FOP_LOCAL_CI_STATUS_REPO"
+    return 0
+  fi
+  for remote in github upstream origin; do
+    url="$(git remote get-url "$remote" 2>/dev/null || true)"
+    if [[ "$url" =~ github.com[:/]([^/]+/[^/.]+)(\.git)?$ ]]; then
+      printf '%s\n' "${BASH_REMATCH[1]}"
+      return 0
+    fi
+  done
+  echo "unable to derive GitHub owner/repo; set FOP_LOCAL_CI_STATUS_REPO" >&2
+  return 1
+}
+
+post_commit_status() {
+  local state="$1"
+  local description="$2"
+  if [[ "$post_status" -ne 1 || "$dry_run" -eq 1 ]]; then
+    return 0
+  fi
+  if ! command -v gh >/dev/null 2>&1; then
+    echo "gh is required for --post-status" >&2
+    return 1
+  fi
+
+  gh api \
+    --method POST \
+    "repos/$(status_repo)/statuses/${sha}" \
+    -f state="$state" \
+    -f context="$context" \
+    -f description="$description" >/dev/null
+}
+
+write_report() {
+  local state="$1"
+  local failed_step="${2:-}"
+  mkdir -p "$report_dir"
+  cat > "$report_path" <<EOF
+{
+  "schema": "parkhub.local-ci.v1",
+  "profile": "$profile",
+  "state": "$state",
+  "commit": "$sha",
+  "started_at": "$started_at",
+  "finished_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+  "failed_step": "$failed_step",
+  "context": "$context"
+}
+EOF
+}
+
+run_step() {
+  local name="$1"
+  local command="$2"
+  printf '\n==> %s\n' "$name"
+  if [[ "$dry_run" -eq 1 ]]; then
+    printf 'DRY-RUN: %s\n' "$command"
+    return 0
+  fi
+  fop build --backend local . --preset custom -- bash -euo pipefail -c "$command"
+}
+
+run_direct() {
+  local name="$1"
+  local command="$2"
+  printf '\n==> %s\n' "$name"
+  if [[ "$dry_run" -eq 1 ]]; then
+    printf 'DRY-RUN: %s\n' "$command"
+    return 0
+  fi
+  bash -euo pipefail -c "$command"
+}
+
+mark_failure() {
+  local line="$1"
+  write_report "failure" "line:${line}"
+  post_commit_status "failure" "fop local ${profile} failed"
+}
+trap 'mark_failure "$LINENO"' ERR
+
+post_commit_status "pending" "fop local ${profile} running"
+
+run_direct "working tree whitespace" "git diff --check"
+
+run_step "cargo fmt" "cargo fmt --all -- --check"
+
+run_step "cargo check headless" "mkdir -p parkhub-web/dist && printf '%s' '<!doctype html><html><body></body></html>' > parkhub-web/dist/index.html && cargo check --locked --package parkhub-common --all-targets && cargo check --locked --package parkhub-server --no-default-features --features headless --all-targets"
+
+run_step "cargo clippy headless" "mkdir -p parkhub-web/dist && printf '%s' '<!doctype html><html><body></body></html>' > parkhub-web/dist/index.html && cargo clippy --locked --package parkhub-common --all-targets -- -D warnings && cargo clippy --locked --package parkhub-server --no-default-features --features headless --all-targets -- -D warnings -A clippy::cognitive_complexity -A clippy::assigning_clones"
+
+run_step "frontend typecheck" "cd parkhub-web && ./node_modules/.bin/tsc --noEmit"
+
+run_step "frontend test and build" "cd parkhub-web && npm test && npm run build"
+
+run_step "typescript bindings drift" "mkdir -p parkhub-web/dist && printf '%s' '<!doctype html><html><body></body></html>' > parkhub-web/dist/index.html && cargo test --locked --features gen-types -p parkhub-server --test ts_export -- --nocapture && git diff --exit-code parkhub-web/src/generated/ && test -z \"\$(git status --porcelain parkhub-web/src/generated/)\""
+
+if [[ "$profile" == "full" ]]; then
+  run_step "openapi drift" "cd parkhub-web && npm run build && cd .. && cargo build --locked --release -p parkhub-server --no-default-features --features 'full,headless' && pid=''; cleanup() { if [[ -n \"\${pid:-}\" ]]; then kill \"\$pid\" 2>/dev/null || true; fi; }; trap cleanup EXIT; mkdir -p /tmp/parkhub-drift-db && { ./target/release/parkhub-server --headless --unattended --port 18181 --data-dir /tmp/parkhub-drift-db >/tmp/parkhub-drift.log 2>&1 & pid=\$!; }; for i in \$(seq 1 45); do curl -sf http://localhost:18181/health >/dev/null 2>&1 && break; sleep 1; done; ./scripts/dump-openapi.sh 18181; git diff --exit-code docs/openapi/rust.json"
+  run_step "playwright chromium" "cd parkhub-web && npm run build && cd .. && cargo build --locked --release -p parkhub-server --no-default-features --features 'full,headless,e2e-bypass' && pid=''; cleanup() { if [[ -n \"\${pid:-}\" ]]; then kill \"\$pid\" 2>/dev/null || true; fi; }; trap cleanup EXIT; { DEMO_MODE=true PARKHUB_ADMIN_PASSWORD=demo PARKHUB_DISABLE_RATE_LIMITS=true ./target/release/parkhub-server --headless --unattended --port 8081 >/tmp/parkhub-e2e.log 2>&1 & pid=\$!; }; for i in \$(seq 1 45); do curl -sf http://localhost:8081/health >/dev/null 2>&1 && break; sleep 1; done; npx playwright test --project=chromium"
+fi
+
+if [[ "$profile" == "cd" ]]; then
+  run_step "release image preflight" "cargo test --locked --package parkhub-common --all-targets && cargo test --locked --package parkhub-server --no-default-features --features headless --all-targets"
+fi
+
+write_report "success"
+post_commit_status "success" "fop local ${profile} passed"
+
+printf '\nlocal CI passed: %s\n' "$report_path"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,43 @@ jobs:
           fail-on-severity: high
           deny-licenses: GPL-2.0, GPL-3.0, AGPL-1.0, AGPL-3.0
 
+  local-ci-attestation:
+    name: fop local CI attestation
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      statuses: read
+    steps:
+      - name: Require fop local CI commit status
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SHA: ${{ github.event.pull_request.head.sha }}
+          REPO: ${{ github.repository }}
+          CONTEXT: fop/local-ci/pr
+        run: |
+          status=""
+          for attempt in $(seq 1 18); do
+            status="$(
+              gh api "repos/${REPO}/commits/${SHA}/status" \
+                --jq ".statuses[] | select(.context == \"${CONTEXT}\") | .state" \
+                | head -n 1
+            )"
+            if [[ "$status" == "success" ]]; then
+              break
+            fi
+            echo "Waiting for ${CONTEXT} status on ${SHA} (${attempt}/18)..."
+            sleep 10
+          done
+          if [[ "$status" != "success" ]]; then
+            echo "::error::Missing successful ${CONTEXT} status for ${SHA}."
+            echo "Run locally:"
+            echo "  .github/scripts/fop-local-ci.sh --profile pr --post-status"
+            exit 1
+          fi
+          echo "${CONTEXT}=${status}"
+
   cargo-deny:
     name: Cargo Deny
     runs-on: ubuntu-latest
@@ -102,6 +139,7 @@ jobs:
 
   fmt:
     name: Cargo Format Check
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository || contains(github.event.pull_request.labels.*.name, 'github-ci-full')
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -118,6 +156,7 @@ jobs:
 
   check:
     name: Cargo Check (headless)
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository || contains(github.event.pull_request.labels.*.name, 'github-ci-full')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -142,6 +181,7 @@ jobs:
 
   client-check:
     name: Desktop Client Check
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository || contains(github.event.pull_request.labels.*.name, 'github-ci-full')
     runs-on: ubuntu-latest
     timeout-minutes: 35
     steps:
@@ -165,6 +205,7 @@ jobs:
 
   clippy:
     name: Cargo Clippy (headless)
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository || contains(github.event.pull_request.labels.*.name, 'github-ci-full')
     runs-on: ubuntu-latest
     timeout-minutes: 40
     steps:
@@ -191,6 +232,7 @@ jobs:
 
   test:
     name: Cargo Test (headless)
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository || contains(github.event.pull_request.labels.*.name, 'github-ci-full')
     runs-on: ubuntu-latest
     timeout-minutes: 45
     needs: [check]
@@ -216,6 +258,7 @@ jobs:
 
   frontend:
     name: Frontend Build & Test
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository || contains(github.event.pull_request.labels.*.name, 'github-ci-full')
     runs-on: ubuntu-latest
     timeout-minutes: 25
     defaults:
@@ -242,6 +285,7 @@ jobs:
 
   integration:
     name: Integration Tests
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository || contains(github.event.pull_request.labels.*.name, 'github-ci-full')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     needs: [test]
@@ -271,6 +315,7 @@ jobs:
 
   types-drift:
     name: TypeScript types drift
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository || contains(github.event.pull_request.labels.*.name, 'github-ci-full')
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -327,6 +372,7 @@ jobs:
 
   openapi-drift:
     name: OpenAPI drift
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository || contains(github.event.pull_request.labels.*.name, 'github-ci-full')
     runs-on: ubuntu-latest
     timeout-minutes: 25
     steps:
@@ -390,7 +436,7 @@ jobs:
   required:
     name: Required checks
     if: always()
-    needs: [actionlint, helm-validate, dependency-review, cargo-deny, fmt, check, client-check, clippy, test, frontend, integration, openapi-drift, types-drift]
+    needs: [actionlint, helm-validate, dependency-review, local-ci-attestation, cargo-deny, fmt, check, client-check, clippy, test, frontend, integration, openapi-drift, types-drift]
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -399,6 +445,9 @@ jobs:
           ACTIONLINT: ${{ needs.actionlint.result }}
           HELM_VALIDATE: ${{ needs.helm-validate.result }}
           DEPENDENCY_REVIEW: ${{ needs.dependency-review.result }}
+          LOCAL_CI: ${{ needs.local-ci-attestation.result }}
+          EVENT_NAME: ${{ github.event_name }}
+          SAME_REPO_PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}
           CARGO_DENY: ${{ needs.cargo-deny.result }}
           CHECK: ${{ needs.check.result }}
           CLIENT_CHECK: ${{ needs.client-check.result }}
@@ -410,10 +459,23 @@ jobs:
           OPENAPI_DRIFT: ${{ needs.openapi-drift.result }}
           TYPES_DRIFT: ${{ needs.types-drift.result }}
         run: |
-          for check in ACTIONLINT HELM_VALIDATE CARGO_DENY CHECK CLIENT_CHECK TEST FRONTEND FMT CLIPPY OPENAPI_DRIFT TYPES_DRIFT; do
+          for check in ACTIONLINT HELM_VALIDATE CARGO_DENY; do
             if [[ "${!check}" != "success" ]]; then
               echo "REQUIRED: ${check} failed: ${!check}"
               exit 1
+            fi
+          done
+          if [[ "${EVENT_NAME}" == "pull_request" && "${SAME_REPO_PR}" == "true" && "${LOCAL_CI}" != "success" ]]; then
+            echo "REQUIRED: LOCAL_CI failed: ${LOCAL_CI}"
+            exit 1
+          fi
+          for check in CHECK CLIENT_CHECK TEST FRONTEND FMT CLIPPY OPENAPI_DRIFT TYPES_DRIFT; do
+            if [[ "${!check}" != "success" && "${!check}" != "skipped" ]]; then
+              echo "REQUIRED: ${check} failed: ${!check}"
+              exit 1
+            fi
+            if [[ "${!check}" == "skipped" ]]; then
+              echo "LOCAL-FIRST: ${check} skipped on PR; covered by fop/local-ci/pr"
             fi
           done
           if [[ "${DEPENDENCY_REVIEW}" != "success" && "${DEPENDENCY_REVIEW}" != "skipped" ]]; then

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -37,10 +37,16 @@ jobs:
           - language: javascript-typescript
 
     steps:
+      - name: Local-first CodeQL skip
+        if: github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'github-ci-full')
+        run: echo "CodeQL is covered on main/schedule/manual, or on PRs labeled github-ci-full."
+
       - name: Checkout
+        if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'github-ci-full')
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Initialize CodeQL
+        if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'github-ci-full')
         uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
         with:
           languages: ${{ matrix.language }}
@@ -50,15 +56,15 @@ jobs:
               - target/**
 
       - name: Install Rust
-        if: matrix.language == 'rust'
+        if: matrix.language == 'rust' && (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'github-ci-full'))
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - name: Install Rust dependencies
-        if: matrix.language == 'rust'
+        if: matrix.language == 'rust' && (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'github-ci-full'))
         run: |
           sudo apt-get update
           sudo apt-get install -y cmake libfontconfig1-dev
       - name: Build Rust for CodeQL
-        if: matrix.language == 'rust'
+        if: matrix.language == 'rust' && (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'github-ci-full'))
         run: |
           mkdir -p parkhub-web/dist
           printf '%s' '<!doctype html><html><body></body></html>' > parkhub-web/dist/index.html
@@ -66,7 +72,7 @@ jobs:
           cargo build --locked --package parkhub-client
 
       - name: Setup Node.js
-        if: matrix.language == 'javascript-typescript'
+        if: matrix.language == 'javascript-typescript' && (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'github-ci-full'))
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: ${{ env.NODE_VERSION }}
@@ -74,13 +80,14 @@ jobs:
           cache-dependency-path: parkhub-web/package-lock.json
 
       - name: Build frontend for CodeQL
-        if: matrix.language == 'javascript-typescript'
+        if: matrix.language == 'javascript-typescript' && (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'github-ci-full'))
         working-directory: parkhub-web
         run: |
           npm ci
           npm run build
 
       - name: Perform CodeQL Analysis
+        if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'github-ci-full')
         uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
         with:
           category: /language:${{ matrix.language }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,7 +2,6 @@ name: Release Container
 
 on:
   push:
-    branches: [main]
     tags: ['v*']
   workflow_dispatch:
 
@@ -112,7 +111,7 @@ jobs:
 
   deploy-demo:
     name: Deploy demo
-    if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+    if: github.event_name == 'workflow_dispatch'
     needs: publish
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -3,8 +3,6 @@ name: E2E Tests
 on:
   push:
     branches: [main]
-  pull_request:
-    branches: [main]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -3,8 +3,7 @@ name: Lighthouse CI
 on:
   push:
     branches: [main]
-  pull_request:
-    branches: [main]
+  workflow_dispatch:
 
 concurrency:
   group: lighthouse-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/openapi-drift.yml
+++ b/.github/workflows/openapi-drift.yml
@@ -1,15 +1,6 @@
 name: OpenAPI Drift
 
 on:
-  pull_request:
-    branches: [main]
-    paths:
-      - 'parkhub-server/**'
-      - 'parkhub-common/**'
-      - 'docs/openapi/**'
-      - 'scripts/dump-openapi.sh'
-      - 'scripts/diff-openapi.sh'
-      - '.github/workflows/openapi-drift.yml'
   push:
     branches: [main]
   workflow_dispatch:

--- a/docs/plans/parkhub-local-first-ci-cd-2026.md
+++ b/docs/plans/parkhub-local-first-ci-cd-2026.md
@@ -1,0 +1,70 @@
+---
+title: "parkhub: local-first CI/CD attestation and GitHub CI thinning"
+repo_path: "."
+type: "implementation"
+priority: "high"
+status: active
+task_id: "T-2133"
+source_note: "Refactor ParkHub CI/CD so fop local verification is the primary PR gate, GitHub Actions are thin/attestation-aware, heavy checks move to local/nightly/main, and CD remains GitOps/signed."
+verification:
+  - "fop build --backend local . --preset custom -- bash -lc 'git diff --check && ./.github/scripts/fop-local-ci.sh --profile pr --dry-run'"
+---
+
+# parkhub: local-first CI/CD attestation and GitHub CI thinning
+
+## Goal
+
+Refactor ParkHub CI/CD so fop local verification is the primary PR gate, GitHub Actions are thin/attestation-aware, heavy checks move to local/nightly/main, and CD remains GitOps/signed.
+
+## Constraints
+
+- Keep `fop` as the only local build/test execution surface; no raw cargo/npm commands outside fop-managed steps.
+- GitHub remains the PR UI and branch-protection surface, not the primary compute surface.
+- Keep security-sensitive remote checks that need GitHub context: dependency review and secret scanning.
+- Do not mix this with the final Rust PR merge train; land as a separate PR.
+
+## Acceptance
+
+- Local command `.github/scripts/fop-local-ci.sh --profile pr` runs the PR gate through fop.
+- Local command can publish the commit status context `fop/local-ci/pr`.
+- GitHub PR CI requires that attestation and only runs lightweight remote checks by default.
+- Heavy CI and CodeQL jobs still run on `main`, by manual dispatch/schedule, or on PRs labeled `github-ci-full`.
+- CD stays release/GitOps-oriented and is not coupled to every PR push.
+
+## Paths
+
+- `.github/scripts/fop-local-ci.sh`
+- `.github/workflows/ci.yml`
+- `.github/workflows/e2e.yml`
+- `.github/workflows/lighthouse.yml`
+- `.github/workflows/openapi-drift.yml`
+- `.github/workflows/docker-publish.yml`
+
+## Platform Fit
+
+ParkHub pilot for a platform-wide pattern: local-first fop attestation as the PR gate, with GitHub as verifier/audit surface. If the pilot works, promote the status context and profile model into fop core.
+
+## Integration Boundary
+
+The stable contract is the commit status context `fop/local-ci/pr`. GitHub branch protection should depend on `Required checks`; `Required checks` depends on the local attestation and cheap remote checks.
+
+## Rollout
+
+1. Pilot in `parkhub-rust`.
+2. Require local PR attestation for normal PRs.
+3. Move E2E/Lighthouse/OpenAPI remote workflows to main/manual.
+4. Stop GitHub container publish/demo deploy from running on every `main` push; keep it for tags/manual fallback.
+5. Keep `github-ci-full` label as the emergency remote-full override for full CI and CodeQL.
+6. Mirror the pattern to `parkhub-php`, then extract into fop presets.
+
+## Rollback / No-Adopt
+
+Rollback is restoring PR triggers and removing `local-ci-attestation` from `ci.yml` `needs`. Keep the script even if branch protection is rolled back; it remains useful as local preflight.
+
+## Verification
+
+- `fop build --backend local . --preset custom -- bash -lc 'git diff --check && ./.github/scripts/fop-local-ci.sh --profile pr --dry-run'`
+
+## Notes
+
+- Based on current GitHub Actions primitives: workflow concurrency, reusable/lightweight workflows, and required checks remain the correct remote-side controls.


### PR DESCRIPTION
## Summary
- add `.github/scripts/fop-local-ci.sh` as the local-first PR/CD gate with report + commit-status attestation support
- thin normal PR GitHub Actions so heavyweight CI runs locally by default and GitHub full CI is label/manual/main-gated
- reduce CD blast radius by moving Docker publish/demo deploy away from every main push and documenting the 2026 local-first rollout plan

## Local verification
- `fop build --backend local . --preset custom -- bash -lc 'git diff --check && bash -n .github/scripts/fop-local-ci.sh && ./.github/scripts/fop-local-ci.sh --profile pr --dry-run'`
- `./.github/scripts/fop-local-ci.sh --profile pr`
- posted commit status: `fop/local-ci/pr` = success for `d0fb15373f0d3ee52ff1e0506c03ce616393db6c`

## Notes
- normal PRs can still force full GitHub CI with the `github-ci-full` label
- heavy CD remains available through tags or manual dispatch