### PR TITLE
refactor(web): replace Policies eslint-disable with useDraftFromActive hook

### DIFF
--- a/parkhub-web/src/design-v5/screens/Policies.tsx
+++ b/parkhub-web/src/design-v5/screens/Policies.tsx
@@ -3,6 +3,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { Card, SectionLabel, V5NamedIcon } from '../primitives';
 import { useV5Toast } from '../Toast';
 import { api, type Policy } from '../../api/client';
+import { useDraftFromActive } from '../../hooks/useDraftFromActive';
 import type { ScreenId } from '../nav';
 
 function formatWhen(iso: string): string {
@@ -16,7 +17,6 @@ export function PoliciesV5({ navigate: _navigate }: { navigate: (id: ScreenId) =
   const toast = useV5Toast();
   const qc = useQueryClient();
   const [activeId, setActiveId] = useState<string | null>(null);
-  const [draft, setDraft] = useState('');
   const [preview, setPreview] = useState(false);
 
   const { data: policies = [], isLoading, isError } = useQuery({
@@ -35,12 +35,16 @@ export function PoliciesV5({ navigate: _navigate }: { navigate: (id: ScreenId) =
 
   const active = policies.find((p) => p.id === activeId) ?? null;
 
+  // Mirrors `active.body` into a local draft. Re-init only fires when the
+  // policy id actually changes (followup #3 of the 2026-04-25 merge-train
+  // session note — replaces the previous useEffect+eslint-disable).
+  const [draft, setDraft] = useDraftFromActive<Policy, string>(active, {
+    derive: (p) => p.body,
+  });
+
+  // Reset the preview flag whenever we switch to a new policy.
   useEffect(() => {
-    const p = policies.find((x) => x.id === activeId);
-    if (p) { setDraft(p.body); setPreview(false); }
-    // Only depend on activeId: refetches produce a new policies array, which
-    // would otherwise clobber the user's in-flight draft on every render.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    setPreview(false);
   }, [activeId]);
 
   const save = useMutation({
@@ -75,7 +79,10 @@ export function PoliciesV5({ navigate: _navigate }: { navigate: (id: ScreenId) =
     );
   }
 
-  const isDirty = active && draft !== active.body;
+  // `draft` mirrors `active`, so when `active` is set the hook has already
+  // seeded `draft`. Normalise the undefined edge for callsites below.
+  const draftBody = draft ?? '';
+  const isDirty = active && draftBody !== active.body;
 
   return (
     <div style={{ padding: 16, flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column', gap: 12 }}>
@@ -130,7 +137,7 @@ export function PoliciesV5({ navigate: _navigate }: { navigate: (id: ScreenId) =
                     <button
                       type="button"
                       disabled={!isDirty || save.isPending}
-                      onClick={() => save.mutate({ id: active.id, body: draft })}
+                      onClick={() => save.mutate({ id: active.id, body: draftBody })}
                       data-testid="policies-save"
                       style={{
                         padding: '6px 14px', borderRadius: 8, background: 'var(--v5-acc)', color: 'var(--v5-accent-fg)',
@@ -151,11 +158,11 @@ export function PoliciesV5({ navigate: _navigate }: { navigate: (id: ScreenId) =
                       fontSize: 12, color: 'var(--v5-txt)', whiteSpace: 'pre-wrap',
                       fontFamily: 'inherit', lineHeight: 1.55,
                     }}
-                  >{draft || '(leer)'}</div>
+                  >{draftBody || '(leer)'}</div>
                 ) : (
                   <textarea
                     data-testid="policies-editor"
-                    value={draft}
+                    value={draftBody}
                     onChange={(e) => setDraft(e.target.value)}
                     style={{
                       flex: 1, padding: 12, borderRadius: 9,

--- a/parkhub-web/src/hooks/__tests__/useDraftFromActive.test.ts
+++ b/parkhub-web/src/hooks/__tests__/useDraftFromActive.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+
+import { useDraftFromActive } from '../useDraftFromActive';
+
+interface Policy {
+  id: string;
+  title: string;
+  body: string;
+}
+
+const P1: Policy = { id: 'p1', title: 'AGB', body: 'Alter Text' };
+const P1_REFETCH: Policy = { id: 'p1', title: 'AGB', body: 'Alter Text' }; // same id, new ref
+const P1_UPSTREAM_EDIT: Policy = { id: 'p1', title: 'AGB', body: 'Server schreibt drüber' };
+const P2: Policy = { id: 'p2', title: 'Datenschutz', body: 'DSGVO' };
+
+describe('useDraftFromActive', () => {
+  it('seeds draft from active on initial mount', () => {
+    const { result } = renderHook(() =>
+      useDraftFromActive<Policy, string>(P1, { derive: (p) => p.body }),
+    );
+    const [draft] = result.current;
+    expect(draft).toBe('Alter Text');
+  });
+
+  it('initial mount with undefined active yields undefined draft', () => {
+    const { result } = renderHook(() =>
+      useDraftFromActive<Policy, string>(undefined, { derive: (p) => p.body }),
+    );
+    const [draft] = result.current;
+    expect(draft).toBeUndefined();
+  });
+
+  it('does NOT reset draft when parent rerenders with same id (regression guard)', () => {
+    const { result, rerender } = renderHook(
+      ({ active }: { active: Policy }) =>
+        useDraftFromActive<Policy, string>(active, { derive: (p) => p.body }),
+      { initialProps: { active: P1 } },
+    );
+
+    act(() => {
+      const [, setDraft] = result.current;
+      setDraft('User-Edit unterwegs');
+    });
+    expect(result.current[0]).toBe('User-Edit unterwegs');
+
+    // Simulate react-query refetch: same id, brand-new array → new object ref.
+    rerender({ active: P1_REFETCH });
+    expect(result.current[0]).toBe('User-Edit unterwegs');
+
+    // Even an upstream body mutation on the SAME id should not clobber the draft.
+    rerender({ active: P1_UPSTREAM_EDIT });
+    expect(result.current[0]).toBe('User-Edit unterwegs');
+  });
+
+  it('persists user edits via setDraft', () => {
+    const { result } = renderHook(() =>
+      useDraftFromActive<Policy, string>(P1, { derive: (p) => p.body }),
+    );
+    act(() => {
+      const [, setDraft] = result.current;
+      setDraft('Neuer Inhalt');
+    });
+    expect(result.current[0]).toBe('Neuer Inhalt');
+  });
+
+  it('re-initialises draft from new active when id changes', () => {
+    const { result, rerender } = renderHook(
+      ({ active }: { active: Policy }) =>
+        useDraftFromActive<Policy, string>(active, { derive: (p) => p.body }),
+      { initialProps: { active: P1 } },
+    );
+    act(() => {
+      const [, setDraft] = result.current;
+      setDraft('In-flight edit on P1');
+    });
+
+    rerender({ active: P2 });
+    expect(result.current[0]).toBe('DSGVO');
+  });
+
+  it('clears draft when active becomes undefined', () => {
+    const { result, rerender } = renderHook(
+      ({ active }: { active: Policy | undefined }) =>
+        useDraftFromActive<Policy, string>(active, { derive: (p) => p.body }),
+      { initialProps: { active: P1 as Policy | undefined } },
+    );
+    expect(result.current[0]).toBe('Alter Text');
+    rerender({ active: undefined });
+    expect(result.current[0]).toBeUndefined();
+  });
+
+  it('re-seeds when going from undefined → defined', () => {
+    const { result, rerender } = renderHook(
+      ({ active }: { active: Policy | undefined }) =>
+        useDraftFromActive<Policy, string>(active, { derive: (p) => p.body }),
+      { initialProps: { active: undefined as Policy | undefined } },
+    );
+    expect(result.current[0]).toBeUndefined();
+    rerender({ active: P2 });
+    expect(result.current[0]).toBe('DSGVO');
+  });
+
+  it('default derive snapshots the whole active object', () => {
+    const { result } = renderHook(() => useDraftFromActive<Policy>(P1));
+    const [draft] = result.current;
+    expect(draft).toEqual(P1);
+    // Shallow clone — separate identity so caller can mutate without leaking.
+    expect(draft).not.toBe(P1);
+  });
+
+  it('respects custom idKey', () => {
+    interface BySlug { slug: string; body: string }
+    const a: BySlug = { slug: 'agb', body: 'one' };
+    const a2: BySlug = { slug: 'agb', body: 'server-edit' }; // same slug
+    const b: BySlug = { slug: 'dsg', body: 'two' };
+
+    const { result, rerender } = renderHook(
+      ({ active }: { active: BySlug }) =>
+        useDraftFromActive<BySlug, string, 'slug'>(active, {
+          idKey: 'slug',
+          derive: (p) => p.body,
+        }),
+      { initialProps: { active: a } },
+    );
+    act(() => result.current[1]('user typed'));
+    rerender({ active: a2 });
+    expect(result.current[0]).toBe('user typed');
+    rerender({ active: b });
+    expect(result.current[0]).toBe('two');
+  });
+
+  it('exposes isDirty + reset meta', () => {
+    const { result } = renderHook(() =>
+      useDraftFromActive<Policy, string>(P1, { derive: (p) => p.body }),
+    );
+    expect(result.current[2].isDirty).toBe(false);
+    expect(result.current[2].pristine).toBe('Alter Text');
+
+    act(() => result.current[1]('changed'));
+    expect(result.current[2].isDirty).toBe(true);
+
+    act(() => result.current[2].reset());
+    expect(result.current[0]).toBe('Alter Text');
+    expect(result.current[2].isDirty).toBe(false);
+  });
+});

--- a/parkhub-web/src/hooks/useDraftFromActive.ts
+++ b/parkhub-web/src/hooks/useDraftFromActive.ts
@@ -1,0 +1,144 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+/**
+ * Hook helpers for {@link useDraftFromActive}.
+ *
+ * Most callers only care about the `[draft, setDraft]` tuple, but `meta`
+ * exposes derived state (`isDirty`) and a manual `reset` so screens can offer
+ * "Discard changes" affordances without re-implementing the comparison.
+ */
+export interface UseDraftFromActiveMeta<TDraft> {
+  /** True when the current draft differs from the snapshot taken on init. */
+  isDirty: boolean;
+  /** Re-snapshot the draft from `active` (or clear it if `active` is undefined). */
+  reset: () => void;
+  /** The exact draft value last seeded from `active` (the "pristine" baseline). */
+  pristine: TDraft | undefined;
+}
+
+export interface UseDraftFromActiveOptions<TActive, TDraft, TKey extends keyof TActive> {
+  /**
+   * Property used as the active item's stable discriminator. Defaults to `'id'`
+   * — when active items lack an `id`, pass e.g. `idKey: 'slug'`.
+   */
+  idKey?: TKey;
+  /**
+   * Project the active item into the draft shape. Defaults to a shallow copy
+   * of `active` (or `active` itself when it is a primitive). Override when the
+   * draft only mirrors a subset of the active item (e.g. `(p) => p.body`).
+   *
+   * MUST be stable across renders (wrap in `useCallback` upstream). The hook
+   * does not memoise it for you.
+   */
+  derive?: (active: TActive) => TDraft;
+}
+
+export type UseDraftFromActiveResult<TDraft> = [
+  TDraft | undefined,
+  React.Dispatch<React.SetStateAction<TDraft | undefined>>,
+  UseDraftFromActiveMeta<TDraft>,
+];
+
+function defaultDerive<TActive, TDraft>(active: TActive): TDraft {
+  // Shallow-clone objects so callers can mutate the draft without touching
+  // upstream state; pass primitives through verbatim.
+  if (active !== null && typeof active === 'object') {
+    return { ...(active as object) } as unknown as TDraft;
+  }
+  return active as unknown as TDraft;
+}
+
+/**
+ * Track a draft mirror of an "active" item without clobbering in-flight edits.
+ *
+ * The naive shape (`useEffect(() => setDraft(active.body), [active])`) re-seeds
+ * the draft every time the parent rerenders the same active object — which is
+ * exactly what happens when react-query refetches the list and produces a new
+ * array. The classic workaround is `[activeId]` plus an
+ * `eslint-disable-next-line react-hooks/exhaustive-deps`, which silences the
+ * linter but loses the dependency-tracking guarantee.
+ *
+ * This hook keeps the lint rule honest: it depends on the full `active`
+ * reference, but uses a ref-tracked id to bail out when the discriminator has
+ * not actually changed. Switching ids snapshots `derive(active)`; same id +
+ * parent rerender leaves the draft alone; `active === undefined` clears the
+ * draft.
+ *
+ * Generic over the discriminator key so callers using `slug`, `uuid`, etc.
+ * can plug in without falling back to `any`.
+ *
+ * @example Mirror a string body (the Policies screen)
+ * ```ts
+ * const [draft, setDraft] = useDraftFromActive(active, {
+ *   derive: (p) => p.body,
+ * });
+ * ```
+ *
+ * @example Snapshot the whole record (default)
+ * ```ts
+ * const [draft, setDraft, { isDirty, reset }] = useDraftFromActive(active);
+ * ```
+ */
+export function useDraftFromActive<
+  TActive extends object,
+  TDraft = TActive,
+  TKey extends keyof TActive = 'id' extends keyof TActive ? 'id' : keyof TActive,
+>(
+  active: TActive | null | undefined,
+  options?: UseDraftFromActiveOptions<TActive, TDraft, TKey>,
+): UseDraftFromActiveResult<TDraft> {
+  const idKey = (options?.idKey ?? ('id' as TKey)) as TKey;
+  const derive = options?.derive ?? (defaultDerive as (a: TActive) => TDraft);
+  // `idKey` is `keyof TActive`, but interfaces don't satisfy
+  // `Record<string, unknown>` — cast through `unknown` to read by string.
+  const readId = useCallback(
+    (a: TActive): unknown => (a as unknown as Record<string, unknown>)[idKey as string],
+    [idKey],
+  );
+
+  const pristineRef = useRef<TDraft | undefined>(undefined);
+  const lastIdRef = useRef<unknown>(undefined);
+
+  const [draft, setDraft] = useState<TDraft | undefined>(() => {
+    if (active != null) {
+      const seed = derive(active);
+      pristineRef.current = seed;
+      lastIdRef.current = readId(active);
+      return seed;
+    }
+    return undefined;
+  });
+
+  useEffect(() => {
+    const nextId: unknown = active != null ? readId(active) : undefined;
+    if (lastIdRef.current === nextId) {
+      // Same id (or both undefined): preserve in-flight edits.
+      return;
+    }
+    lastIdRef.current = nextId;
+    if (active == null) {
+      pristineRef.current = undefined;
+      setDraft(undefined);
+      return;
+    }
+    const seed = derive(active);
+    pristineRef.current = seed;
+    setDraft(seed);
+  }, [active, derive, readId]);
+
+  const reset = useCallback(() => {
+    if (active == null) {
+      pristineRef.current = undefined;
+      setDraft(undefined);
+      return;
+    }
+    const seed = derive(active);
+    pristineRef.current = seed;
+    setDraft(seed);
+  }, [active, derive]);
+
+  const isDirty =
+    pristineRef.current !== undefined && !Object.is(draft, pristineRef.current);
+
+  return [draft, setDraft, { isDirty, reset, pristine: pristineRef.current }];
+}


### PR DESCRIPTION
## Summary

- Factors the Policies draft-from-active pattern from PR #407 into a reusable `useDraftFromActive` hook in `parkhub-web/src/hooks/`.
- Drops the `// eslint-disable-next-line react-hooks/exhaustive-deps` smell from `Policies.tsx` — the hook keeps the lint rule honest via a `useRef`-tracked id discriminator.
- Adds 10 Vitest cases covering initial seed, in-flight edits surviving parent rerenders (the regression #407 targeted), id transitions, undefined-active clearing, custom \`idKey\`, default whole-object derive, and the \`isDirty\`/\`reset\` meta.

## Why

Standing follow-up #3 from \`Sessions/2026-04-25-parkhub-merge-train-cleanup.md\` (line 190): \"factor out a \`useDraftFromActive(active)\` hook with a ref-tracked initialization id; the current fix uses \`// eslint-disable-next-line react-hooks/exhaustive-deps\` which is a smell.\"

## Test plan

- [x] \`./.github/scripts/fop-local-ci.sh --profile pr\` passes locally (running with --post-status to attest \`fop/local-ci/pr\`)
- [x] Hook unit tests: 10 cases cover seed/persist/transition/clear/custom-idKey/derive/reset
- [x] Existing 7-test Policies screen suite continues to pass unchanged
- [x] No new tsc errors introduced
- [ ] CodeQL Analyze (javascript-typescript) green (CI)

## Follow-up (out of scope)

Mirror to parkhub-php's identical Policies admin screen. Tracked in the session note's Phase 2 outcomes.