### PR TITLE
ci(security): add typos + zizmor as advisory CI checks (Wave 5b)

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -146,3 +146,35 @@ jobs:
           else
             gitleaks detect --source=. --redact --verbose --no-banner
           fi
+
+  typos:
+    name: Typos (advisory)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # Advisory until typo backlog is cleared. Promote to required once green.
+    continue-on-error: true
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Run typos
+        uses: crate-ci/typos@5ca5db740be4c6b2e6ce383819386a7340babd1e # v1.45.1
+
+  zizmor:
+    name: Zizmor (GHA SAST, audit-mode)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    # Audit-mode: surface findings as informational; do NOT fail the gate yet.
+    # Promote findings to errors once the workflow inventory has been triaged.
+    continue-on-error: true
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3
+        with:
+          # auditor persona surfaces low-severity findings useful for hardening
+          # without flooding the PR with regular-user noise.
+          persona: auditor


### PR DESCRIPTION
## Summary

Adds two cutting-edge 2026 supply-chain hygiene tools as **advisory** GHA jobs (`continue-on-error: true`). Both pinned by 40-char SHA + version comment. Both license-clean (MIT/Apache).

| Tool | Repo | License | SHA | Mode |
|---|---|---|---|---|
| typos | crate-ci/typos v1.45.1 | Apache-2.0 | `5ca5db740be4c6b2e6ce383819386a7340babd1e` | advisory |
| zizmor | zizmorcore/zizmor-action v0.5.3 | MIT (Trail-of-Bits-authored Rust GHA SAST) | `b1d7e1fb5de872772f31590499237e7cce841e8e` | audit-mode (auditor persona) |

## Why

Wave 5b from claude1 tracker. Promotes two tools the local-CI script already calls graceful-skip (when binary present) into first-class GHA jobs. Both are non-blocking initially so existing workflow + typo backlog surfaces findings without immediately failing merges. Promote to required once triaged.

## License compliance

Per the 2026 dev-tooling research matrix: skipped Renovate (AGPL-3.0), Semgrep CLI (LGPL-2.1), Mergify/CodeRabbit/Sourcery/Greptile (proprietary SaaS), trufflehog ≥3.95 (license drift). Kept gitleaks binary, CodeQL, dependabot, actionlint v1.7.12 — all already in repo and license-clean.

## Verification

- [x] python yaml.safe_load passes on the workflow file
- [x] +32 lines on `.github/workflows/security.yml`, no other files touched
- [ ] Local-CI `fop/local-ci/pr=success` (running with --post-status; diff-aware: workflows-only → ~1s)

## Follow-ups

- Wave 5c: mirror typos + zizmor jobs to parkhub-php
- Wave 5d: cargo-machete, knip, ast-grep, OSV-Scanner, lychee
- Wave 5e: Bun, Oxlint+Biome, mise, cargo-nextest, SLSA L3 + cosign keyless
- Promote typos + zizmor to required-checks once advisory backlog triaged