### PR TITLE
chore(release): bump version to 5.0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6550,7 +6550,7 @@ dependencies = [
 
 [[package]]
 name = "parkhub-client"
-version = "5.0.1"
+version = "5.0.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6577,7 +6577,7 @@ dependencies = [
 
 [[package]]
 name = "parkhub-common"
-version = "5.0.1"
+version = "5.0.2"
 dependencies = [
  "chrono",
  "proptest",
@@ -6591,7 +6591,7 @@ dependencies = [
 
 [[package]]
 name = "parkhub-desktop"
-version = "5.0.1"
+version = "5.0.2"
 dependencies = [
  "directories",
  "serde",
@@ -6615,7 +6615,7 @@ dependencies = [
 
 [[package]]
 name = "parkhub-server"
-version = "5.0.1"
+version = "5.0.2"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "5.0.1"
+version = "5.0.2"
 edition = "2024"
 rust-version = "1.94"
 authors = ["nash87"]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parkhub",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "description": "Open source parking lot management system with client-server architecture.",
   "scripts": {
     "test:e2e": "npx playwright test",

--- a/parkhub-web/package.json
+++ b/parkhub-web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "parkhub-web",
   "type": "module",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "engines": {
     "node": ">=22.12.0"
   },


### PR DESCRIPTION
Re-publishes the linux x64/ARM64 + macOS universal + Windows x64 release artifacts that v5.0.0 + v5.0.1 failed to ship — root cause was a vite 8 / @tailwindcss/vite incompat surfaced in the Build web frontend step. Fix landed via PR #437 (vite ^7 override). This bump is the trigger commit for v5.0.2 tag.