### PR TITLE
chore(test): add app-version drift guard

### DIFF
--- a/parkhub-web/src/lib/appVersion.test.ts
+++ b/parkhub-web/src/lib/appVersion.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import pkg from '../../package.json' with { type: 'json' };
+
+const repoRoot = resolve(process.cwd(), '..');
+
+describe('app version drift', () => {
+  it('parkhub-web/package.json matches root package.json', () => {
+    const rootPkg = JSON.parse(readFileSync(`${repoRoot}/package.json`, 'utf8'));
+    expect(pkg.version).toBe(rootPkg.version);
+  });
+
+  it('parkhub-web/package.json matches workspace Cargo.toml', () => {
+    const cargo = readFileSync(`${repoRoot}/Cargo.toml`, 'utf8');
+    const m = cargo.match(/^version\s*=\s*"([^"]+)"/m);
+    expect(m?.[1]).toBe(pkg.version);
+  });
+});


### PR DESCRIPTION
## Summary
Adds a vitest unit test asserting `parkhub-web/package.json.version` stays in sync with the root `package.json` and `Cargo.toml [workspace.package].version`.

## Why
Sister repo (parkhub-php) shipped a footer reading `ParkHub v4.13.4` on a v5.0.x deploy because three stale `appVersion.*.js` bundles were accumulating in `public/_astro/` across builds. Catching the version mismatch in CI is cheap; users seeing the wrong product version in the footer is not.

## Test plan
- [x] `npx vitest run src/lib/appVersion.test.ts` → green (2/2 passes)
- [x] Mutation check: edit `package.json` to a wrong version, test fails
- [x] Companion PR for parkhub-php (chore/release-5.0.3) bumps the sibling repo + adds the same drift guard there