### PR TITLE
fix(v5): register service worker + use PNG apple-touch-icon

### DIFF
--- a/parkhub-web/src/pages/v5.astro
+++ b/parkhub-web/src/pages/v5.astro
@@ -10,16 +10,13 @@ import '../styles/global.css';
     <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' ws: wss:; base-uri 'self'; form-action 'self';" />
     <meta name="description" content="ParkHub v5 — the 2026 urban mobility command center. Dashboard, bookings, fleet, admin — all in one keyboard-first surface." />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <!-- PWA manifest (design-v5: red #dc2626 / dark #0f0f0f). Service
-         worker registration lives in index.astro for the marketing root;
-         v5 is the React command-center surface and inherits the same SW. -->
     <link rel="manifest" href="/manifest.webmanifest" />
     <meta name="theme-color" content="#dc2626" />
     <meta name="mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <meta name="apple-mobile-web-app-title" content="ParkHub" />
-    <link rel="apple-touch-icon" href="/favicon.svg" />
+    <link rel="apple-touch-icon" sizes="192x192" href="/icons/icon-192.png" />
     <title>ParkHub v5 — Command Center</title>
     <script is:inline>
       // Pre-hydration mode boot — avoids the light→dark flash when the stored
@@ -33,6 +30,11 @@ import '../styles/global.css';
         }
         document.documentElement.setAttribute('data-ph-mode', m);
       })();
+    </script>
+    <script is:inline>
+      if ('serviceWorker' in navigator) {
+        navigator.serviceWorker.register('/sw.js').catch(() => {});
+      }
     </script>
   </head>
   <body style="margin:0;background:var(--v5-bg);color:var(--v5-txt);">


### PR DESCRIPTION
## Summary
Follow-up fixes for PR #441 review feedback that landed *after* #441 merged:

- Register `/sw.js` in `v5.astro` so deep-linked `/v5` visitors actually get PWA caching/offline. Previously the head comment claimed inheritance from `index.astro`, but service workers don't propagate that way — only users who visited `/` first would get the SW.
- Switch `apple-touch-icon` from `/favicon.svg` → `/icons/icon-192.png` since iOS home-screen icons don't reliably render SVG.

## Test plan
- [ ] After merge + redeploy, hit `parkhub-rust.test:8090/v5` directly in a fresh browser profile and confirm `navigator.serviceWorker.controller` is non-null.
- [ ] iOS Safari → "Add to Home Screen" from `/v5` shows the PNG icon, not a fallback glyph.