### PR TITLE
chore(release): bump version to 5.0.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6550,7 +6550,7 @@ dependencies = [
 
 [[package]]
 name = "parkhub-client"
-version = "5.0.3"
+version = "5.0.4"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6577,7 +6577,7 @@ dependencies = [
 
 [[package]]
 name = "parkhub-common"
-version = "5.0.3"
+version = "5.0.4"
 dependencies = [
  "chrono",
  "proptest",
@@ -6591,7 +6591,7 @@ dependencies = [
 
 [[package]]
 name = "parkhub-desktop"
-version = "5.0.3"
+version = "5.0.4"
 dependencies = [
  "directories",
  "serde",
@@ -6615,7 +6615,7 @@ dependencies = [
 
 [[package]]
 name = "parkhub-server"
-version = "5.0.3"
+version = "5.0.4"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "5.0.3"
+version = "5.0.4"
 edition = "2024"
 rust-version = "1.94"
 authors = ["nash87"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "parkhub",
-  "version": "5.0.1",
+  "version": "5.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "parkhub",
-      "version": "5.0.1",
+      "version": "5.0.4",
       "license": "ISC",
       "devDependencies": {
         "@axe-core/playwright": "^4.11.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parkhub",
-  "version": "5.0.3",
+  "version": "5.0.4",
   "description": "Open source parking lot management system with client-server architecture.",
   "scripts": {
     "test:e2e": "npx playwright test",

--- a/parkhub-web/package-lock.json
+++ b/parkhub-web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "parkhub-web",
-  "version": "5.0.1",
+  "version": "5.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "parkhub-web",
-      "version": "5.0.1",
+      "version": "5.0.4",
       "dependencies": {
         "@astrojs/react": "^5.0.3",
         "@fontsource-variable/inter": "^5.2.8",

--- a/parkhub-web/package.json
+++ b/parkhub-web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "parkhub-web",
   "type": "module",
-  "version": "5.0.3",
+  "version": "5.0.4",
   "engines": {
     "node": ">=22.12.0"
   },


### PR DESCRIPTION
## Summary
Roll-up release bringing the recently merged hardening into a tagged build.

Includes:
- #441 Tauri desktop installers + multi-arch container + PWA prep
- #442 vitest drift guard
- #443 cosign sign-blob + SPDX SBOM for release archives (T-2272 Phase A)
- #444 v5.astro: register `/sw.js` + use PNG `apple-touch-icon`

## Test plan
- [x] vitest drift guard passes locally (`parkhub-web/package.json` ↔ `Cargo.toml [workspace.package].version` ↔ root `package.json` all `5.0.4`)
- [x] Cargo.lock workspace entries bumped to 5.0.4
- [ ] After merge: tag `v5.0.4` → release pipeline ships `.sig` / `.pem` / `.spdx.json` triplets for the first time