### PR TITLE
fix(tauri): point tauri.conf.json version at package.json

### DIFF
--- a/parkhub-desktop/tauri.conf.json
+++ b/parkhub-desktop/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "ParkHub",
-  "version": "../Cargo.toml",
+  "version": "../package.json",
   "identifier": "app.parkhub.desktop",
   "build": {
     "beforeDevCommand": "cd ../parkhub-web && npm run dev",


### PR DESCRIPTION
## Summary
Tauri's `--from` version reader only parses JSON; pointing `version:` at `../Cargo.toml` produces:
```
failed to parse config: failed to read version JSON file: expected value at line 1 column 2
```

Switch to `../package.json` (which the existing version-drift guard keeps synced with `Cargo.toml [workspace.package].version` and root `package.json`).

## Repro
v5.0.4 release run #25092013064 — all three Tauri jobs (Linux/macOS/Windows) failed at "Build Tauri bundles" with the JSON parse error. Linux x64 / ARM64 / macOS universal / Windows binaries built fine because they don't use Tauri.

## Test plan
- [ ] After merge: re-tag v5.0.4 → release pipeline produces deb/rpm/AppImage + macOS .dmg/.app + Windows MSI/EXE installers from Tauri