### PR TITLE
fix(tauri): beforeBuildCommand relative to repo root, not projectPath

### DIFF
--- a/parkhub-desktop/tauri.conf.json
+++ b/parkhub-desktop/tauri.conf.json
@@ -4,8 +4,8 @@
   "version": "../package.json",
   "identifier": "app.parkhub.desktop",
   "build": {
-    "beforeDevCommand": "cd ../parkhub-web && npm run dev",
-    "beforeBuildCommand": "cd ../parkhub-web && npm run build",
+    "beforeDevCommand": "cd parkhub-web && npm run dev",
+    "beforeBuildCommand": "cd parkhub-web && npm run build",
     "devUrl": "http://localhost:4321",
     "frontendDist": "../parkhub-web/dist"
   },


### PR DESCRIPTION
## Summary
tauri-action@v0.6.2 executes `beforeBuildCommand` from the **workflow's cwd** (repo root on GHA), NOT from `projectPath: parkhub-desktop`. So `cd ../parkhub-web && npm run build` tried to escape to `/home/runner/work/` and failed:

```
sh: 1: cd: can't cd to ../parkhub-web
beforeBuildCommand failed with exit code 2
```

Switch to `cd parkhub-web && npm run build` (repo-root relative). `frontendDist: ../parkhub-web/dist` stays — that IS read from the conf file's own location.

## Repro
v5.0.4 release run #25092142913 — all three Tauri jobs (Linux, macOS, Windows) fail at the same beforeBuildCommand step.