### PR TITLE
chore(release): bump version to 5.0.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6550,7 +6550,7 @@ dependencies = [
 
 [[package]]
 name = "parkhub-client"
-version = "5.0.4"
+version = "5.0.5"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6577,7 +6577,7 @@ dependencies = [
 
 [[package]]
 name = "parkhub-common"
-version = "5.0.4"
+version = "5.0.5"
 dependencies = [
  "chrono",
  "proptest",
@@ -6591,7 +6591,7 @@ dependencies = [
 
 [[package]]
 name = "parkhub-desktop"
-version = "5.0.4"
+version = "5.0.5"
 dependencies = [
  "directories",
  "serde",
@@ -6615,7 +6615,7 @@ dependencies = [
 
 [[package]]
 name = "parkhub-server"
-version = "5.0.4"
+version = "5.0.5"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "5.0.4"
+version = "5.0.5"
 edition = "2024"
 rust-version = "1.94"
 authors = ["nash87"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "parkhub",
-  "version": "5.0.4",
+  "version": "5.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "parkhub",
-      "version": "5.0.4",
+      "version": "5.0.5",
       "license": "ISC",
       "devDependencies": {
         "@axe-core/playwright": "^4.11.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parkhub",
-  "version": "5.0.4",
+  "version": "5.0.5",
   "description": "Open source parking lot management system with client-server architecture.",
   "scripts": {
     "test:e2e": "npx playwright test",

--- a/parkhub-web/package-lock.json
+++ b/parkhub-web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "parkhub-web",
-  "version": "5.0.4",
+  "version": "5.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "parkhub-web",
-      "version": "5.0.4",
+      "version": "5.0.5",
       "dependencies": {
         "@astrojs/react": "^5.0.3",
         "@fontsource-variable/inter": "^5.2.8",

--- a/parkhub-web/package.json
+++ b/parkhub-web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "parkhub-web",
   "type": "module",
-  "version": "5.0.4",
+  "version": "5.0.5",
   "engines": {
     "node": ">=22.12.0"
   },


### PR DESCRIPTION
## Summary
Roll-up release with full Tauri installer support, after fixing both tauri-config bugs that surfaced in v5.0.4.

Includes since v5.0.3:
- #441 Tauri desktop + multi-arch + PWA prep
- #442 drift guard
- #443 cosign sign-blob + SPDX SBOM
- #444 v5.astro SW + PNG apple-touch-icon
- #446 tauri version path fix
- #447 tauri beforeBuildCommand path fix

## Test plan
- [x] All 5 version sources synced (Cargo.toml, root package.json, parkhub-web/package.json, both package-lock.json files, Cargo.lock)
- [x] vitest drift guard (added in #442) passes locally
- [ ] After merge: tag `v5.0.5` → release pipeline ships first complete artifact set: 4 platform binaries + cosign + SBOM + 3 Tauri installer triplets