### PR TITLE
fix(release): cosign 3.x needs explicit --bundle flag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -727,6 +727,11 @@ jobs:
         uses: anchore/sbom-action/download-syft@d8a2c0130026bf585de5c176ab8f7ce62d75bf04 # v0.20.7
 
       - name: Sign release archives (cosign keyless)
+        # cosign 3.x default behaviour writes a Sigstore bundle file
+        # alongside .sig/.cert; without --bundle <path> it tries to
+        # open an empty path and exits 1 ("create bundle file: open :
+        # no such file or directory"). Pin --bundle explicitly so the
+        # new-bundle-format file is named alongside .sig/.pem.
         env:
           COSIGN_EXPERIMENTAL: '1'
         run: |
@@ -737,6 +742,7 @@ jobs:
               cosign sign-blob --yes \
                 --output-signature "${f}.sig" \
                 --output-certificate "${f}.pem" \
+                --bundle "${f}.cosign.bundle" \
                 "$f"
             fi
           done
@@ -775,6 +781,11 @@ jobs:
             parkhub-macos-universal.tar.gz.pem
             parkhub-windows-x64.zip.pem
             checksums.txt.pem
+            parkhub-linux-x64.tar.gz.cosign.bundle
+            parkhub-linux-arm64.tar.gz.cosign.bundle
+            parkhub-macos-universal.tar.gz.cosign.bundle
+            parkhub-windows-x64.zip.cosign.bundle
+            checksums.txt.cosign.bundle
             parkhub-linux-x64.tar.gz.spdx.json
             parkhub-linux-arm64.tar.gz.spdx.json
             parkhub-macos-universal.tar.gz.spdx.json


### PR DESCRIPTION
## Summary
v5.0.4 release run failed at the `Sign release archives (cosign keyless)` step with:
```
signing parkhub-linux-x64.tar.gz: create bundle file: open : no such file or directory
```

cosign 3.x writes a Sigstore bundle file by default; without `--bundle <path>` the path argument is empty and cosign tries `open("")` → ENOENT.

## Fix
Add `--bundle "${f}.cosign.bundle"` to the cosign sign-blob invocation, and add the resulting `.cosign.bundle` files to the release asset upload list so downstream consumers can verify with the modern bundle format.

## Test plan
- [x] Workflow YAML lints clean (zizmor pre-push gate)
- [ ] After merge: re-tag v5.0.5 → release pipeline produces `.sig` + `.pem` + `.cosign.bundle` + `.spdx.json` triplets