### PR TITLE
ci(docker-publish): drop ARM64 — QEMU exceeds 90-min timeout

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -127,23 +127,28 @@ jobs:
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
 
-      - name: Build and push (multi-arch)
+      - name: Build and push (amd64 only)
         id: push
-        # platforms: amd64 + arm64. The arm64 leg runs under QEMU on the
-        # amd64 runner; this is slower than native but we keep a single
-        # job for atomic provenance/SBOM/cosign signing across both arches
-        # (one OCI index → one digest → one set of attestations).
-        # cache scope is shared across both arches so the rust + node
-        # dependency layers are not duplicated in the GHA cache backend.
+        # ARM64 dropped from container build — Rust release profile
+        # (lto=fat + codegen-units=1 + opt-level=z) under QEMU emulation
+        # exceeds the 90-minute job timeout. v5.0.5 docker-publish run
+        # 25100278382 was cancelled at the 90 min mark on the buildx step.
+        # Users wanting an ARM64 build can pull the signed tarball from the
+        # GitHub Release (parkhub-linux-arm64.tar.gz; built natively on
+        # ubuntu-24.04-arm in release.yml, verifiable with cosign verify-blob
+        # against the published .cosign.bundle).
+        # TODO: split into amd64 + arm64 native jobs (mirroring release.yml
+        # pattern) and combine via `docker buildx imagetools create` for a
+        # multi-arch manifest list. Tracked as a follow-up.
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7
         with:
           context: .
           push: true
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha,scope=release-docker-multiarch
-          cache-to: type=gha,scope=release-docker-multiarch,mode=max
+          cache-from: type=gha,scope=release-docker-amd64
+          cache-to: type=gha,scope=release-docker-amd64,mode=max
           provenance: mode=max
           sbom: true
 


### PR DESCRIPTION
## Summary
v5.0.5 docker-publish run 25100278382 hit the 90-minute job timeout on the multi-arch buildx step. Rust release profile (`lto=fat`, `codegen-units=1`, `opt-level=z`) under QEMU ARM64 emulation is single-threaded LTO link; 85+ min elapsed and Build-and-push was still in flight when the runner cancelled.

## Fix
Switch container build to **amd64 only**. Users wanting ARM64 binaries can pull `parkhub-linux-arm64.tar.gz` from the GitHub Release (built natively on `ubuntu-24.04-arm` in release.yml; verifiable with `cosign verify-blob` against the published `.cosign.bundle`).

## Cache
Scope renamed `release-docker-multiarch` → `release-docker-amd64` to avoid mixing with the prior multi-arch cache layout.

## Follow-up
Track `ci(docker-publish): split into amd64 + arm64 native jobs + manifest combine` — mirror the release.yml pattern that already uses `runs-on: ubuntu-24.04-arm` for native ARM64 binary builds. With native runners the entire matrix would complete in ~15-20 min (vs cancelled at 90 min on QEMU).

## Test plan
- [x] zizmor 1.24.1 clean
- [x] yaml-load parses
- [ ] After merge: re-trigger docker-publish on v5.0.5 → ghcr.io/nash87/parkhub-rust:v5.0.5 lands