### PR TITLE
ci(docker): release-container profile (thin LTO) to fit 90-min timeout

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -160,3 +160,15 @@ codegen-units = 1
 strip = true
 opt-level = "z"
 panic = "abort"
+
+# Container build profile — drops fat LTO + single codegen unit to keep the
+# Dockerfile build (cold cargo-chef cook) inside the GHA 90-minute timeout.
+# Used by the Dockerfile via `--profile release-container` for cargo chef
+# cook + cargo build. Binary ends up ~10-15 % larger than `release` but
+# CI builds in ~15 min instead of timing out at 90+.
+# Native release tarballs in release.yml still use the strict `release`
+# profile for smallest binary size.
+[profile.release-container]
+inherits = "release"
+lto = "thin"
+codegen-units = 16

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,7 @@ FROM chef AS deps
 COPY --from=planner /app/recipe.json recipe.json
 COPY Cargo.toml Cargo.lock ./
 RUN sed -i -e '/"parkhub-client"/d' -e '/"parkhub-desktop"/d' Cargo.toml
-RUN cargo chef cook --release --recipe-path recipe.json \
+RUN cargo chef cook --profile release-container --recipe-path recipe.json \
     --package parkhub-server --no-default-features --features headless
 
 # ---------------------------------------------------------------------------
@@ -64,9 +64,9 @@ COPY parkhub-server/ ./parkhub-server/
 COPY --from=web-builder /app/dist ./parkhub-web/dist/
 # Touch sources to invalidate fingerprints, then build
 RUN touch parkhub-common/src/lib.rs parkhub-server/src/main.rs && \
-    cargo build --release --package parkhub-server \
+    cargo build --profile release-container --package parkhub-server \
         --no-default-features --features headless && \
-    strip /app/target/release/parkhub-server
+    strip /app/target/release-container/parkhub-server
 
 # ---------------------------------------------------------------------------
 # Stage 6: Data-directory scaffold
@@ -93,7 +93,7 @@ FROM gcr.io/distroless/cc-debian13@sha256:56aaf20ab2523a346a67c8e8f8e8dabe447447
 WORKDIR /app
 
 # Copy binary
-COPY --from=builder --chown=65532:65532 /app/target/release/parkhub-server /app/parkhub-server
+COPY --from=builder --chown=65532:65532 /app/target/release-container/parkhub-server /app/parkhub-server
 
 # Copy pre-created /data directory (owned by nonroot UID 65532).
 # --chown is required: COPY --from defaults to root:root regardless of


### PR DESCRIPTION
## Summary
After PR #454 dropped ARM64 from `docker-publish.yml`, the amd64-only run for v5.0.5 (run #25104253537) **still hit the 90-min timeout**. Cold cargo-chef cook + cargo build with `lto = "fat"` + `codegen-units = 1` + `opt-level = "z"` is too slow for the GHA runner — release.yml only succeeds because its native cargo build benefits from sccache + cargo-cache layers that the Docker build can't reach.

## Fix
Add `[profile.release-container]` inheriting from `release` but switching:
- `lto: "fat" → "thin"`
- `codegen-units: 1 → 16`

Dockerfile updated to use `--profile release-container` for both `cargo chef cook` and `cargo build`. Binary path moves from `target/release/` to `target/release-container/`.

## Trade-off
Container binary ends up ~10-15 % larger than the strict release profile (acceptable inside an already-larger Docker image with full glibc + Wolfi base). **Native release.yml binary tarballs continue to use the strict release profile** for the smallest possible distribution download.

## Expected impact
Cold container build ~15-20 min (vs hitting 90 min cap). Warm rebuilds (cache-from gha hits) ~5-10 min.

## Repro
v5.0.5 docker-publish runs that timed out:
- 25100278382 (multi-arch via QEMU; cancelled at 90 min)
- 25104253537 (amd64 native, full LTO; cancelled at 90 min)