### PR TITLE
chore(release): bump version to 5.0.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6550,7 +6550,7 @@ dependencies = [
 
 [[package]]
 name = "parkhub-client"
-version = "5.0.5"
+version = "5.0.6"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6577,7 +6577,7 @@ dependencies = [
 
 [[package]]
 name = "parkhub-common"
-version = "5.0.5"
+version = "5.0.6"
 dependencies = [
  "chrono",
  "proptest",
@@ -6591,7 +6591,7 @@ dependencies = [
 
 [[package]]
 name = "parkhub-desktop"
-version = "5.0.5"
+version = "5.0.6"
 dependencies = [
  "directories",
  "serde",
@@ -6615,7 +6615,7 @@ dependencies = [
 
 [[package]]
 name = "parkhub-server"
-version = "5.0.5"
+version = "5.0.6"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "5.0.5"
+version = "5.0.6"
 edition = "2024"
 rust-version = "1.94"
 authors = ["nash87"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "parkhub",
-  "version": "5.0.5",
+  "version": "5.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "parkhub",
-      "version": "5.0.5",
+      "version": "5.0.6",
       "license": "ISC",
       "devDependencies": {
         "@axe-core/playwright": "^4.11.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parkhub",
-  "version": "5.0.5",
+  "version": "5.0.6",
   "description": "Open source parking lot management system with client-server architecture.",
   "scripts": {
     "test:e2e": "npx playwright test",

--- a/parkhub-web/package-lock.json
+++ b/parkhub-web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "parkhub-web",
-  "version": "5.0.5",
+  "version": "5.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "parkhub-web",
-      "version": "5.0.5",
+      "version": "5.0.6",
       "dependencies": {
         "@astrojs/react": "^5.0.3",
         "@fontsource-variable/inter": "^5.2.8",

--- a/parkhub-web/package.json
+++ b/parkhub-web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "parkhub-web",
   "type": "module",
-  "version": "5.0.5",
+  "version": "5.0.6",
   "engines": {
     "node": ">=22.12.0"
   },


### PR DESCRIPTION
## Summary
Roll-up release picking up the docker-publish fixes:

- #454 docker-publish drops ARM64 (QEMU emulation exceeds 90 min)
- #455 Dockerfile `release-container` profile (thin LTO, fits 90 min)

v5.0.6 should be the first version where docker-publish.yml completes within timeout for amd64-only image.

## Distribution matrix after this release
| Channel | Architectures | Built by |
|---|---|---|
| GitHub Release tarballs (`parkhub-*.tar.gz` etc.) | amd64 + arm64 + macOS universal + Windows | release.yml (native runners, strict release profile) |
| ghcr.io/nash87/parkhub-rust container | amd64 only | docker-publish.yml (release-container profile) |
| Tauri installers (deb/rpm/AppImage/dmg/MSI) | per-platform | release.yml |

ARM64 container parity tracked as follow-up (split to parallel native runners + manifest combine).

## Test plan
- [x] All 5 version sources synced (Cargo.toml, root + parkhub-web package.json, both lock files)
- [ ] After merge: tag `v5.0.6` → release.yml publishes signed tarballs + Tauri installers (proven path from v5.0.5)
- [ ] After tag: docker-publish.yml succeeds in <30 min and pushes ghcr image