### PR TITLE
ci: make Attest provenance advisory in release.yml + docker-publish.yml

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -174,6 +174,12 @@ jobs:
           sarif_file: trivy-results.sarif
 
       - name: Attest image provenance
+        # GHA installation API rate-limit hits this step intermittently
+        # (observed v5.0.6 runs 25108343024 + 25108620933 on the same SHA).
+        # Make it advisory so cosign signing + Syft SBOM + deploy-demo
+        # still complete — those provide the cryptographic + supply-chain
+        # proof we rely on even when SLSA provenance API is rate-limited.
+        continue-on-error: true
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -705,6 +705,12 @@ jobs:
           cat checksums.txt
 
       - name: Attest release artifacts
+        # GHA installation API rate-limit hits this step intermittently
+        # (v5.0.6 release.yml run 25108343017 failed here, then v5.0.4
+        # before that). Make it advisory so cosign signing + Syft SBOM
+        # + Create Release still publish the artifacts even when the
+        # SLSA attestations API is rate-limited.
+        continue-on-error: true
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4
         with:
           subject-path: |


### PR DESCRIPTION
## Summary
GHA installation API rate-limit hits `actions/attest-build-provenance` intermittently (v5.0.6 runs 25108343024 + 25108620933 both failed at this step on the same SHA). The image is already built + pushed to GHCR before this step, but the failure cascades to skip cosign signing + Syft SBOM + deploy-demo, aborting the entire publish.

## Fix
Mark the step `continue-on-error: true` so the rest of the pipeline runs to completion when the attestations API is rate-limited. **Cosign signing + Syft SBOM continue to attach cryptographic + supply-chain proof** — SLSA provenance attestation is best-effort.

## Test plan
- [x] zizmor 1.24.1 clean
- [ ] After merge: re-trigger v5.0.6 docker-publish; expect cosign sign + SBOM + deploy-demo to complete even if attestations API is still rate-limited.