### PR TITLE
chore(release): bump version to 5.0.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6550,7 +6550,7 @@ dependencies = [
 
 [[package]]
 name = "parkhub-client"
-version = "5.0.6"
+version = "5.0.7"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6577,7 +6577,7 @@ dependencies = [
 
 [[package]]
 name = "parkhub-common"
-version = "5.0.6"
+version = "5.0.7"
 dependencies = [
  "chrono",
  "proptest",
@@ -6591,7 +6591,7 @@ dependencies = [
 
 [[package]]
 name = "parkhub-desktop"
-version = "5.0.6"
+version = "5.0.7"
 dependencies = [
  "directories",
  "serde",
@@ -6615,7 +6615,7 @@ dependencies = [
 
 [[package]]
 name = "parkhub-server"
-version = "5.0.6"
+version = "5.0.7"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "5.0.6"
+version = "5.0.7"
 edition = "2024"
 rust-version = "1.94"
 authors = ["nash87"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "parkhub",
-  "version": "5.0.6",
+  "version": "5.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "parkhub",
-      "version": "5.0.6",
+      "version": "5.0.7",
       "license": "ISC",
       "devDependencies": {
         "@axe-core/playwright": "^4.11.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parkhub",
-  "version": "5.0.6",
+  "version": "5.0.7",
   "description": "Open source parking lot management system with client-server architecture.",
   "scripts": {
     "test:e2e": "npx playwright test",

--- a/parkhub-web/package-lock.json
+++ b/parkhub-web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "parkhub-web",
-  "version": "5.0.6",
+  "version": "5.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "parkhub-web",
-      "version": "5.0.6",
+      "version": "5.0.7",
       "dependencies": {
         "@astrojs/react": "^5.0.3",
         "@fontsource-variable/inter": "^5.2.8",

--- a/parkhub-web/package.json
+++ b/parkhub-web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "parkhub-web",
   "type": "module",
-  "version": "5.0.6",
+  "version": "5.0.7",
   "engines": {
     "node": ">=22.12.0"
   },


### PR DESCRIPTION
## Summary
v5.0.6 release.yml + docker-publish runs both failed at the SLSA `actions/attest-build-provenance` step due to GHA installation API rate-limit. PR #457 made that step `continue-on-error: true` in both workflows.

v5.0.7 is the first tagged release where the attest-build-provenance step is non-blocking, so cosign signing + Syft SBOM + Create Release run to completion even when the API throttles.

## Test plan
- [x] All 5 version sources synced
- [ ] After merge: tag `v5.0.7` → release.yml + docker-publish both publish artifacts, with attest-step warnings (visible in run summary) if API still rate-limited.