### PR TITLE
ci(docker-publish): make SBOM cosign attestation advisory (cosign 3.x compat)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -220,6 +220,19 @@ jobs:
           python3 -c "import json,sys; json.load(open('sbom.spdx.json'))"
 
       - name: Attach SBOM as cosign attestation (keyless OIDC)
+        # cosign 3.x regressed `cosign attest --type spdx` against this
+        # SBOM-format combination — observed v5.0.7 docker-publish run
+        # 25109842488 step 15 failure:
+        #   "failed to fetch envelope statement: validation error:
+        #    invalid attestation: decoding json"
+        # Make this advisory: image is still signed (Sign step earlier),
+        # SBOM is still uploaded as an artifact (Upload SBOM step below).
+        # The miss is the binding of SBOM to image digest in OCI registry.
+        # TODO: investigate cosign 3.x attestation envelope expectations;
+        # possibly switch to `--predicate-type` flag or upgrade syft SPDX
+        # output to a compatible version.
+        id: attest_sbom
+        continue-on-error: true
         env:
           COSIGN_EXPERIMENTAL: 'true'
           IMAGE_DIGEST: ${{ steps.push.outputs.digest }}
@@ -229,6 +242,23 @@ jobs:
             --predicate sbom.spdx.json \
             --type spdx \
             "${IMAGE_REF}@${IMAGE_DIGEST}"
+
+      - name: Surface SBOM attestation failure to job summary
+        if: always() && steps.attest_sbom.outcome == 'failure'
+        env:
+          IMAGE_REF: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          IMAGE_DIGEST: ${{ steps.push.outputs.digest }}
+        run: |
+          {
+            echo "## ⚠️ SBOM cosign attestation FAILED"
+            echo ""
+            echo "cosign attest --type spdx returned outcome=failure for image ${IMAGE_REF}@${IMAGE_DIGEST}."
+            echo ""
+            echo "Image is still cosign-signed (Sign container image step earlier). SBOM file is still uploaded as a workflow artifact (Upload SBOM step below). The miss is the OCI-registry binding of SBOM to image digest."
+            echo ""
+            echo "Likely cosign 3.x compatibility regression with --type spdx. Tracked as a follow-up to investigate."
+          } | tee -a "$GITHUB_STEP_SUMMARY"
+          echo "::warning title=SBOM attestation missing::cosign attest --type spdx failed; image signed + SBOM artifact still attached."
 
       - name: Upload SBOM artifact
         uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5


### PR DESCRIPTION
## Summary
v5.0.7 docker-publish run 25109842488 step 15 failed:
```
Error: signing ghcr.io/nash87/parkhub-rust@sha256:...: signing bundle:
error signing bundle: failed to fetch envelope statement: validation
error: invalid attestation: decoding json
```

cosign 3.x regressed `cosign attest --type spdx` for this SBOM format. Image is still signed in the prior **Sign container image** step, and SBOM file is still uploaded as a workflow artifact in **Upload SBOM artifact**. The miss is the OCI-registry binding of SBOM to image digest.

## Fix
Mark the step `continue-on-error: true` so deploy-demo + the rest of the pipeline still complete. Add a summary-warn step (env:-bound, zizmor-clean) so missing SBOM attestations stay visible.

## Follow-up
Investigate cosign 3.x attestation envelope expectations — possibly switch to `--predicate-type` flag or pin syft SPDX output format.

## Test plan
- [x] zizmor 1.24.1 clean
- [ ] After merge: bump v5.0.8, tag, expect docker-publish to complete (with attest-step warning visible in summary).