### PR TITLE
chore(release): bump version to 5.0.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6550,7 +6550,7 @@ dependencies = [
 
 [[package]]
 name = "parkhub-client"
-version = "5.0.7"
+version = "5.0.8"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6577,7 +6577,7 @@ dependencies = [
 
 [[package]]
 name = "parkhub-common"
-version = "5.0.7"
+version = "5.0.8"
 dependencies = [
  "chrono",
  "proptest",
@@ -6591,7 +6591,7 @@ dependencies = [
 
 [[package]]
 name = "parkhub-desktop"
-version = "5.0.7"
+version = "5.0.8"
 dependencies = [
  "directories",
  "serde",
@@ -6615,7 +6615,7 @@ dependencies = [
 
 [[package]]
 name = "parkhub-server"
-version = "5.0.7"
+version = "5.0.8"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "5.0.7"
+version = "5.0.8"
 edition = "2024"
 rust-version = "1.94"
 authors = ["nash87"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "parkhub",
-  "version": "5.0.7",
+  "version": "5.0.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "parkhub",
-      "version": "5.0.7",
+      "version": "5.0.8",
       "license": "ISC",
       "devDependencies": {
         "@axe-core/playwright": "^4.11.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parkhub",
-  "version": "5.0.7",
+  "version": "5.0.8",
   "description": "Open source parking lot management system with client-server architecture.",
   "scripts": {
     "test:e2e": "npx playwright test",

--- a/parkhub-web/package-lock.json
+++ b/parkhub-web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "parkhub-web",
-  "version": "5.0.7",
+  "version": "5.0.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "parkhub-web",
-      "version": "5.0.7",
+      "version": "5.0.8",
       "dependencies": {
         "@astrojs/react": "^5.0.3",
         "@fontsource-variable/inter": "^5.2.8",

--- a/parkhub-web/package.json
+++ b/parkhub-web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "parkhub-web",
   "type": "module",
-  "version": "5.0.7",
+  "version": "5.0.8",
   "engines": {
     "node": ">=22.12.0"
   },


### PR DESCRIPTION
## Summary
First tag with all release-pipeline reliability fixes integrated:

- #459 Attest provenance + SBOM-attest advisory
- #462 native amd64 + arm64 docker-publish split (with `--type spdxjson` cosign fix already inline)
- #461 README cosign-verify quickstart (queued, may merge before this lands)

## Test plan
- [x] All 5 version sources synced
- [ ] On tag push: release.yml publishes signed binaries (proven from v5.0.5)
- [ ] On tag push: docker-publish.yml publishes multi-arch manifest (`linux/amd64 + linux/arm64`) with cosign signatures + SBOM attest succeeding (`--type spdxjson` correct for cosign 3.x)

## Honest expectations
SLSA `actions/attest-build-provenance` may still hit GHA installation rate-limit; #459 made it `continue-on-error` with a summary banner. If rate-limited, image still gets cosign-signed + Syft SBOM + SLSA-blob provenance for binaries.