### PR TITLE
ci(docker-publish): use --format templating for manifest digest

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -450,11 +450,25 @@ jobs:
 
           # Resolve the manifest digest from the first canonical tag
           # (they all point at the same index, by construction).
+          # Use buildx's templated output instead of awk'ing the
+          # human-friendly format — the legacy `Digest:` text line is
+          # not consistently emitted across docker-buildx versions and
+          # bit us on v5.0.8 (run 25116116538). The template field is
+          # stable across docker-buildx 0.18+.
           first_tag="${tags[0]}"
-          digest="$(docker buildx imagetools inspect "${first_tag}" 2>/dev/null | awk '/^Digest:/ { print $2; exit }')"
+          if ! digest="$(docker buildx imagetools inspect --format '{{.Manifest.Digest}}' "${first_tag}")"; then
+            echo "::error::Failed to inspect manifest digest from ${first_tag}"
+            echo "::group::Full inspect output for diagnosis"
+            docker buildx imagetools inspect "${first_tag}" || true
+            echo "::endgroup::"
+            exit 1
+          fi
 
           if [[ ! "${digest}" =~ ^sha256:[0-9a-f]{64}$ ]]; then
-            echo "::error::Failed to resolve manifest digest from ${first_tag}"
+            echo "::error::Failed to resolve manifest digest from ${first_tag} — got: '${digest}'"
+            echo "::group::Full inspect output for diagnosis"
+            docker buildx imagetools inspect "${first_tag}" || true
+            echo "::endgroup::"
             exit 1
           fi
 


### PR DESCRIPTION
## Summary
v5.0.8 docker-publish run 25116116538 failed at the manifest-list job. The two per-arch builds + imagetools create succeeded; the failure was in the digest-resolve step:

```bash
digest="$(docker buildx imagetools inspect ... | awk '/^Digest:/ { print $2; exit }')"
```

awk pattern returned empty → digest regex check failed → `exit 1` (manifest job 255'd, deploy-demo skipped, signing skipped). Multi-arch index was actually pushed successfully — only the digest-extract for downstream cosign signing failed.

## Fix
Use buildx's templated output:
```bash
digest="$(docker buildx imagetools inspect --format '{{.Manifest.Digest}}' ...)"
```

Stable across docker-buildx 0.18+. Also add a diagnostic group that dumps full inspect output when the regex check fails, turning the silent exit-255 into an actionable error.

## Test plan
- [x] zizmor 1.24.1 clean
- [ ] After merge: bump v5.0.9, tag, expect manifest job to resolve digest cleanly + cosign sign manifest digest + Trivy scan complete