### PR TITLE
fix(a11y): heatmap ARIA grid wrapping + breadcrumb contrast

### DIFF
--- a/parkhub-web/src/components/OccupancyHeatmap.tsx
+++ b/parkhub-web/src/components/OccupancyHeatmap.tsx
@@ -193,34 +193,43 @@ export function OccupancyHeatmap({ bookings, totalSlots }: OccupancyHeatmapProps
           role="grid"
           aria-label={t('heatmap.title')}
         >
-          {/* Top-left empty corner */}
-          <div />
+          {/* Header row — wrap in role="row" so role="grid" has the
+              required role="row" → role="columnheader" parent chain.
+              `display: contents` keeps the CSS Grid layout intact while
+              still adding the ARIA row landmark for assistive tech. */}
+          <div role="row" style={{ display: 'contents' }}>
+            {/* Top-left empty corner */}
+            <div />
 
-          {/* Day column headers */}
-          {dayLabels.map((label, i) => (
-            <div
-              key={`day-${i}`}
-              className="text-xs font-medium text-surface-500 dark:text-surface-400 text-center py-1 select-none"
-              role="columnheader"
-            >
-              {label}
-            </div>
-          ))}
+            {/* Day column headers */}
+            {dayLabels.map((label, i) => (
+              <div
+                key={`day-${i}`}
+                className="text-xs font-medium text-surface-500 dark:text-surface-400 text-center py-1 select-none"
+                role="columnheader"
+              >
+                {label}
+              </div>
+            ))}
+          </div>
 
           {/* Rows: one per hour */}
           {hours.map(hour => (
             <Fragment key={`row-${hour}`}>
-              {/* Hour label */}
-              <div
-                key={`hour-label-${hour}`}
-                className="text-xs font-medium text-surface-500 dark:text-surface-400 text-right pr-2 flex items-center justify-end select-none tabular-nums"
-                role="rowheader"
-              >
-                {`${hour}:00`}
-              </div>
+              {/* `display: contents` again — keeps the inline-grid auto-flow
+                  while the role="row" wrapper completes the ARIA chain. */}
+              <div role="row" style={{ display: 'contents' }}>
+                {/* Hour label */}
+                <div
+                  key={`hour-label-${hour}`}
+                  className="text-xs font-medium text-surface-500 dark:text-surface-400 text-right pr-2 flex items-center justify-end select-none tabular-nums"
+                  role="rowheader"
+                >
+                  {`${hour}:00`}
+                </div>
 
-              {/* 7 cells for this hour */}
-              {Array.from({ length: 7 }, (_, day) => {
+                {/* 7 cells for this hour */}
+                {Array.from({ length: 7 }, (_, day) => {
                 const cell = cells.find(c => c.day === day && c.hour === hour);
                 const pct = cell?.percentage ?? 0;
                 return (
@@ -238,6 +247,7 @@ export function OccupancyHeatmap({ bookings, totalSlots }: OccupancyHeatmapProps
                   />
                 );
               })}
+              </div>
             </Fragment>
           ))}
         </div>

--- a/parkhub-web/src/components/ui/Breadcrumb.tsx
+++ b/parkhub-web/src/components/ui/Breadcrumb.tsx
@@ -41,7 +41,7 @@ export function Breadcrumb() {
     <nav aria-label={t('ui.breadcrumb')} className="flex items-center gap-1.5 text-sm mb-4">
       <Link
         to="/"
-        className="text-surface-400 hover:text-primary-600 dark:hover:text-primary-400 transition-colors font-medium"
+        className="text-surface-600 dark:text-surface-400 hover:text-primary-600 dark:hover:text-primary-400 transition-colors font-medium"
         aria-current={pathname === '/' ? 'page' : undefined}
       >
         {t('nav.dashboard')}
@@ -56,7 +56,7 @@ export function Breadcrumb() {
           ) : (
             <Link
               to={crumb.path}
-              className="text-surface-400 hover:text-primary-600 dark:hover:text-primary-400 transition-colors font-medium"
+              className="text-surface-600 dark:text-surface-400 hover:text-primary-600 dark:hover:text-primary-400 transition-colors font-medium"
             >
               {crumb.label}
             </Link>


### PR DESCRIPTION
## Summary

Two accessibility fixes from the **web-design-guidelines audit (audit-batch-1)**:

- **`OccupancyHeatmap.tsx`** — Wrap header row + each hour row in `role=\"row\"` with `display:contents`. The `role=\"grid\"` parent now has the required `role=\"row\"` chain over its `role=\"columnheader\"` / `role=\"gridcell\"` children, which axe-core flagged. CSS Grid auto-flow is preserved via `display:contents` so the visual layout is unchanged.
- **`Breadcrumb.tsx`** — Inactive crumb links were `text-surface-400` (~3.4:1 contrast on white), failing WCAG 2.1 AA's 4.5:1. Bumped to `text-surface-600 dark:text-surface-400` (~7:1 on light, dark mode unchanged).

## Test plan

- [x] `tsc --noEmit` clean
- [x] Local lefthook pre-commit clean
- [ ] Visual regression CI (Chromatic / Playwright)
- [ ] axe-core run on /admin/* routes (the heatmap container)
- [ ] Manual contrast check on `/bookings`, `/admin/users`, `/admin/lots` breadcrumbs

## Audit context

Findings from prior subagent runs (Tasks #32, #33, #36). Bigger systemic fixes (focus-visible utility, prefers-reduced-motion guards, framer-motion removal in PHP, sidebar `<button>`→`<Link>`) deferred to subsequent batches.