### PR TITLE
fix(a11y): focus-visible utility, scoped transitions, link-based bottom nav

### DIFF
--- a/parkhub-web/src/components/Layout.tsx
+++ b/parkhub-web/src/components/Layout.tsx
@@ -170,7 +170,7 @@ function SidebarNav({
           : undefined
       }
       className={({ isActive }) =>
-        `relative flex items-center gap-3 ${itemPadding} text-sm font-medium rounded-lg transition-all ${
+        `focus-ring relative flex items-center gap-3 ${itemPadding} text-sm font-medium rounded-lg transition-colors ${
           isActive
             ? 'text-primary-700 dark:text-primary-300 bg-primary-50/80 dark:bg-primary-950/30'
             : 'text-surface-600 dark:text-surface-400 hover:text-surface-900 dark:hover:text-white hover:bg-surface-100/60 dark:hover:bg-surface-800/40'
@@ -268,7 +268,7 @@ function SidebarNav({
             to="/admin"
             onClick={onItemClick}
             className={({ isActive }) =>
-              `relative flex items-center gap-3 ${itemPadding} text-sm font-medium rounded-lg transition-all ${
+              `focus-ring relative flex items-center gap-3 ${itemPadding} text-sm font-medium rounded-lg transition-colors ${
                 isActive
                   ? 'text-primary-700 dark:text-primary-300 bg-primary-50/80 dark:bg-primary-950/30'
                   : 'text-surface-600 dark:text-surface-400 hover:text-surface-900 dark:hover:text-white hover:bg-surface-100/60 dark:hover:bg-surface-800/40'
@@ -303,7 +303,7 @@ function LanguageSelector() {
     <div ref={ref} className="relative">
       <button
         onClick={() => setOpen(o => !o)}
-        className="flex items-center gap-2 px-3 py-2 text-sm font-medium text-surface-600 dark:text-surface-400 hover:text-surface-900 dark:hover:text-white rounded-lg hover:bg-surface-100/60 dark:hover:bg-surface-800/40 transition-all w-full"
+        className="focus-ring flex items-center gap-2 px-3 py-2 text-sm font-medium text-surface-600 dark:text-surface-400 hover:text-surface-900 dark:hover:text-white rounded-lg hover:bg-surface-100/60 dark:hover:bg-surface-800/40 transition-colors w-full"
         aria-label="Change language"
         aria-expanded={open}
       >
@@ -317,7 +317,7 @@ function LanguageSelector() {
             <button
               key={lang.code}
               onClick={() => { i18n?.changeLanguage(lang.code); setOpen(false); }}
-              className={`flex items-center gap-2 w-full px-3 py-2 text-sm transition-colors ${
+              className={`focus-ring flex items-center gap-2 w-full px-3 py-2 text-sm transition-colors ${
                 lang.code === i18n?.language
                   ? 'bg-primary-50 dark:bg-primary-950/30 text-primary-700 dark:text-primary-300 font-medium'
                   : 'text-surface-700 dark:text-surface-300 hover:bg-surface-50 dark:hover:bg-surface-700/50'
@@ -484,7 +484,7 @@ export function Layout() {
 
         <button
           onClick={() => setTheme(resolved === 'dark' ? 'light' : 'dark')}
-          className="flex items-center gap-3 px-3 py-2 text-sm font-medium text-surface-600 dark:text-surface-400 hover:text-surface-900 dark:hover:text-white rounded-lg hover:bg-surface-100/60 dark:hover:bg-surface-800/40 transition-all mb-2"
+          className="focus-ring flex items-center gap-3 px-3 py-2 text-sm font-medium text-surface-600 dark:text-surface-400 hover:text-surface-900 dark:hover:text-white rounded-lg hover:bg-surface-100/60 dark:hover:bg-surface-800/40 transition-colors mb-2"
         >
           {resolved === 'dark' ? <SunDim weight="fill" className="w-5 h-5" /> : <Moon weight="fill" className="w-5 h-5" />}
           {resolved === 'dark' ? t('nav.lightMode') : t('nav.darkMode')}
@@ -507,7 +507,7 @@ export function Layout() {
           </div>
           <button
             onClick={handleLogout}
-            className="flex items-center gap-3 px-3 py-2 text-sm font-medium text-red-600 hover:text-red-700 dark:hover:text-red-400 hover:bg-red-50/60 dark:hover:bg-red-950/20 rounded-lg transition-all w-full"
+            className="focus-ring flex items-center gap-3 px-3 py-2 text-sm font-medium text-red-600 hover:text-red-700 dark:hover:text-red-400 hover:bg-red-50/60 dark:hover:bg-red-950/20 rounded-lg transition-colors w-full"
           >
             <SignOut weight="bold" className="w-5 h-5" />
             {t('nav.logout')}
@@ -592,7 +592,7 @@ export function Layout() {
                   />
                 </div>
                 <div className="absolute bottom-4 left-4 right-4">
-                  <button onClick={handleLogout} className="flex items-center gap-3 px-3 py-2.5 text-sm font-medium text-red-600 w-full rounded-lg hover:bg-red-50/60 dark:hover:bg-red-950/20 transition-all">
+                  <button onClick={handleLogout} className="focus-ring flex items-center gap-3 px-3 py-2.5 text-sm font-medium text-red-600 w-full rounded-lg hover:bg-red-50/60 dark:hover:bg-red-950/20 transition-colors">
                     <SignOut weight="bold" className="w-5 h-5" /> {t('nav.logout')}
                   </button>
                 </div>

--- a/parkhub-web/src/components/PWAEnhanced.test.tsx
+++ b/parkhub-web/src/components/PWAEnhanced.test.tsx
@@ -1,7 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import React from 'react';
 import { render, screen, waitFor, fireEvent, act } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 
 const { mockNavigate, mockLocation } = vi.hoisted(() => ({
   mockNavigate: vi.fn(),
@@ -31,6 +30,11 @@ vi.mock('react-i18next', () => ({
 vi.mock('react-router-dom', () => ({
   useNavigate: () => mockNavigate,
   useLocation: () => mockLocation,
+  Link: ({ to, children, ...rest }: any) => (
+    <a href={typeof to === 'string' ? to : '#'} {...rest}>
+      {children}
+    </a>
+  ),
 }));
 
 vi.mock('@phosphor-icons/react', () => ({
@@ -116,19 +120,21 @@ describe('BottomNavBar', () => {
     expect(screen.getByText('Profile')).toBeDefined();
   });
 
-  it('has 5 navigation buttons', () => {
+  it('renders 5 navigation links (not buttons)', () => {
+    // a11y: tabs must be real <a> links so cmd-click / middle-click open
+    // in a new tab, right-click opens the context menu, status bar shows
+    // destination URL, and screen readers announce them as links.
     render(<BottomNavBar />);
-    const buttons = screen.getAllByRole('button');
-    expect(buttons.length).toBe(5);
+    const links = screen.getAllByRole('link');
+    expect(links.length).toBe(5);
+    // No buttons should be used for navigation in the bottom bar.
+    expect(screen.queryAllByRole('button')).toHaveLength(0);
   });
 
-  it('navigates when a tab is clicked', async () => {
-    const user = userEvent.setup();
+  it('exposes the route path in the href so middle/cmd-click open in a new tab', async () => {
     render(<BottomNavBar />);
-
-    await user.click(screen.getByLabelText('Vehicles'));
-
-    expect(mockNavigate).toHaveBeenCalledWith('/vehicles');
+    expect(screen.getByLabelText('Vehicles').getAttribute('href')).toBe('/vehicles');
+    expect(screen.getByLabelText('Dashboard').getAttribute('href')).toBe('/');
   });
 
   it('marks nested booking routes as active', () => {

--- a/parkhub-web/src/components/PWAEnhanced.tsx
+++ b/parkhub-web/src/components/PWAEnhanced.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { WifiSlash, ArrowDown, House, CalendarBlank, Car, User } from '@phosphor-icons/react';
-import { useNavigate, useLocation } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Offline Indicator
@@ -108,10 +108,14 @@ export function CachedBookingCard() {
 // Bottom Navigation Bar (Mobile)
 // ─────────────────────────────────────────────────────────────────────────────
 
-/** Mobile bottom navigation bar — visible only on small screens. */
+/** Mobile bottom navigation bar — visible only on small screens.
+ *
+ * Uses real `<Link>` elements (not `<button onClick={navigate}>`) so the
+ * browser's native link affordances work: cmd-click / middle-click open
+ * the route in a new tab, right-click opens the context menu, and the
+ * status bar shows the destination URL on hover. */
 export function BottomNavBar() {
   const { t } = useTranslation();
-  const navigate = useNavigate();
   const location = useLocation();
 
   const tabs = [
@@ -128,16 +132,16 @@ export function BottomNavBar() {
         {tabs.map(tab => {
           const isActive = location.pathname === tab.path || (tab.path !== '/' && location.pathname.startsWith(tab.path));
           return (
-            <button
+            <Link
               key={tab.path}
-              onClick={() => navigate(tab.path)}
-              className={`flex flex-col items-center gap-0.5 px-3 py-1 rounded-lg transition-colors ${isActive ? 'text-primary-500' : 'text-surface-400 hover:text-surface-600'}`}
+              to={tab.path}
+              className={`focus-ring flex flex-col items-center gap-0.5 px-3 py-1 rounded-lg transition-colors ${isActive ? 'text-primary-500' : 'text-surface-400 hover:text-surface-600'}`}
               aria-label={tab.label}
               aria-current={isActive ? 'page' : undefined}
             >
               <tab.icon size={22} weight={isActive ? 'fill' : 'regular'} />
               <span className="text-[10px] font-medium leading-tight">{tab.label}</span>
-            </button>
+            </Link>
           );
         })}
       </div>

--- a/parkhub-web/src/styles/global.css
+++ b/parkhub-web/src/styles/global.css
@@ -442,10 +442,22 @@ p { line-height: 1.6; }
 ::-webkit-scrollbar-thumb { background: var(--color-surface-300); border-radius: var(--radius-full); }
 .dark ::-webkit-scrollbar-thumb { background: var(--color-surface-600); }
 
-/* Focus ring */
+/* Focus ring — global default for any focusable element */
 *:focus-visible {
   outline: 2px solid var(--color-primary-500);
   outline-offset: 2px;
+}
+
+/* Focus ring — opt-in utility for interactive elements that need to
+   override component-local outline styles (e.g. when a parent sets
+   `focus:outline-none`). Use `:focus-visible` so the ring only shows on
+   keyboard navigation, not on mouse clicks. */
+@utility focus-ring {
+  &:focus-visible {
+    outline: 2px solid var(--color-primary-500);
+    outline-offset: 2px;
+    border-radius: var(--radius-md);
+  }
 }
 
 /* Mobile touch target minimum */


### PR DESCRIPTION
## Summary
Three independent a11y fixes from audit-batch-3, applied to the Astro+React frontend in `parkhub-web/`.

### 1. `focus-ring` utility (Tailwind v4 `@utility`)
Adds a named `:focus-visible`-only focus-ring utility in `parkhub-web/src/styles/global.css`. The ring shows on keyboard navigation but not on mouse clicks. Applied to: sidebar nav links, language selector, theme toggle, logout buttons, language dropdown items, and the new bottom-nav links.

### 2. Scoped transitions
Replaces `transition-all` on every Layout interactive element with explicit `transition-colors`. `transition: all` animates layout properties and can cause hover-driven layout-shift surprises. The existing `@media (prefers-reduced-motion: reduce)` guard in `global.css` continues to neutralise transitions for users who request it (no change needed there — already best-in-class).

### 3. Bottom-nav as `<Link>` (the big one)
The mobile `BottomNavBar` tabs in `PWAEnhanced.tsx` were rendered as `<button onClick={() => navigate(path)}>`. This breaks every native link affordance: cmd-click / middle-click can't open the route in a new tab, right-click doesn't show the context menu, the status bar doesn't preview the destination URL, and screen readers announce them as buttons (action) instead of links (navigation). Converted to `<Link to={path}>` from `react-router-dom`.

### Notes / scope
- The classic sidebar (`Layout.SidebarNav`) already uses `NavLink`, so no conversion was needed there.
- Alt nav variants (`RailSidebar`, `TopTabs`, `FloatingDock`, `SidebarV3`) already use `NavLink` for navigation.
- No dependency bumps. No unrelated refactors.
- Tests updated for `BottomNavBar` to assert role=link, href, and absence of role=button.

## Test plan
- [x] `npx tsc --noEmit` clean from `parkhub-web/` — no new errors
- [x] `npx vitest run src/components/PWAEnhanced.test.tsx` — 17/17 green (added href/role assertions)
- [x] `npx vitest run src/components/Layout.test.tsx` — 36/36 green
- [x] Pre-push hooks (cargo-check / clippy / cargo-test-fast / openapi-drift / osv-scanner / trivy-fs / types-drift / zizmor) all pass
- [ ] Manual: keyboard tab through sidebar → ring shows; mouse-click → no ring
- [ ] Manual: cmd-click a bottom-nav tab on iOS Safari → opens in new tab
- [ ] Manual: trigger system reduced-motion → sidebar slide & nav hover transitions complete in <0.01ms