### PR TITLE
fix(supply-chain): cosign-verify uses --type spdxjson (matches docker-publish)

### DIFF
--- a/.github/workflows/cosign-verify.yml
+++ b/.github/workflows/cosign-verify.yml
@@ -115,7 +115,7 @@ jobs:
           set -euo pipefail
           repo="${IMAGE%:*}"
           if ! cosign verify-attestation \
-            --type spdx \
+            --type spdxjson \
             --certificate-identity-regexp "${IDENTITY_REGEX}" \
             --certificate-oidc-issuer "${ISSUER}" \
             "${repo}@${DIGEST}" 2>&1; then


### PR DESCRIPTION
## Summary

The `verify-attestation` step has been silently failing-as-advisory since cosign 3.x hardened in-toto predicate validation:

- `docker-publish.yml` writes the SBOM via `cosign attest --type spdxjson` (the SPDX-JSON in-toto predicate, https://spdx.dev/Document)
- `cosign-verify.yml` was checking `--type spdx` (the tag-value text shortname)
- 3.x rejects the cross-format match → `invalid attestation` even on legitimate signatures
- `continue-on-error: true` masked it; the `SBOM attestation not yet present (advisory)` notice was firing on every PR

Switch verify to `--type spdxjson` so it actually validates what the build produces. Once we see a green signed run, the `continue-on-error` can be dropped to promote this from advisory to required.

## Test plan
- [ ] Cosign-Verify workflow run on this PR re-validates the most recent `:latest` digest with the corrected predicate type
- [ ] Once green: open follow-up to drop `continue-on-error: true` (line 99) and bump SBOM-attestation to required
- [ ] Mirrors the parkhub-php cosign-verify port (PR open in that repo)

## Refs
- `feedback_cosign_3x_attest_spdxjson.md` — the original attest-side fix
- T-2268 platform CI/CD standardization
- SOTA-2026 gap analysis HIGH-1 (own report at `.fop/reports/sota-2026-gap-analysis-2026-04-29.md`)