### PR TITLE
fix(server): /sw.js + non-hashed root assets must be no-cache (v4.15.0 trap)

### DIFF
--- a/parkhub-server/src/static_files.rs
+++ b/parkhub-server/src/static_files.rs
@@ -103,103 +103,103 @@ mod tests {
 
     #[test]
     fn serve_file_js_gets_immutable_cache() {
-        if let Some(file) = WebAssets::get("index.html") {
-            // Use a fake .js path to trigger the cache branch
-            let resp = serve_file("assets/app.js", file);
-            let cache = resp
-                .headers()
-                .get(header::CACHE_CONTROL)
-                .and_then(|v| v.to_str().ok())
-                .unwrap_or("");
-            assert!(
-                cache.contains("immutable"),
-                "JS assets must get immutable cache header, got: {cache}"
-            );
-            assert!(
-                cache.contains("31536000"),
-                "JS assets must get 1-year max-age"
-            );
-        }
+        let file = WebAssets::get("index.html")
+            .expect("WebAssets::get(\"index.html\") must succeed: embedded assets missing means parkhub-web/dist/ wasn't built before parkhub-server compile");
+        // Use a fake .js path to trigger the cache branch
+        let resp = serve_file("assets/app.js", file);
+        let cache = resp
+            .headers()
+            .get(header::CACHE_CONTROL)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("");
+        assert!(
+            cache.contains("immutable"),
+            "JS assets must get immutable cache header, got: {cache}"
+        );
+        assert!(
+            cache.contains("31536000"),
+            "JS assets must get 1-year max-age"
+        );
     }
 
     #[test]
     fn serve_file_css_gets_immutable_cache() {
-        if let Some(file) = WebAssets::get("index.html") {
-            let resp = serve_file("assets/style.css", file);
-            let cache = resp
-                .headers()
-                .get(header::CACHE_CONTROL)
-                .and_then(|v| v.to_str().ok())
-                .unwrap_or("");
-            assert!(
-                cache.contains("immutable"),
-                "CSS assets must get immutable cache header"
-            );
-        }
+        let file = WebAssets::get("index.html")
+            .expect("WebAssets::get(\"index.html\") must succeed: embedded assets missing means parkhub-web/dist/ wasn't built before parkhub-server compile");
+        let resp = serve_file("assets/style.css", file);
+        let cache = resp
+            .headers()
+            .get(header::CACHE_CONTROL)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("");
+        assert!(
+            cache.contains("immutable"),
+            "CSS assets must get immutable cache header"
+        );
     }
 
     #[test]
     fn serve_file_index_html_gets_no_cache() {
-        if let Some(file) = WebAssets::get("index.html") {
-            let resp = serve_file("index.html", file);
-            let cache = resp
-                .headers()
-                .get(header::CACHE_CONTROL)
-                .and_then(|v| v.to_str().ok())
-                .unwrap_or("");
-            assert_eq!(
-                cache, "no-cache",
-                "index.html must have no-cache for SPA updates"
-            );
-        }
+        let file = WebAssets::get("index.html")
+            .expect("WebAssets::get(\"index.html\") must succeed: embedded assets missing means parkhub-web/dist/ wasn't built before parkhub-server compile");
+        let resp = serve_file("index.html", file);
+        let cache = resp
+            .headers()
+            .get(header::CACHE_CONTROL)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("");
+        assert_eq!(
+            cache, "no-cache",
+            "index.html must have no-cache for SPA updates"
+        );
     }
 
     #[test]
     fn serve_file_non_asset_path_gets_no_cache() {
-        if let Some(file) = WebAssets::get("index.html") {
-            let resp = serve_file("favicon.ico", file);
-            let cache = resp
-                .headers()
-                .get(header::CACHE_CONTROL)
-                .and_then(|v| v.to_str().ok())
-                .unwrap_or("");
-            assert_eq!(
-                cache, "no-cache",
-                "non-asset files should get no-cache, got: {cache}"
-            );
-        }
+        let file = WebAssets::get("index.html")
+            .expect("WebAssets::get(\"index.html\") must succeed: embedded assets missing means parkhub-web/dist/ wasn't built before parkhub-server compile");
+        let resp = serve_file("favicon.ico", file);
+        let cache = resp
+            .headers()
+            .get(header::CACHE_CONTROL)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("");
+        assert_eq!(
+            cache, "no-cache",
+            "non-asset files should get no-cache, got: {cache}"
+        );
     }
 
     #[test]
     fn serve_file_sets_content_type_for_html() {
-        if let Some(file) = WebAssets::get("index.html") {
-            let resp = serve_file("index.html", file);
-            let ct = resp
-                .headers()
-                .get(header::CONTENT_TYPE)
-                .and_then(|v| v.to_str().ok())
-                .unwrap_or("");
-            assert!(
-                ct.contains("text/html"),
-                "index.html must be served as text/html, got: {ct}"
-            );
-        }
+        let file = WebAssets::get("index.html")
+            .expect("WebAssets::get(\"index.html\") must succeed: embedded assets missing means parkhub-web/dist/ wasn't built before parkhub-server compile");
+        let resp = serve_file("index.html", file);
+        let ct = resp
+            .headers()
+            .get(header::CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("");
+        assert!(
+            ct.contains("text/html"),
+            "index.html must be served as text/html, got: {ct}"
+        );
     }
 
     #[test]
     fn serve_file_sets_content_type_for_js() {
-        if let Some(file) = WebAssets::get("index.html") {
-            let resp = serve_file("app.js", file);
-            let ct = resp
-                .headers()
-                .get(header::CONTENT_TYPE)
-                .and_then(|v| v.to_str().ok())
-                .unwrap_or("");
-            assert!(
-                ct.contains("javascript"),
-                "JS files must be served as javascript, got: {ct}"
-            );
-        }
+        let file = WebAssets::get("index.html")
+            .expect("WebAssets::get(\"index.html\") must succeed: embedded assets missing means parkhub-web/dist/ wasn't built before parkhub-server compile");
+        let resp = serve_file("app.js", file);
+        let ct = resp
+            .headers()
+            .get(header::CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("");
+        assert!(
+            ct.contains("javascript"),
+            "JS files must be served as javascript, got: {ct}"
+        );
     }
 
     // ── static_handler SPA routing ──
@@ -259,13 +259,14 @@ mod tests {
     #[test]
     fn list_assets_returns_vec() {
         let assets = list_assets();
-        // Should contain at least index.html if web assets are embedded
-        if has_web_assets() {
-            assert!(
-                assets.iter().any(|a| a.contains("index.html")),
-                "assets should include index.html"
-            );
-        }
+        assert!(
+            has_web_assets(),
+            "test environment must have embedded web assets — parkhub-web/dist/ wasn't built before parkhub-server compile"
+        );
+        assert!(
+            assets.iter().any(|a| a.contains("index.html")),
+            "list_assets() must include index.html"
+        );
     }
 
     // ── serve_file no-cache for non-hashed root assets (regression: sw.js v4.15.0 trap) ──
@@ -278,101 +279,101 @@ mod tests {
         // updates to the active service worker — the v4 footer kept rendering
         // long after the deployed binary moved to v5.0.x. sw.js MUST be served
         // with no-cache so the browser re-fetches it on every page load.
-        if let Some(file) = WebAssets::get("index.html") {
-            let resp = serve_file("sw.js", file);
-            let cache = resp
-                .headers()
-                .get(header::CACHE_CONTROL)
-                .and_then(|v| v.to_str().ok())
-                .unwrap_or("");
-            assert_eq!(
-                cache, "no-cache",
-                "sw.js must be served with no-cache so SW updates propagate, got: {cache}"
-            );
-        }
+        let file = WebAssets::get("index.html")
+            .expect("WebAssets::get(\"index.html\") must succeed: embedded assets missing means parkhub-web/dist/ wasn't built before parkhub-server compile");
+        let resp = serve_file("sw.js", file);
+        let cache = resp
+            .headers()
+            .get(header::CACHE_CONTROL)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("");
+        assert_eq!(
+            cache, "no-cache",
+            "sw.js must be served with no-cache so SW updates propagate, got: {cache}"
+        );
     }
 
     #[test]
     fn serve_file_manifest_json_gets_no_cache() {
         // PWA manifest is at the dist root and not hashed; updates to icons,
         // start_url, theme_color etc. should propagate without 1-year staleness.
-        if let Some(file) = WebAssets::get("index.html") {
-            let resp = serve_file("manifest.json", file);
-            let cache = resp
-                .headers()
-                .get(header::CACHE_CONTROL)
-                .and_then(|v| v.to_str().ok())
-                .unwrap_or("");
-            assert_eq!(
-                cache, "no-cache",
-                "manifest.json must be served with no-cache, got: {cache}"
-            );
-        }
+        let file = WebAssets::get("index.html")
+            .expect("WebAssets::get(\"index.html\") must succeed: embedded assets missing means parkhub-web/dist/ wasn't built before parkhub-server compile");
+        let resp = serve_file("manifest.json", file);
+        let cache = resp
+            .headers()
+            .get(header::CACHE_CONTROL)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("");
+        assert_eq!(
+            cache, "no-cache",
+            "manifest.json must be served with no-cache, got: {cache}"
+        );
     }
 
     #[test]
     fn serve_file_root_level_js_not_in_hashed_dir_gets_no_cache() {
         // Any *.js outside /_astro/ or /assets/ is presumed non-hashed and
         // must use no-cache to avoid the same trap as sw.js.
-        if let Some(file) = WebAssets::get("index.html") {
-            let resp = serve_file("legacy-script.js", file);
-            let cache = resp
-                .headers()
-                .get(header::CACHE_CONTROL)
-                .and_then(|v| v.to_str().ok())
-                .unwrap_or("");
-            assert_eq!(
-                cache, "no-cache",
-                "non-hashed root .js files must use no-cache, got: {cache}"
-            );
-        }
+        let file = WebAssets::get("index.html")
+            .expect("WebAssets::get(\"index.html\") must succeed: embedded assets missing means parkhub-web/dist/ wasn't built before parkhub-server compile");
+        let resp = serve_file("legacy-script.js", file);
+        let cache = resp
+            .headers()
+            .get(header::CACHE_CONTROL)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("");
+        assert_eq!(
+            cache, "no-cache",
+            "non-hashed root .js files must use no-cache, got: {cache}"
+        );
     }
 
     #[test]
     fn serve_file_astro_hashed_js_gets_immutable_cache() {
         // Files in _astro/ have content hashes (e.g., Welcome.DcWMTKUm.js)
         // so URL changes on every edit — immutable caching is safe.
-        if let Some(file) = WebAssets::get("index.html") {
-            let resp = serve_file("_astro/Welcome.DcWMTKUm.js", file);
-            let cache = resp
-                .headers()
-                .get(header::CACHE_CONTROL)
-                .and_then(|v| v.to_str().ok())
-                .unwrap_or("");
-            assert!(
-                cache.contains("immutable"),
-                "_astro/* files must be immutable-cached (content-hashed URLs), got: {cache}"
-            );
-        }
+        let file = WebAssets::get("index.html")
+            .expect("WebAssets::get(\"index.html\") must succeed: embedded assets missing means parkhub-web/dist/ wasn't built before parkhub-server compile");
+        let resp = serve_file("_astro/Welcome.DcWMTKUm.js", file);
+        let cache = resp
+            .headers()
+            .get(header::CACHE_CONTROL)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("");
+        assert!(
+            cache.contains("immutable"),
+            "_astro/* files must be immutable-cached (content-hashed URLs), got: {cache}"
+        );
     }
 
     // ── serve_file with assets path ──
 
     #[test]
     fn serve_file_deep_assets_subpath_gets_immutable_cache() {
-        if let Some(file) = WebAssets::get("index.html") {
-            // The code checks path.contains("/assets/") — for paths with nested subdirectories
-            let resp = serve_file("static/assets/images/logo.png", file);
-            let cache = resp
-                .headers()
-                .get(header::CACHE_CONTROL)
-                .and_then(|v| v.to_str().ok())
-                .unwrap_or("");
-            assert!(
-                cache.contains("immutable"),
-                "files under /assets/ in a nested path must get immutable cache"
-            );
-        }
+        let file = WebAssets::get("index.html")
+            .expect("WebAssets::get(\"index.html\") must succeed: embedded assets missing means parkhub-web/dist/ wasn't built before parkhub-server compile");
+        // The code checks path.contains("/assets/") — for paths with nested subdirectories
+        let resp = serve_file("static/assets/images/logo.png", file);
+        let cache = resp
+            .headers()
+            .get(header::CACHE_CONTROL)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("");
+        assert!(
+            cache.contains("immutable"),
+            "files under /assets/ in a nested path must get immutable cache"
+        );
     }
 
     // ── Content body ──
 
     #[tokio::test]
     async fn serve_file_returns_non_empty_body() {
-        if let Some(file) = WebAssets::get("index.html") {
-            let resp = serve_file("index.html", file);
-            let body = resp.into_body().collect().await.unwrap().to_bytes();
-            assert!(!body.is_empty(), "served file body should not be empty");
-        }
+        let file = WebAssets::get("index.html")
+            .expect("WebAssets::get(\"index.html\") must succeed: embedded assets missing means parkhub-web/dist/ wasn't built before parkhub-server compile");
+        let resp = serve_file("index.html", file);
+        let body = resp.into_body().collect().await.unwrap().to_bytes();
+        assert!(!body.is_empty(), "served file body should not be empty");
     }
 }

--- a/parkhub-server/src/static_files.rs
+++ b/parkhub-server/src/static_files.rs
@@ -2,8 +2,6 @@
 //!
 //! Embeds and serves the web frontend from the binary.
 
-use std::path::Path;
-
 use axum::{
     body::Body,
     http::{StatusCode, Uri, header},
@@ -51,23 +49,33 @@ pub async fn static_handler(uri: Uri) -> impl IntoResponse {
     (StatusCode::NOT_FOUND, "Not found").into_response()
 }
 
+/// Returns true when the URL path points to a directory that contains
+/// content-hashed asset filenames (Astro emits to `_astro/`, Vite + legacy
+/// Astro emit to `/assets/`). Files under those paths are safe to mark
+/// `immutable` because the URL itself changes on every edit.
+///
+/// Files outside those directories — `sw.js`, `manifest.json`, `favicon.*`,
+/// hand-written root scripts — keep their filename across releases, so they
+/// MUST be served `no-cache`. Otherwise a browser that fetched an old `sw.js`
+/// will keep serving it for up to a year (the previous max-age was 31536000),
+/// pinning users to whatever app version that service worker last cached.
+fn is_content_hashed_asset_path(path: &str) -> bool {
+    path.starts_with("_astro/")
+        || path.contains("/_astro/")
+        || path.starts_with("assets/")
+        || path.contains("/assets/")
+}
+
 fn serve_file(path: &str, file: rust_embed::EmbeddedFile) -> Response {
     let mime = mime_guess::from_path(path).first_or_octet_stream();
 
     let mut response = Response::builder().header(header::CONTENT_TYPE, mime.as_ref());
 
-    // Add cache headers for assets (not index.html)
-    if path != "index.html"
-        && (path.contains("/assets/")
-            || Path::new(path)
-                .extension()
-                .is_some_and(|e| e.eq_ignore_ascii_case("js"))
-            || Path::new(path)
-                .extension()
-                .is_some_and(|e| e.eq_ignore_ascii_case("css")))
-    {
+    if path != "index.html" && is_content_hashed_asset_path(path) {
         response = response.header(header::CACHE_CONTROL, "public, max-age=31536000, immutable");
     } else {
+        // Includes index.html and all non-hashed root files (sw.js,
+        // manifest.json, favicon.ico, offline.html, …). Always re-validate.
         response = response.header(header::CACHE_CONTROL, "no-cache");
     }
 
@@ -256,6 +264,84 @@ mod tests {
             assert!(
                 assets.iter().any(|a| a.contains("index.html")),
                 "assets should include index.html"
+            );
+        }
+    }
+
+    // ── serve_file no-cache for non-hashed root assets (regression: sw.js v4.15.0 trap) ──
+
+    #[test]
+    fn serve_file_sw_js_must_not_be_immutable() {
+        // sw.js is at the dist root and not content-hashed in the filename.
+        // Browsers honored the previous `public, max-age=31536000, immutable`
+        // for up to 1 year, so users who installed a v4.15.0 sw.js never saw
+        // updates to the active service worker — the v4 footer kept rendering
+        // long after the deployed binary moved to v5.0.x. sw.js MUST be served
+        // with no-cache so the browser re-fetches it on every page load.
+        if let Some(file) = WebAssets::get("index.html") {
+            let resp = serve_file("sw.js", file);
+            let cache = resp
+                .headers()
+                .get(header::CACHE_CONTROL)
+                .and_then(|v| v.to_str().ok())
+                .unwrap_or("");
+            assert_eq!(
+                cache, "no-cache",
+                "sw.js must be served with no-cache so SW updates propagate, got: {cache}"
+            );
+        }
+    }
+
+    #[test]
+    fn serve_file_manifest_json_gets_no_cache() {
+        // PWA manifest is at the dist root and not hashed; updates to icons,
+        // start_url, theme_color etc. should propagate without 1-year staleness.
+        if let Some(file) = WebAssets::get("index.html") {
+            let resp = serve_file("manifest.json", file);
+            let cache = resp
+                .headers()
+                .get(header::CACHE_CONTROL)
+                .and_then(|v| v.to_str().ok())
+                .unwrap_or("");
+            assert_eq!(
+                cache, "no-cache",
+                "manifest.json must be served with no-cache, got: {cache}"
+            );
+        }
+    }
+
+    #[test]
+    fn serve_file_root_level_js_not_in_hashed_dir_gets_no_cache() {
+        // Any *.js outside /_astro/ or /assets/ is presumed non-hashed and
+        // must use no-cache to avoid the same trap as sw.js.
+        if let Some(file) = WebAssets::get("index.html") {
+            let resp = serve_file("legacy-script.js", file);
+            let cache = resp
+                .headers()
+                .get(header::CACHE_CONTROL)
+                .and_then(|v| v.to_str().ok())
+                .unwrap_or("");
+            assert_eq!(
+                cache, "no-cache",
+                "non-hashed root .js files must use no-cache, got: {cache}"
+            );
+        }
+    }
+
+    #[test]
+    fn serve_file_astro_hashed_js_gets_immutable_cache() {
+        // Files in _astro/ have content hashes (e.g., Welcome.DcWMTKUm.js)
+        // so URL changes on every edit — immutable caching is safe.
+        if let Some(file) = WebAssets::get("index.html") {
+            let resp = serve_file("_astro/Welcome.DcWMTKUm.js", file);
+            let cache = resp
+                .headers()
+                .get(header::CACHE_CONTROL)
+                .and_then(|v| v.to_str().ok())
+                .unwrap_or("");
+            assert!(
+                cache.contains("immutable"),
+                "_astro/* files must be immutable-cached (content-hashed URLs), got: {cache}"
             );
         }
     }


### PR DESCRIPTION
## CRITICAL — service-worker upgrade trap

The `serve_file` cache logic was applying `public, max-age=31536000, immutable` to **any** `.js` or `.css` file, which trapped `/sw.js` on the immutable rule. Browsers honored that header for up to a year, so a user who once installed a v4.15.0 service worker kept seeing v4.15.0 long after the deployed binary advanced to v5.0.x — the SW cache hijacked every static asset request, the SW.js itself never got re-checked, and `/login` still rendered **\"ParkHub v4.15.0\"** today.

**Live confirmation**: Florian's screenshot of `parkhub-rust.test/login` against a v5.0.3 binary shows v4.15.0 in the footer.

## Root cause

`parkhub-server/src/static_files.rs:60-67` (before this PR):

```rust
if path != \"index.html\"
    && (path.contains(\"/assets/\")
        || ext == \"js\"
        || ext == \"css\")
{
    response.header(CACHE_CONTROL, \"public, max-age=31536000, immutable\");
}
```

The `ext == \"js\"` catch-all matched `/sw.js`, even though the SW filename is **not content-hashed** (it stays `sw.js` across releases). The browser had no signal that the file changed, so it served the locally-cached one for the full year.

## Fix

Tighten immutable-caching to paths that contain *content-hashed* filenames:

- `/_astro/*` (Astro v5 default, e.g., `Welcome.DcWMTKUm.js`)
- `/assets/*` (legacy Astro/Vite default)

Everything else, including `index.html`, `/sw.js`, `/manifest.json`, `/favicon.*`, `/offline.html`, gets `no-cache` so updates propagate on the next page load.

## TDD

4 new tests in `static_files::tests`:

- `serve_file_sw_js_must_not_be_immutable` — regression guard, the actual bug
- `serve_file_manifest_json_gets_no_cache` — defensive
- `serve_file_root_level_js_not_in_hashed_dir_gets_no_cache` — regression guard for any future non-hashed root .js
- `serve_file_astro_hashed_js_gets_immutable_cache` — positive case

Existing tests (`serve_file_js_gets_immutable_cache`, `serve_file_css_gets_immutable_cache`) still pass — their fixture paths use `assets/app.js` / `assets/style.css` which match the `assets/` branch.

## Test plan
- [x] `cargo check -p parkhub-server` clean
- [ ] Full `cargo test -p parkhub-server static_files::tests` (local OOM'd, GHA will run it)
- [ ] After merge + redeploy: hard-refresh `parkhub-rust.test/login` → footer shows v5.0.x. Users with a stale SW will re-fetch `/sw.js` on next page load, the new SW activates, `SWUpdatePrompt` fires, banner appears, click to reload.
- [ ] Lighthouse audit on `/` confirms `Cache-Control` of `/_astro/*.js` is still `immutable, max-age=31536000` (no perf regression on hashed assets)

## Refs
- parkhub-rust login footer drift incident 2026-04-30
- web.dev: [Service Worker registration](https://web.dev/articles/service-worker-lifecycle) — \"sw.js should be served with no-cache\"
- MDN: [Service Worker browser fetching](https://developer.mozilla.org/en-US/docs/Web/API/ServiceWorkerRegistration#examples)