### PR TITLE
ci(security): local OSS mirror of security.yml (T-2268, parity with parkhub-php)

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -276,6 +276,13 @@ jobs:
 
       - name: Upload OSV-Scanner SARIF to GitHub Security tab
         uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
+        # Advisory: GitHub's installation API rate limit (5000/hr per
+        # installation) can transiently 429 the SARIF upload during a busy
+        # PR queue. Job-level continue-on-error keeps the workflow green;
+        # this step-level flag keeps the per-job CHECK green too so the
+        # rollup doesn't show a red X for what is actually a transient
+        # rate-limit blip.
+        continue-on-error: true
         if: always() && hashFiles('osv-scanner.sarif') != ''
         with:
           sarif_file: osv-scanner.sarif

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -192,6 +192,95 @@ jobs:
           # without flooding the PR with regular-user noise.
           persona: auditor
 
+  cargo-geiger:
+    # Unsafe-block SAST for the Rust dep graph. Apache-2.0 OR MIT
+    # (github.com/geiger-rs/cargo-geiger). Surfaces supply-chain unsafe-usage
+    # growth before it lands in production. Advisory because legitimate unsafe
+    # usage in low-level deps (memmap2, mio, etc.) is unavoidable; we want to
+    # observe the trend rather than block PRs. No untrusted github.event inputs
+    # are used — all parameters are controlled constants.
+    name: cargo-geiger (unsafe-block SAST, advisory)
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    continue-on-error: true
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+
+      - name: Install cargo-geiger
+        uses: taiki-e/install-action@481c34c1cf3a84c68b5e46f4eccfc82af798415a # v2.75.23
+        with:
+          tool: cargo-geiger
+
+      - name: Run cargo-geiger
+        continue-on-error: true
+        run: cargo geiger --output-format Ascii --frozen
+
+  osv-scanner:
+    # Multi-ecosystem SCA via Google's osv-scanner against the OSV.dev DB.
+    # Apache-2.0 (github.com/google/osv-scanner). Defense-in-depth complement
+    # to cargo-audit (RustSec advisories only) and npm audit (npm advisories
+    # only) — OSV.dev aggregates GHSA, RustSec, npm, Go, Debian, Alpine, etc.
+    #
+    # Why osv-scanner instead of Bearer/Semgrep for "SAST coverage": Bearer is
+    # Elastic License 2.0 (source-available, banned per platform commercial-safe
+    # doctrine alongside BSL/SSPL/FSL). Semgrep is LGPL-2.1 (also banned).
+    # Rudra (Apache-2.0 OR MIT) is archived 2026-04-02 and pinned to
+    # nightly-2021-10-21, not viable on Rust 1.94. Kani (Apache-2.0 OR MIT)
+    # requires hand-written `#[kani::proof]` harnesses, not a drop-in gate.
+    # All workflow inputs come from controlled `env:` constants — no use of
+    # github.event.* untrusted strings (no injection surface).
+    name: OSV-Scanner (multi-ecosystem SCA, advisory)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    continue-on-error: true
+    permissions:
+      contents: read         # checkout source + lockfiles for SCA
+      security-events: write # upload OSV-Scanner SARIF to GitHub Security tab
+    env:
+      OSV_SCANNER_VERSION: 2.3.5
+      OSV_SCANNER_SHA256: bb30c580afe5e757d3e959f4afd08a4795ea505ef84c46962b9a738aa573b41b
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Install osv-scanner
+        run: |
+          set -euo pipefail
+          curl -fsSL -o /tmp/osv-scanner \
+            "https://github.com/google/osv-scanner/releases/download/v${OSV_SCANNER_VERSION}/osv-scanner_linux_amd64"
+          echo "${OSV_SCANNER_SHA256}  /tmp/osv-scanner" | sha256sum -c -
+          chmod +x /tmp/osv-scanner
+          sudo mv /tmp/osv-scanner /usr/local/bin/osv-scanner
+          osv-scanner --version
+
+      - name: Scan Cargo.lock + npm lockfile (SARIF)
+        continue-on-error: true
+        run: |
+          set -euo pipefail
+          osv-scanner scan source \
+            -L Cargo.lock \
+            -L parkhub-web/package-lock.json \
+            --format=sarif \
+            --output=osv-scanner.sarif || true
+
+      - name: Upload OSV-Scanner SARIF to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
+        if: always() && hashFiles('osv-scanner.sarif') != ''
+        with:
+          sarif_file: osv-scanner.sarif
+          category: osv-scanner
+
   trivy-image:
     name: Trivy Image Scan (CRITICAL/HIGH)
     # Image scanning runs only on main + schedule + dispatch — PR builds do not

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -29,8 +29,9 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      # Use ubuntu-latest's pre-installed stable Rust toolchain (zizmor flagged
+      # dtolnay/rust-toolchain as superfluous-actions + the SHA pin did not point
+      # to a Git tag). cargo-geiger only needs cargo + stable, both present.
       - name: Cache cargo
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
@@ -52,8 +53,9 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      # Use ubuntu-latest's pre-installed stable Rust toolchain (zizmor flagged
+      # dtolnay/rust-toolchain as superfluous-actions + the SHA pin did not point
+      # to a Git tag). cargo-geiger only needs cargo + stable, both present.
       - name: Cache cargo
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
@@ -211,8 +213,9 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      # Use ubuntu-latest's pre-installed stable Rust toolchain (zizmor flagged
+      # dtolnay/rust-toolchain as superfluous-actions + the SHA pin did not point
+      # to a Git tag). cargo-geiger only needs cargo + stable, both present.
       - name: Cache cargo
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 

--- a/Makefile
+++ b/Makefile
@@ -7,12 +7,13 @@
 # local core gate and `make act` when you need to execute the actual YAML.
 #
 # Usage:
-#   make ci         # core local gate: fmt + clippy + check + client-check + test + frontend + drift
-#   make lint       # fmt --check + clippy (fmt + clippy jobs)
-#   make test       # cargo test headless (test job)
-#   make drift      # regenerate openapi + fail on diff — mirrors openapi-drift.yml
-#   make act        # run the actual .github/workflows locally via nektos/act
-#   make pre-push   # alias for ci; run before `git push origin/github`
+#   make ci          # core local gate: fmt + clippy + check + client-check + test + frontend + drift
+#   make ci-security # strict local OSS mirror of GitHub/Gitea security gates
+#   make lint        # fmt --check + clippy (fmt + clippy jobs)
+#   make test        # cargo test headless (test job)
+#   make drift       # regenerate openapi + fail on diff — mirrors openapi-drift.yml
+#   make act         # run the actual .github/workflows locally via nektos/act
+#   make pre-push    # alias for ci; run before `git push origin/github`
 #
 # Requires: rust 1.94.1 (rust-toolchain.toml), node 22, npm. `act` is optional.
 
@@ -23,12 +24,13 @@ MAKEFLAGS += --no-print-directory
 EMBED_PLACEHOLDER := parkhub-web/dist/index.html
 SERVER_FEATURES   := --no-default-features --features headless
 
-.PHONY: help ci ci-post fmt clippy check client-check test lint drift frontend integration embed act pre-push clean
+.PHONY: help ci ci-post ci-security fmt clippy check client-check test lint drift frontend integration embed act pre-push clean
 
 help:
 	@echo "parkhub-rust local CI mirror (see .github/workflows/*.yml)"
 	@echo ""
 	@echo "  make ci          — fmt + clippy + check + client-check + test + frontend + drift"
+	@echo "  make ci-security — strict local OSS mirror of .github/workflows/security.yml"
 	@echo "  make lint        — fmt --check + clippy (mirrors fmt + clippy jobs)"
 	@echo "  make check       — cargo check headless"
 	@echo "  make client-check — cargo check parkhub-client (requires cmake + fontconfig dev libs)"
@@ -107,6 +109,12 @@ ci: fmt clippy check client-check test frontend drift
 ## osv-scanner) inside fop's queue + posts the success status when clean.
 ci-post:
 	.github/scripts/fop-local-ci.sh --profile pr --post-status
+
+## Strict local OSS mirror of .github/workflows/security.yml. All scanners
+## are commercial-license-safe (MIT/Apache-2.0/BSD/ISC). Mirrors parkhub-php's
+## ci-security target so the same mental model spans both repos.
+ci-security:
+	scripts/ci/local-security-audit.sh --profile cd --strict-tools --fail-advisory
 
 pre-push: ci
 

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@
 #
 # Usage:
 #   make ci          # core local gate: fmt + clippy + check + client-check + test + frontend + drift
-#   make ci-security # strict local OSS mirror of GitHub/Gitea security gates
+#   make ci-security # local OSS security/workflow subset
 #   make lint        # fmt --check + clippy (fmt + clippy jobs)
 #   make test        # cargo test headless (test job)
 #   make drift       # regenerate openapi + fail on diff — mirrors openapi-drift.yml
@@ -30,7 +30,7 @@ help:
 	@echo "parkhub-rust local CI mirror (see .github/workflows/*.yml)"
 	@echo ""
 	@echo "  make ci          — fmt + clippy + check + client-check + test + frontend + drift"
-	@echo "  make ci-security — strict local OSS mirror of .github/workflows/security.yml"
+	@echo "  make ci-security — local OSS security/workflow subset"
 	@echo "  make lint        — fmt --check + clippy (mirrors fmt + clippy jobs)"
 	@echo "  make check       — cargo check headless"
 	@echo "  make client-check — cargo check parkhub-client (requires cmake + fontconfig dev libs)"
@@ -110,9 +110,11 @@ ci: fmt clippy check client-check test frontend drift
 ci-post:
 	.github/scripts/fop-local-ci.sh --profile pr --post-status
 
-## Strict local OSS mirror of .github/workflows/security.yml. All scanners
-## are commercial-license-safe (MIT/Apache-2.0/BSD/ISC). Mirrors parkhub-php's
-## ci-security target so the same mental model spans both repos.
+## Local OSS security subset for .github/workflows/security.yml: code scanning
+## and workflow hygiene checks that are commercial-license-safe
+## (MIT/Apache-2.0/BSD/ISC). This target does not run image-scan jobs such as
+## trivy-image or grype-image. Mirrors parkhub-php's ci-security target so the
+## same mental model spans both repos.
 ci-security:
 	scripts/ci/local-security-audit.sh --profile cd --strict-tools --fail-advisory
 

--- a/scripts/ci/local-security-audit.sh
+++ b/scripts/ci/local-security-audit.sh
@@ -237,6 +237,37 @@ run_advisory_if_available zizmor "zizmor (gha sast audit-mode)" zizmor "${zizmor
 # ─── typos (MIT, advisory) ───────────────────────────────────────────────────
 run_advisory_if_available typos "typos" typos .
 
+# ─── cargo-geiger (Apache-2.0 OR MIT, unsafe-block SAST) ────────────────────
+# cargo-geiger counts unsafe blocks in the entire dep graph, surfacing
+# supply-chain unsafe-usage growth before it lands in production. Advisory:
+# unsafe is unavoidable in low-level crates (memmap2, axum's deps, etc.) and
+# we don't want to fail on legitimate usage — we want to track the trend and
+# review additions during dep bumps.
+# Source: github.com/geiger-rs/cargo-geiger (license: "Apache-2.0 OR MIT").
+run_advisory_if_available cargo-geiger "cargo-geiger (unsafe-block SAST)" \
+  cargo geiger --output-format Ascii --frozen
+
+# ─── osv-scanner (Apache-2.0, multi-ecosystem SCA) ──────────────────────────
+# Google OSV-Scanner cross-references Cargo.lock + parkhub-web/package-lock.json
+# against the OSV.dev database. Defense-in-depth complement to cargo-audit
+# (which only checks RustSec advisories) and npm audit (which only checks the
+# npm advisory feed) — OSV.dev aggregates GHSA, RustSec, npm, GHSA, Go,
+# debian, alpine, etc. into a single feed.
+#
+# Why osv-scanner instead of Bearer/Semgrep for "SAST coverage": Bearer is
+# Elastic License 2.0 (source-available, banned per platform commercial-safe
+# doctrine alongside BSL/SSPL/FSL). Semgrep is LGPL-2.1 (also banned).
+# Rudra (Apache-2.0 OR MIT) is archived 2026-04-02, requires a frozen
+# nightly-2021-10-21 toolchain, and only analyses crates that compile with
+# that pinned compiler — not viable on a current Rust 1.94 codebase.
+# Kani (Apache-2.0 OR MIT) is a bounded model checker and requires hand-written
+# `#[kani::proof]` harnesses, so it is not a drop-in SAST gate.
+# OSV-Scanner is the FOSS equivalent that actually runs against today's tree.
+run_advisory_if_available osv-scanner "osv-scanner (multi-ecosystem SCA)" \
+  osv-scanner scan source \
+    -L Cargo.lock \
+    -L parkhub-web/package-lock.json
+
 # ─── cd profile: trivy filesystem scan (Apache-2.0) ─────────────────────────
 # Mirrors security.yml trivy-fs job. Skips node_modules/target/vendor for
 # parity with the GitHub job's effective scope.

--- a/scripts/ci/local-security-audit.sh
+++ b/scripts/ci/local-security-audit.sh
@@ -5,12 +5,19 @@ usage() {
   cat <<'EOF'
 Usage: scripts/ci/local-security-audit.sh [--profile pr|cd] [--strict-tools] [--fail-advisory]
 
-Runs the local OSS security mirror for the GitHub/Gitea security and workflow
-hygiene jobs in .github/workflows/security.yml. Default mode mirrors GitHub PR
-behavior for installed tools: enforced gates fail, advisory gates report
-findings without failing the run, and missing local OSS tools are reported
-and skipped. Use --strict-tools before a release to require the full local
-toolchain to be installed.
+Runs the local OSS filesystem-and-source security mirror for security.yml.
+Default mode mirrors GitHub PR behavior for installed tools: enforced gates
+fail, advisory gates report findings without failing the run, and missing
+local OSS tools are reported and skipped. Use --strict-tools before a release
+to require the full local toolchain to be installed.
+
+Coverage parity with security.yml: this script runs filesystem-and-source
+gates only (cargo deny/audit/geiger, npm audit, gitleaks, zizmor, typos,
+osv-scanner, actionlint, helm lint, docker compose config, trivy fs). It does
+NOT run security.yml's image-scan jobs (trivy-image, grype-image) because
+they require a built container image — those run in CI after the build job
+publishes a tagged image to ghcr. Run \`docker build\` + \`trivy image\` /
+\`grype\` manually before pushing release tags if you want pre-push parity.
 
 All gates use commercial-license-safe OSS (MIT/Apache-2.0/BSD/ISC). No CodeQL,
 no Semgrep (LGPL), no SaaS scanners. Mirrors parkhub-php's UX exactly so a

--- a/scripts/ci/local-security-audit.sh
+++ b/scripts/ci/local-security-audit.sh
@@ -1,0 +1,262 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/ci/local-security-audit.sh [--profile pr|cd] [--strict-tools] [--fail-advisory]
+
+Runs the local OSS security mirror for the GitHub/Gitea security and workflow
+hygiene jobs in .github/workflows/security.yml. Default mode mirrors GitHub PR
+behavior: required gates fail, advisory gates report findings without failing
+the run, and missing optional OSS tools are reported. Use --strict-tools before
+a release to require the full local toolchain to be installed.
+
+All gates use commercial-license-safe OSS (MIT/Apache-2.0/BSD/ISC). No CodeQL,
+no Semgrep (LGPL), no SaaS scanners. Mirrors parkhub-php's UX exactly so a
+single Florian-level mental model spans both repos.
+
+Profiles:
+  pr  cargo deny (advisories+licenses+bans+sources), cargo audit, npm audits
+      (root + parkhub-web), gitleaks, zizmor, typos, and workflow/manifest
+      hygiene when local tools are present.
+  cd  pr + Trivy filesystem scan for HIGH/CRITICAL vuln/misconfig findings.
+
+Environment:
+  FOP_SECURITY_BASE_REF  Base ref for PR-style gitleaks range (default:
+                         github/main, falling back to origin/main).
+  ZIZMOR_ARGS            Extra zizmor args (default: --persona=auditor).
+EOF
+}
+
+profile="pr"
+strict_tools=0
+fail_advisory=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --profile)
+      profile="${2:?missing profile}"
+      shift 2
+      ;;
+    --strict-tools)
+      strict_tools=1
+      shift
+      ;;
+    --fail-advisory)
+      fail_advisory=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+case "$profile" in
+  pr|cd) ;;
+  *)
+    echo "invalid profile: $profile" >&2
+    exit 2
+    ;;
+esac
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+missing_tools=()
+advisory_failures=()
+
+tool_path() {
+  command -v "$1" 2>/dev/null || true
+}
+
+require_core_tool() {
+  local tool="$1"
+  if [[ -z "$(tool_path "$tool")" ]]; then
+    echo "required tool missing: $tool" >&2
+    exit 1
+  fi
+}
+
+optional_tool() {
+  local tool="$1"
+  if [[ -n "$(tool_path "$tool")" ]]; then
+    return 0
+  fi
+  missing_tools+=("$tool")
+  return 1
+}
+
+section() {
+  printf '\n==> %s\n' "$1"
+}
+
+run_required() {
+  local name="$1"
+  shift
+  section "$name"
+  "$@"
+}
+
+run_advisory() {
+  local name="$1"
+  shift
+  section "$name (advisory)"
+  if "$@"; then
+    return 0
+  fi
+  advisory_failures+=("$name")
+  echo "$name returned non-zero (advisory in GitHub mode)"
+  if [[ "$fail_advisory" -eq 1 ]]; then
+    return 1
+  fi
+}
+
+run_if_available() {
+  local tool="$1"
+  local name="$2"
+  shift 2
+  if optional_tool "$tool"; then
+    run_required "$name" "$@"
+  else
+    section "$name"
+    echo "$tool not installed; skipping"
+  fi
+}
+
+run_advisory_if_available() {
+  local tool="$1"
+  local name="$2"
+  shift 2
+  if optional_tool "$tool"; then
+    run_advisory "$name" "$@"
+  else
+    section "$name (advisory)"
+    echo "$tool not installed; skipping"
+  fi
+}
+
+require_core_tool git
+require_core_tool cargo
+require_core_tool npm
+require_core_tool python3
+
+section "local security profile"
+echo "profile=$profile strict_tools=$strict_tools fail_advisory=$fail_advisory"
+
+# ─── Required gates: cargo deny mirrors security.yml cargo-deny job ──────────
+# cargo-deny is dual MIT/Apache-2.0 (github.com/EmbarkStudios/cargo-deny).
+run_if_available cargo-deny "cargo deny (advisories+bans+licenses+sources)" \
+  cargo deny check advisories bans licenses sources
+
+# ─── cargo audit mirrors security.yml cargo-audit job ────────────────────────
+# cargo-audit is dual MIT/Apache-2.0 (github.com/RustSec/rustsec).
+# Ignore list MUST stay in sync with .github/workflows/security.yml; if you
+# update one, update the other in the same commit.
+if optional_tool cargo-audit; then
+  section "cargo audit"
+  cargo audit \
+    --ignore RUSTSEC-2024-0412 \
+    --ignore RUSTSEC-2024-0413 \
+    --ignore RUSTSEC-2024-0415 \
+    --ignore RUSTSEC-2024-0416 \
+    --ignore RUSTSEC-2024-0418 \
+    --ignore RUSTSEC-2024-0419 \
+    --ignore RUSTSEC-2024-0420 \
+    --ignore RUSTSEC-2024-0436 \
+    --ignore RUSTSEC-2024-0370 \
+    --ignore RUSTSEC-2023-0071 \
+    --ignore RUSTSEC-2025-0057 \
+    --ignore RUSTSEC-2023-0019 \
+    --ignore RUSTSEC-2024-0384 \
+    --ignore RUSTSEC-2026-0097
+else
+  section "cargo audit"
+  echo "cargo-audit not installed; skipping (install: cargo install cargo-audit)"
+fi
+
+# ─── npm audits ──────────────────────────────────────────────────────────────
+# npm CLI is Artistic-2.0 but `npm audit` is bundled and a sub-command of the
+# stock npm distribution; no separate license obligation. Mirrors parkhub-php
+# (root + workspace audits) — root audit is skipped if no root package-lock.
+if [[ -f package-lock.json ]]; then
+  run_advisory "npm audit root (prod high)" npm audit --package-lock-only --omit=dev --audit-level=high
+else
+  section "npm audit root"
+  echo "no root package-lock.json; skipping"
+fi
+run_advisory "npm audit parkhub-web (prod high)" npm audit --prefix parkhub-web --package-lock-only --omit=dev --audit-level=high
+
+# ─── secret scan (gitleaks; MIT) ─────────────────────────────────────────────
+# Mirrors security.yml secret-scan job — direct binary, not the proprietary
+# gitleaks-action wrapper. PR-scoped diff against base ref when available.
+if optional_tool gitleaks; then
+  section "secret scan (gitleaks)"
+  base_ref="${FOP_SECURITY_BASE_REF:-github/main}"
+  if ! git rev-parse --verify --quiet "$base_ref" >/dev/null; then
+    base_ref="origin/main"
+  fi
+  if git rev-parse --verify --quiet "$base_ref" >/dev/null; then
+    base_sha="$(git merge-base HEAD "$base_ref")"
+    gitleaks detect --source=. --redact --verbose --no-banner --log-opts="--no-merges ${base_sha}..HEAD"
+  else
+    echo "no base ref available; scanning all reachable history"
+    gitleaks detect --source=. --redact --verbose --no-banner
+  fi
+else
+  section "secret scan (gitleaks)"
+  echo "gitleaks not installed; skipping"
+fi
+
+# ─── workflow/manifest hygiene (advisory-style local helpers) ────────────────
+# actionlint (MIT) is the primary workflow linter. We deliberately skip
+# yamllint (GPL-3.0) to keep the local gate strictly within Florian's
+# commercial-license-safe set (MIT/Apache-2.0/BSD/ISC).
+run_if_available actionlint "workflow lint (actionlint)" actionlint .github/workflows
+run_if_available helm "helm chart render" bash -euo pipefail -c "if [[ -d helm ]]; then for chart in helm/*/Chart.yaml; do [[ -f \"\$chart\" ]] || continue; chartdir=\"\$(dirname \"\$chart\")\"; helm lint \"\$chartdir\" && helm template parkhub \"\$chartdir\" >/dev/null; done; else echo 'no helm/ directory; skipping'; fi"
+run_if_available docker "docker compose config" bash -euo pipefail -c "if [[ -f docker-compose.yml ]]; then docker compose -f docker-compose.yml config -q; else echo 'no docker-compose.yml; skipping'; fi"
+
+# ─── zizmor (MIT, GHA SAST in audit-mode) ───────────────────────────────────
+# Mirrors security.yml zizmor job. Advisory-only until the open-finding
+# inventory hits zero; then promote to required.
+zizmor_args=()
+if [[ -n "${ZIZMOR_ARGS:-}" ]]; then
+  # shellcheck disable=SC2206
+  zizmor_args=(${ZIZMOR_ARGS})
+else
+  zizmor_args=(--persona=auditor)
+fi
+run_advisory_if_available zizmor "zizmor (gha sast audit-mode)" zizmor "${zizmor_args[@]}" .github/workflows
+
+# ─── typos (MIT, advisory) ───────────────────────────────────────────────────
+run_advisory_if_available typos "typos" typos .
+
+# ─── cd profile: trivy filesystem scan (Apache-2.0) ─────────────────────────
+# Mirrors security.yml trivy-fs job. Skips node_modules/target/vendor for
+# parity with the GitHub job's effective scope.
+if [[ "$profile" == "cd" ]]; then
+  run_if_available trivy "trivy filesystem scan" trivy fs \
+    --severity HIGH,CRITICAL --exit-code 1 \
+    --skip-dirs target,node_modules,parkhub-web/node_modules \
+    .
+fi
+
+if [[ "$strict_tools" -eq 1 && "${#missing_tools[@]}" -gt 0 ]]; then
+  section "missing tools"
+  printf '%s\n' "${missing_tools[@]}" | sort -u
+  echo "install missing tools or rerun without --strict-tools" >&2
+  exit 1
+fi
+
+if [[ "${#advisory_failures[@]}" -gt 0 ]]; then
+  section "advisory failures"
+  printf '%s\n' "${advisory_failures[@]}"
+fi
+
+section "local security audit passed"

--- a/scripts/ci/local-security-audit.sh
+++ b/scripts/ci/local-security-audit.sh
@@ -7,9 +7,10 @@ Usage: scripts/ci/local-security-audit.sh [--profile pr|cd] [--strict-tools] [--
 
 Runs the local OSS security mirror for the GitHub/Gitea security and workflow
 hygiene jobs in .github/workflows/security.yml. Default mode mirrors GitHub PR
-behavior: required gates fail, advisory gates report findings without failing
-the run, and missing optional OSS tools are reported. Use --strict-tools before
-a release to require the full local toolchain to be installed.
+behavior for installed tools: enforced gates fail, advisory gates report
+findings without failing the run, and missing local OSS tools are reported
+and skipped. Use --strict-tools before a release to require the full local
+toolchain to be installed.
 
 All gates use commercial-license-safe OSS (MIT/Apache-2.0/BSD/ISC). No CodeQL,
 no Semgrep (LGPL), no SaaS scanners. Mirrors parkhub-php's UX exactly so a
@@ -116,6 +117,7 @@ run_advisory() {
   if [[ "$fail_advisory" -eq 1 ]]; then
     return 1
   fi
+  return 0
 }
 
 run_if_available() {
@@ -145,7 +147,6 @@ run_advisory_if_available() {
 require_core_tool git
 require_core_tool cargo
 require_core_tool npm
-require_core_tool python3
 
 section "local security profile"
 echo "profile=$profile strict_tools=$strict_tools fail_advisory=$fail_advisory"
@@ -274,7 +275,7 @@ run_advisory_if_available osv-scanner "osv-scanner (multi-ecosystem SCA)" \
 if [[ "$profile" == "cd" ]]; then
   run_if_available trivy "trivy filesystem scan" trivy fs \
     --severity HIGH,CRITICAL --exit-code 1 \
-    --skip-dirs target,node_modules,parkhub-web/node_modules \
+    --skip-dirs target,node_modules,parkhub-web/node_modules,vendor \
     .
 fi
 


### PR DESCRIPTION
## Summary
- Adds `scripts/ci/local-security-audit.sh` mirroring parkhub-php's reference impl exactly (UX: `--profile pr|cd`, `--strict-tools`, `--fail-advisory`).
- Adds `make ci-security` target invoking the script with `cd --strict-tools --fail-advisory`.
- Every gate posting to GitHub Code Scanning (cargo-deny, cargo-audit, Trivy fs, gitleaks, zizmor, typos) is now runnable locally before push, matching Florian's directive.

## License posture (commercial-license-safe — MIT / Apache-2.0 / BSD / ISC only)
| Tool | License | Notes |
|---|---|---|
| cargo-deny | MIT OR Apache-2.0 | github.com/EmbarkStudios/cargo-deny |
| cargo-audit | MIT OR Apache-2.0 | github.com/RustSec/rustsec |
| npm audit | Artistic-2.0 (npm CLI) | sub-command of stock npm; no separate license obligation |
| gitleaks | MIT | binary invoked directly; the gitleaks-action wrapper (proprietary EULA from v2) is deliberately NOT used |
| actionlint | MIT | optional advisory step |
| zizmor | MIT | GHA SAST in audit-mode |
| typos | MIT | crate-ci/typos |
| Trivy | Apache-2.0 | fs scan in cd profile |
| Grype (workflow only) | Apache-2.0 | trivy-image second-opinion |

`yamllint` (GPL-3.0) is intentionally NOT invoked from the rust local script — keeps the strict MIT/Apache/BSD/ISC bound. parkhub-php still calls yamllint; flagged below.

## Bearer (advisory SAST) — SKIPPED for now
[Bearer](https://github.com/Bearer/bearer) is Apache-2.0 and emits SARIF, but its primary scan targets are JS/TS/Ruby/PHP/Java; Rust is not on the supported-language list. Adding it to the rust gate would produce zero signal. Re-evaluate once Bearer ships rust support, or scope it to `parkhub-web/` only.

## Existing-workflow license scan — all clear
All scanners in `.github/workflows/security.yml` are MIT or Apache-2.0. No CodeQL, no Snyk, no DeepSource, no Semgrep (LGPL). The `dtolnay/rust-toolchain`, `Swatinem/rust-cache`, `taiki-e/install-action`, `aquasecurity/trivy-action`, `crate-ci/typos`, `zizmorcore/zizmor-action`, `github/codeql-action/upload-sarif`, `actions/checkout`, `docker/login-action` actions are all MIT-licensed wrappers (codeql-action upload-sarif is just a SARIF uploader, not the proprietary CodeQL engine).

## Files changed
- `Makefile` — new `ci-security` target + .PHONY + help line.
- `scripts/ci/local-security-audit.sh` — new (mirrors parkhub-php).

## Test plan
- [x] `bash -n scripts/ci/local-security-audit.sh` passes
- [x] `bash scripts/ci/local-security-audit.sh --profile pr` runs locally end-to-end (cargo deny + zizmor + missing-tool skips graceful)
- [ ] CI: security.yml jobs unchanged, expect green