### PR TITLE
chore(ci): drop COSIGN_EXPERIMENTAL=true (no-op since cosign 3.x)

### DIFF
--- a/.github/workflows/cosign-verify.yml
+++ b/.github/workflows/cosign-verify.yml
@@ -82,7 +82,6 @@ jobs:
       - name: Verify cosign signature (keyless)
         if: steps.digest.outputs.skip != 'true'
         env:
-          COSIGN_EXPERIMENTAL: 'true'
           IMAGE: ${{ env.IMAGE_REF }}
           DIGEST: ${{ steps.digest.outputs.digest }}
           IDENTITY_REGEX: ${{ env.EXPECTED_IDENTITY_REGEX }}
@@ -106,7 +105,6 @@ jobs:
         if: steps.digest.outputs.skip != 'true'
         continue-on-error: true
         env:
-          COSIGN_EXPERIMENTAL: 'true'
           IMAGE: ${{ env.IMAGE_REF }}
           DIGEST: ${{ steps.digest.outputs.digest }}
           IDENTITY_REGEX: ${{ env.EXPECTED_IDENTITY_REGEX }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -199,7 +199,6 @@ jobs:
 
       - name: Sign amd64 image (keyless OIDC)
         env:
-          COSIGN_EXPERIMENTAL: 'true'
           IMAGE_DIGEST: ${{ steps.push.outputs.digest }}
           IMAGE_REF: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
         run: |
@@ -231,7 +230,6 @@ jobs:
         id: attest_sbom
         continue-on-error: true
         env:
-          COSIGN_EXPERIMENTAL: 'true'
           IMAGE_DIGEST: ${{ steps.push.outputs.digest }}
           IMAGE_REF: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
         run: |
@@ -337,7 +335,6 @@ jobs:
 
       - name: Sign arm64 image (keyless OIDC)
         env:
-          COSIGN_EXPERIMENTAL: 'true'
           IMAGE_DIGEST: ${{ steps.push.outputs.digest }}
           IMAGE_REF: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
         run: |
@@ -361,7 +358,6 @@ jobs:
         id: attest_sbom
         continue-on-error: true
         env:
-          COSIGN_EXPERIMENTAL: 'true'
           IMAGE_DIGEST: ${{ steps.push.outputs.digest }}
           IMAGE_REF: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
         run: |
@@ -482,7 +478,6 @@ jobs:
 
       - name: Sign manifest list (keyless OIDC)
         env:
-          COSIGN_EXPERIMENTAL: 'true'
           IMAGE_DIGEST: ${{ steps.manifest.outputs.digest }}
           IMAGE_REF: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
         run: |

--- a/.github/workflows/release-rehearsal.yml
+++ b/.github/workflows/release-rehearsal.yml
@@ -208,8 +208,6 @@ jobs:
       - name: Install syft
         uses: anchore/sbom-action/download-syft@d8a2c0130026bf585de5c176ab8f7ce62d75bf04 # v0.20.7
       - name: Sign release archives (cosign keyless)
-        env:
-          COSIGN_EXPERIMENTAL: '1'
         run: |
           set -euo pipefail
           for f in parkhub-linux-x64.tar.gz parkhub-linux-arm64.tar.gz checksums.txt; do

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -738,8 +738,6 @@ jobs:
         # open an empty path and exits 1 ("create bundle file: open :
         # no such file or directory"). Pin --bundle explicitly so the
         # new-bundle-format file is named alongside .sig/.pem.
-        env:
-          COSIGN_EXPERIMENTAL: '1'
         run: |
           set -euo pipefail
           for f in parkhub-linux-x64.tar.gz parkhub-linux-arm64.tar.gz parkhub-macos-universal.tar.gz parkhub-windows-x64.zip checksums.txt; do


### PR DESCRIPTION
## Summary

`COSIGN_EXPERIMENTAL` was required for cosign 1.x to enable Sigstore keyless signing. Cosign 2.0 made keyless the default; 3.0 hardened it further. The variable has been a no-op for ~3 years.

This PR removes 9 occurrences across 4 workflows:
- `docker-publish.yml` (5×) — env: blocks remain valid (`IMAGE_DIGEST`, `IMAGE_REF` still present)
- `cosign-verify.yml` (2×) — same; `IMAGE`, etc. still present
- `release.yml` (1×) — solo env var; entire env: block dropped
- `release-rehearsal.yml` (1×) — solo env var; entire env: block dropped

## Why

From the SOTA-2026 gap analysis (`.fop/reports/sota-2026-gap-analysis-2026-04-29.md` priority MED-3): 7 cosign steps in this repo carried the legacy variable; same flag count flagged in parkhub-php (separate companion PR).

Drops visual noise + prevents future operators from cargo-culting it into new workflows under the false belief that it's still required for keyless OIDC.

## Test plan

- [x] `python3 yaml.safe_load` validates all 4 modified files
- [ ] Next push to a PR re-runs `cosign-verify` workflow without the flag
- [ ] Next tag release re-runs `release.yml` cosign sign-blob without the flag

## Refs

- T-2268 platform CI/CD standardization
- Companion PR for parkhub-php (chore/drop-cosign-experimental-noop) drops 2 occurrences in docker-publish.yml
- [Sigstore docs: keyless signing default since cosign 2.0](https://docs.sigstore.dev/cosign/signing/overview/)