### PR TITLE
ci(security): cargo-geiger + OSV-Scanner SAST/SCA suite (T-2268, stacked on #470)

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -192,6 +192,95 @@ jobs:
           # without flooding the PR with regular-user noise.
           persona: auditor
 
+  cargo-geiger:
+    # Unsafe-block SAST for the Rust dep graph. Apache-2.0 OR MIT
+    # (github.com/geiger-rs/cargo-geiger). Surfaces supply-chain unsafe-usage
+    # growth before it lands in production. Advisory because legitimate unsafe
+    # usage in low-level deps (memmap2, mio, etc.) is unavoidable; we want to
+    # observe the trend rather than block PRs. No untrusted github.event inputs
+    # are used — all parameters are controlled constants.
+    name: cargo-geiger (unsafe-block SAST, advisory)
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    continue-on-error: true
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+
+      - name: Install cargo-geiger
+        uses: taiki-e/install-action@481c34c1cf3a84c68b5e46f4eccfc82af798415a # v2.75.23
+        with:
+          tool: cargo-geiger
+
+      - name: Run cargo-geiger
+        continue-on-error: true
+        run: cargo geiger --output-format Ascii --frozen
+
+  osv-scanner:
+    # Multi-ecosystem SCA via Google's osv-scanner against the OSV.dev DB.
+    # Apache-2.0 (github.com/google/osv-scanner). Defense-in-depth complement
+    # to cargo-audit (RustSec advisories only) and npm audit (npm advisories
+    # only) — OSV.dev aggregates GHSA, RustSec, npm, Go, Debian, Alpine, etc.
+    #
+    # Why osv-scanner instead of Bearer/Semgrep for "SAST coverage": Bearer is
+    # Elastic License 2.0 (source-available, banned per platform commercial-safe
+    # doctrine alongside BSL/SSPL/FSL). Semgrep is LGPL-2.1 (also banned).
+    # Rudra (Apache-2.0 OR MIT) is archived 2026-04-02 and pinned to
+    # nightly-2021-10-21, not viable on Rust 1.94. Kani (Apache-2.0 OR MIT)
+    # requires hand-written `#[kani::proof]` harnesses, not a drop-in gate.
+    # All workflow inputs come from controlled `env:` constants — no use of
+    # github.event.* untrusted strings (no injection surface).
+    name: OSV-Scanner (multi-ecosystem SCA, advisory)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    continue-on-error: true
+    permissions:
+      contents: read         # checkout source + lockfiles for SCA
+      security-events: write # upload OSV-Scanner SARIF to GitHub Security tab
+    env:
+      OSV_SCANNER_VERSION: 2.3.5
+      OSV_SCANNER_SHA256: bb30c580afe5e757d3e959f4afd08a4795ea505ef84c46962b9a738aa573b41b
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Install osv-scanner
+        run: |
+          set -euo pipefail
+          curl -fsSL -o /tmp/osv-scanner \
+            "https://github.com/google/osv-scanner/releases/download/v${OSV_SCANNER_VERSION}/osv-scanner_linux_amd64"
+          echo "${OSV_SCANNER_SHA256}  /tmp/osv-scanner" | sha256sum -c -
+          chmod +x /tmp/osv-scanner
+          sudo mv /tmp/osv-scanner /usr/local/bin/osv-scanner
+          osv-scanner --version
+
+      - name: Scan Cargo.lock + npm lockfile (SARIF)
+        continue-on-error: true
+        run: |
+          set -euo pipefail
+          osv-scanner scan source \
+            -L Cargo.lock \
+            -L parkhub-web/package-lock.json \
+            --format=sarif \
+            --output=osv-scanner.sarif || true
+
+      - name: Upload OSV-Scanner SARIF to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
+        if: always() && hashFiles('osv-scanner.sarif') != ''
+        with:
+          sarif_file: osv-scanner.sarif
+          category: osv-scanner
+
   trivy-image:
     name: Trivy Image Scan (CRITICAL/HIGH)
     # Image scanning runs only on main + schedule + dispatch — PR builds do not

--- a/scripts/ci/local-security-audit.sh
+++ b/scripts/ci/local-security-audit.sh
@@ -237,6 +237,37 @@ run_advisory_if_available zizmor "zizmor (gha sast audit-mode)" zizmor "${zizmor
 # ─── typos (MIT, advisory) ───────────────────────────────────────────────────
 run_advisory_if_available typos "typos" typos .
 
+# ─── cargo-geiger (Apache-2.0 OR MIT, unsafe-block SAST) ────────────────────
+# cargo-geiger counts unsafe blocks in the entire dep graph, surfacing
+# supply-chain unsafe-usage growth before it lands in production. Advisory:
+# unsafe is unavoidable in low-level crates (memmap2, axum's deps, etc.) and
+# we don't want to fail on legitimate usage — we want to track the trend and
+# review additions during dep bumps.
+# Source: github.com/geiger-rs/cargo-geiger (license: "Apache-2.0 OR MIT").
+run_advisory_if_available cargo-geiger "cargo-geiger (unsafe-block SAST)" \
+  cargo geiger --output-format Ascii --frozen
+
+# ─── osv-scanner (Apache-2.0, multi-ecosystem SCA) ──────────────────────────
+# Google OSV-Scanner cross-references Cargo.lock + parkhub-web/package-lock.json
+# against the OSV.dev database. Defense-in-depth complement to cargo-audit
+# (which only checks RustSec advisories) and npm audit (which only checks the
+# npm advisory feed) — OSV.dev aggregates GHSA, RustSec, npm, GHSA, Go,
+# debian, alpine, etc. into a single feed.
+#
+# Why osv-scanner instead of Bearer/Semgrep for "SAST coverage": Bearer is
+# Elastic License 2.0 (source-available, banned per platform commercial-safe
+# doctrine alongside BSL/SSPL/FSL). Semgrep is LGPL-2.1 (also banned).
+# Rudra (Apache-2.0 OR MIT) is archived 2026-04-02, requires a frozen
+# nightly-2021-10-21 toolchain, and only analyses crates that compile with
+# that pinned compiler — not viable on a current Rust 1.94 codebase.
+# Kani (Apache-2.0 OR MIT) is a bounded model checker and requires hand-written
+# `#[kani::proof]` harnesses, so it is not a drop-in SAST gate.
+# OSV-Scanner is the FOSS equivalent that actually runs against today's tree.
+run_advisory_if_available osv-scanner "osv-scanner (multi-ecosystem SCA)" \
+  osv-scanner scan source \
+    -L Cargo.lock \
+    -L parkhub-web/package-lock.json
+
 # ─── cd profile: trivy filesystem scan (Apache-2.0) ─────────────────────────
 # Mirrors security.yml trivy-fs job. Skips node_modules/target/vendor for
 # parity with the GitHub job's effective scope.


### PR DESCRIPTION
## Summary

Stacks on **#470** (local OSS security mirror) to extend FOSS SAST/SCA
coverage to Rust + parkhub-web. Florian's standing rule for T-2268 is
**1:1 feature parity** with parkhub-php's security mirror, so this PR
adds the Rust-side equivalents to the originally-scoped Bearer gate.

Bearer itself is **Elastic License 2.0** (source-available, banned per
commercial-license-safe doctrine alongside BSL/SSPL/FSL). Semgrep is
LGPL-2.1 (banned). OSV-Scanner (Apache-2.0, Google) is the FOSS equivalent
plus cargo-geiger (Apache-2.0 OR MIT) for Rust-specific unsafe-block SAST.

## What it adds

- `.github/workflows/security.yml`:
  - **`cargo-geiger`** advisory job — unsafe-block SAST across the dep
    graph; skipped on PRs (slow), runs on push/schedule/dispatch.
  - **`osv-scanner`** advisory job — pinned v2.3.5 binary,
    sha256-verified install, SARIF upload to Security tab. Scans
    `Cargo.lock` + `parkhub-web/package-lock.json`. No untrusted
    `github.event.*` inputs.
- `scripts/ci/local-security-audit.sh` — matching local invocations
  (`cargo-geiger`, `osv-scanner`) so developers running the local mirror
  get the same signal as CI.

## Why these tools

- **cargo-geiger** (Apache-2.0 OR MIT, geiger-rs/cargo-geiger): tracks
  unsafe-block usage trend across the entire transitive graph.
- **osv-scanner** (Apache-2.0, google/osv-scanner): defense-in-depth SCA
  on top of cargo-audit/npm-audit; OSV.dev aggregates GHSA + RustSec +
  npm + Go + Debian + Alpine into one feed.

## Tools considered + rejected

| Tool | License | Reason |
|---|---|---|
| Bearer | **ELv2** | Banned (source-available, no Rust support) |
| Semgrep | **LGPL-2.1** | Banned |
| Rudra | Apache-2.0 OR MIT | Archived 2026-04-02, pinned to nightly-2021-10-21 — won't run on Rust 1.94 |
| Kani | Apache-2.0 OR MIT | Bounded model checker, requires hand-written `#[kani::proof]` harnesses |
| MIRAI | MIT | Same harness-style + minimal maintenance |

## License posture

All new tooling: **Apache-2.0/MIT/BSD/ISC**. No GPL/LGPL/AGPL/BSL/SSPL/FSL/ELv2.
Binary install pattern matches existing gitleaks/grype precedent.

## Suppressions

Reuses repo's existing `osv-scanner.toml`. Surfaces same single dev-only
finding as parkhub-php: `yaml@2.7.1` GHSA-48c2-rrv3-qjmp on parkhub-web.
The two repos stay in lockstep.

## Stacking note

Based on `feat/t2268-local-security-mirror` (#470). Rebase to `main`
after #470 merges, or set base to `main` once #470 is in.

## Test plan

- [x] `bash -n scripts/ci/local-security-audit.sh` — syntax OK
- [x] YAML parses OK
- [x] zizmor audit clean (only pre-existing `dtolnay/rust-toolchain` info findings)
- [x] `osv-scanner scan source -L Cargo.lock -L parkhub-web/package-lock.json` runs locally and surfaces only the suppressed dev-only finding
- [ ] CI green on push (both new jobs are advisory, `continue-on-error: true`)
- [ ] SARIF visible in GitHub Security tab after first run

Refs T-2268.