### PR TITLE
fix(web): tighten dashboard and reports parity

### DIFF
--- a/parkhub-web/src/api/client.ts
+++ b/parkhub-web/src/api/client.ts
@@ -25,6 +25,7 @@ import type { SwapRequestStatus as GeneratedSwapRequestStatus } from '../generat
 import type { AnnouncementSeverity as GeneratedAnnouncementSeverity } from '../generated/types/AnnouncementSeverity';
 import type { VehicleType as GeneratedVehicleType } from '../generated/types/VehicleType';
 import type { FuelType as GeneratedFuelType } from '../generated/types/FuelType';
+import type { BookingStatus as GeneratedBookingStatus } from '../generated/types/BookingStatus';
 import type { PaginatedResponse } from '../generated/types/PaginatedResponse';
 import type { JsonValue } from '../generated/types/serde_json/JsonValue';
 
@@ -56,6 +57,7 @@ export type SwapRequestStatus = GeneratedSwapRequestStatus;
 export type AnnouncementSeverity = GeneratedAnnouncementSeverity;
 export type VehicleType = GeneratedVehicleType;
 export type FuelType = GeneratedFuelType;
+export type BookingStatus = GeneratedBookingStatus;
 
 export interface RequestOptions extends Omit<RequestInit, 'signal'> {
   signal?: AbortSignal;
@@ -436,6 +438,10 @@ export const api = {
 
   // ── Admin ──
   adminStats: () => request<AdminStats>('/api/v1/admin/stats'),
+  adminBookings: (perPage = 500) =>
+    request<PaginatedResponse<AdminBooking>>(`/api/v1/admin/bookings?per_page=${perPage}`),
+  adminReports: (days = 7) =>
+    request<DailyBookingStat[]>(`/api/v1/admin/reports?days=${days}`),
   adminUsers: () => request<PaginatedResponse<User>>('/api/v1/admin/users'),
   adminUpdateUser: (id: string, data: UpdateUserPayload) => request<User>(`/api/v1/admin/users/${id}`, { method: 'PUT', body: JSON.stringify(data) }),
   adminDeleteUser: (id: string) => request<void>(`/api/v1/admin/users/${id}`, { method: 'DELETE' }),
@@ -1007,7 +1013,7 @@ export interface Booking {
   vehicle_plate?: string;
   start_time: string;
   end_time: string;
-  status: 'confirmed' | 'active' | 'completed' | 'cancelled';
+  status: BookingStatus;
   booking_type?: string;
   dauer_interval?: string;
   notes?: string;
@@ -1015,6 +1021,18 @@ export interface Booking {
   tax_amount?: number;
   total_price?: number;
   currency?: string;
+}
+
+export interface AdminBooking extends Booking {
+  status: BookingStatus;
+  user_name?: string;
+  user_email?: string;
+  created_at: string;
+}
+
+export interface DailyBookingStat {
+  date: string;
+  count: number;
 }
 
 export interface Vehicle {
@@ -1143,8 +1161,10 @@ export interface Co2Summary {
 export interface AdminStats {
   total_users: number;
   total_lots: number;
+  total_slots: number;
   total_bookings: number;
   active_bookings: number;
+  occupancy_percent: number;
 }
 
 /** Raw shape from the Rust API (nested objects) */

--- a/parkhub-web/src/design-v5/screens/Buchungen.tsx
+++ b/parkhub-web/src/design-v5/screens/Buchungen.tsx
@@ -29,10 +29,13 @@ function statusVariant(s: Booking['status']): BadgeVariant {
 }
 
 const STATUS_LABEL: Record<Booking['status'], string> = {
+  pending: 'Ausstehend',
   active: 'Aktiv',
   confirmed: 'Bestätigt',
   completed: 'Abgeschlossen',
   cancelled: 'Storniert',
+  expired: 'Abgelaufen',
+  no_show: 'Nicht erschienen',
 };
 
 function formatDateTime(iso: string): string {

--- a/parkhub-web/src/views/AdminReports.test.tsx
+++ b/parkhub-web/src/views/AdminReports.test.tsx
@@ -5,13 +5,13 @@ import { render, screen, waitFor } from '@testing-library/react';
 // ── Mocks ──
 
 const mockAdminStats = vi.fn();
-const mockGetBookings = vi.fn();
+const mockAdminBookings = vi.fn();
 const mockGetLots = vi.fn();
 
 vi.mock('../api/client', () => ({
   api: {
     adminStats: (...args: any[]) => mockAdminStats(...args),
-    getBookings: (...args: any[]) => mockGetBookings(...args),
+    adminBookings: (...args: any[]) => mockAdminBookings(...args),
     getLots: (...args: any[]) => mockGetLots(...args),
   },
 }));
@@ -83,9 +83,12 @@ import { AdminReportsPage } from './AdminReports';
 describe('AdminReportsPage', () => {
   beforeEach(() => {
     mockAdminStats.mockClear();
-    mockGetBookings.mockClear();
+    mockAdminBookings.mockClear();
     mockGetLots.mockClear();
-    mockGetBookings.mockResolvedValue({ success: true, data: [] });
+    mockAdminBookings.mockResolvedValue({
+      success: true,
+      data: { items: [], page: 1, per_page: 500, total: 0, total_pages: 0 },
+    });
     mockGetLots.mockResolvedValue({ success: true, data: [] });
   });
 
@@ -95,7 +98,7 @@ describe('AdminReportsPage', () => {
 
   it('shows loading spinner initially', () => {
     mockAdminStats.mockReturnValue(new Promise(() => {}));
-    mockGetBookings.mockReturnValue(new Promise(() => {}));
+    mockAdminBookings.mockReturnValue(new Promise(() => {}));
     render(<AdminReportsPage />);
     expect(screen.getByTestId('icon-spinner')).toBeInTheDocument();
   });
@@ -103,7 +106,7 @@ describe('AdminReportsPage', () => {
   it('renders Reports heading after loading', async () => {
     mockAdminStats.mockResolvedValue({
       success: true,
-      data: { total_users: 50, total_lots: 3, total_bookings: 200, active_bookings: 15 },
+      data: { total_users: 50, total_lots: 3, total_slots: 60, total_bookings: 200, active_bookings: 15, occupancy_percent: 25 },
     });
 
     render(<AdminReportsPage />);
@@ -116,7 +119,7 @@ describe('AdminReportsPage', () => {
   it('renders stat cards with correct values', async () => {
     mockAdminStats.mockResolvedValue({
       success: true,
-      data: { total_users: 50, total_lots: 3, total_bookings: 200, active_bookings: 15 },
+      data: { total_users: 50, total_lots: 3, total_slots: 60, total_bookings: 200, active_bookings: 15, occupancy_percent: 25 },
     });
 
     render(<AdminReportsPage />);
@@ -136,7 +139,7 @@ describe('AdminReportsPage', () => {
   it('renders overview summary section', async () => {
     mockAdminStats.mockResolvedValue({
       success: true,
-      data: { total_users: 50, total_lots: 3, total_bookings: 200, active_bookings: 15 },
+      data: { total_users: 50, total_lots: 3, total_slots: 60, total_bookings: 200, active_bookings: 15, occupancy_percent: 25 },
     });
 
     render(<AdminReportsPage />);
@@ -152,7 +155,30 @@ describe('AdminReportsPage', () => {
   it('renders bar chart component', async () => {
     mockAdminStats.mockResolvedValue({
       success: true,
-      data: { total_users: 10, total_lots: 2, total_bookings: 50, active_bookings: 5 },
+      data: { total_users: 10, total_lots: 2, total_slots: 40, total_bookings: 50, active_bookings: 5, occupancy_percent: 12.5 },
+    });
+    mockAdminBookings.mockResolvedValue({
+      success: true,
+      data: {
+        items: [
+          {
+            id: 'b1',
+            user_id: 'u1',
+            lot_id: 'l1',
+            slot_id: 's1',
+            lot_name: 'Lot A',
+            slot_number: 'S01',
+            start_time: '2026-04-20T08:00:00Z',
+            end_time: '2026-04-20T17:00:00Z',
+            status: 'confirmed',
+            created_at: '2026-04-01T12:00:00Z',
+          },
+        ],
+        page: 1,
+        per_page: 500,
+        total: 1,
+        total_pages: 1,
+      },
     });
 
     render(<AdminReportsPage />);
@@ -165,7 +191,7 @@ describe('AdminReportsPage', () => {
   it('renders donut chart when lots exist', async () => {
     mockAdminStats.mockResolvedValue({
       success: true,
-      data: { total_users: 10, total_lots: 3, total_bookings: 50, active_bookings: 5 },
+      data: { total_users: 10, total_lots: 3, total_slots: 65, total_bookings: 50, active_bookings: 5, occupancy_percent: 8 },
     });
     mockGetLots.mockResolvedValue({
       success: true,
@@ -186,7 +212,54 @@ describe('AdminReportsPage', () => {
   it('renders occupancy heatmap section', async () => {
     mockAdminStats.mockResolvedValue({
       success: true,
-      data: { total_users: 10, total_lots: 2, total_bookings: 50, active_bookings: 5 },
+      data: { total_users: 10, total_lots: 2, total_slots: 40, total_bookings: 50, active_bookings: 5, occupancy_percent: 12.5 },
+    });
+    mockAdminBookings.mockResolvedValue({
+      success: true,
+      data: {
+        items: [
+          {
+            id: 'b1',
+            user_id: 'u1',
+            lot_id: 'l1',
+            slot_id: 's1',
+            lot_name: 'Lot A',
+            slot_number: 'S01',
+            start_time: '2026-04-20T08:00:00Z',
+            end_time: '2026-04-20T17:00:00Z',
+            status: 'confirmed',
+            created_at: '2026-04-19T12:00:00Z',
+          },
+          {
+            id: 'b2',
+            user_id: 'u1',
+            lot_id: 'l1',
+            slot_id: 's2',
+            lot_name: 'Lot A',
+            slot_number: 'S02',
+            start_time: '2026-04-20T09:00:00Z',
+            end_time: '2026-04-20T17:00:00Z',
+            status: 'pending',
+            created_at: '2026-04-19T12:00:00Z',
+          },
+          {
+            id: 'b3',
+            user_id: 'u1',
+            lot_id: 'l1',
+            slot_id: 's3',
+            lot_name: 'Lot A',
+            slot_number: 'S03',
+            start_time: '2026-04-20T10:00:00Z',
+            end_time: '2026-04-20T17:00:00Z',
+            status: 'expired',
+            created_at: '2026-04-19T12:00:00Z',
+          },
+        ],
+        page: 1,
+        per_page: 500,
+        total: 3,
+        total_pages: 1,
+      },
     });
 
     render(<AdminReportsPage />);
@@ -194,20 +267,21 @@ describe('AdminReportsPage', () => {
     await waitFor(() => {
       expect(screen.getByTestId('occupancy-heatmap')).toBeInTheDocument();
     });
+    expect(mockAdminBookings).toHaveBeenCalledWith(500);
     expect(screen.getByText('Occupancy Heatmap')).toBeInTheDocument();
+    expect(screen.getByText('heatmap: 1 bookings, 40 slots')).toBeInTheDocument();
   });
 
-  it('calculates correct utilization rate', async () => {
+  it('uses backend occupancy percent for utilization rate', async () => {
     mockAdminStats.mockResolvedValue({
       success: true,
-      data: { total_users: 10, total_lots: 5, total_bookings: 100, active_bookings: 3 },
+      data: { total_users: 10, total_lots: 5, total_slots: 100, total_bookings: 100, active_bookings: 3, occupancy_percent: 3 },
     });
 
     render(<AdminReportsPage />);
 
     await waitFor(() => {
-      // 3 / 5 = 60%
-      expect(screen.getByText('60%')).toBeInTheDocument();
+      expect(screen.getAllByText('3%').length).toBeGreaterThanOrEqual(1);
     });
   });
 });

--- a/parkhub-web/src/views/AdminReports.tsx
+++ b/parkhub-web/src/views/AdminReports.tsx
@@ -1,11 +1,13 @@
 import { useState, useEffect, useMemo } from 'react';
 import { motion } from 'framer-motion';
 import { SpinnerGap, Users, Buildings, CalendarCheck, Lightning, type Icon } from '@phosphor-icons/react';
-import { api, type AdminStats, type Booking, type ParkingLot } from '../api/client';
+import { api, type AdminBooking, type AdminStats, type ParkingLot } from '../api/client';
 import { useTranslation } from 'react-i18next';
 import { BarChart, DonutChart, type DonutSlice } from '../components/SimpleChart';
 import { OccupancyHeatmap } from '../components/OccupancyHeatmap';
 import { ExportButton } from '../components/ExportButton';
+
+const HEATMAP_STATUSES = new Set(['confirmed', 'active', 'completed']);
 
 function StatCard({ icon: Icon, label, value }: {
   icon: Icon;
@@ -40,39 +42,50 @@ function lotOccupancyFromData(lots: ParkingLot[]): DonutSlice[] {
   });
 }
 
-/** Build mock "bookings this week" from total bookings to show a plausible distribution. */
-function weeklyBookingData(totalBookings: number, t: (key: string) => string): { label: string; value: number }[] {
+/** Build real booking totals for each weekday from booking start times. */
+function weeklyBookingData(bookings: AdminBooking[], t: (key: string) => string): { label: string; value: number }[] {
   const dayKeys = ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'];
-  // Weights simulate typical office-parking week pattern
-  const weights = [0.18, 0.20, 0.22, 0.19, 0.15, 0.04, 0.02];
+  const counts = new Map<number, number>(dayKeys.map((_, index) => [index, 0]));
+  for (const booking of bookings) {
+    if (!HEATMAP_STATUSES.has(booking.status)) continue;
+    const date = new Date(booking.start_time);
+    if (Number.isNaN(date.valueOf())) continue;
+    const mondayFirstIndex = date.getDay() === 0 ? 6 : date.getDay() - 1;
+    counts.set(mondayFirstIndex, (counts.get(mondayFirstIndex) ?? 0) + 1);
+  }
   return dayKeys.map((key, i) => ({
     label: t(`reports.weekdays.${key}`),
-    value: Math.round(totalBookings * (weights[i] ?? 0)),
+    value: counts.get(i) ?? 0,
   }));
 }
 
 export function AdminReportsPage() {
   const { t } = useTranslation();
   const [stats, setStats] = useState<AdminStats | null>(null);
-  const [bookings, setBookings] = useState<Booking[]>([]);
+  const [bookings, setBookings] = useState<AdminBooking[]>([]);
   const [lots, setLots] = useState<ParkingLot[]>([]);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     Promise.all([
       api.adminStats(),
-      api.getBookings(),
+      api.adminBookings(500),
       api.getLots(),
     ]).then(([statsRes, bookingsRes, lotsRes]) => {
       if (statsRes.success && statsRes.data) setStats(statsRes.data);
-      if (bookingsRes.success && bookingsRes.data) setBookings(bookingsRes.data);
+      if (bookingsRes.success && bookingsRes.data) setBookings(bookingsRes.data.items ?? []);
       if (lotsRes.success && lotsRes.data) setLots(lotsRes.data);
     }).finally(() => setLoading(false));
   }, []);
 
   const weeklyData = useMemo(
-    () => weeklyBookingData(stats?.total_bookings ?? 0, t),
-    [stats?.total_bookings, t],
+    () => weeklyBookingData(bookings, t),
+    [bookings, t],
+  );
+
+  const heatmapBookings = useMemo(
+    () => bookings.filter(booking => HEATMAP_STATUSES.has(booking.status)),
+    [bookings],
   );
 
   const lotOccupancy = useMemo(
@@ -81,8 +94,8 @@ export function AdminReportsPage() {
   );
 
   const totalSlots = useMemo(
-    () => lots.reduce((sum, l) => sum + l.total_slots, 0) || 20,
-    [lots],
+    () => lots.reduce((sum, l) => sum + l.total_slots, 0) || stats?.total_slots || 0,
+    [lots, stats?.total_slots],
   );
 
   if (loading) {
@@ -136,8 +149,8 @@ export function AdminReportsPage() {
           <div className="flex items-center justify-between py-3 border-b border-surface-100 dark:border-surface-800">
             <span className="text-sm text-surface-600 dark:text-surface-400">{t('admin.utilizationRate')}</span>
             <span className="text-sm font-semibold text-surface-900 dark:text-white">
-              {stats && stats.total_lots > 0
-                ? `${Math.round((stats.active_bookings / Math.max(stats.total_lots, 1)) * 100)}%`
+              {stats && Number.isFinite(stats.occupancy_percent)
+                ? `${Math.round(stats.occupancy_percent)}%`
                 : '0%'}
             </span>
           </div>
@@ -207,7 +220,7 @@ export function AdminReportsPage() {
         <p className="text-xs text-surface-500 dark:text-surface-400 mb-4">
           {t('heatmap.subtitle')}
         </p>
-        <OccupancyHeatmap bookings={bookings} totalSlots={totalSlots} />
+        <OccupancyHeatmap bookings={heatmapBookings} totalSlots={totalSlots} />
       </div>
     </motion.div>
   );

--- a/parkhub-web/src/views/Bookings.tsx
+++ b/parkhub-web/src/views/Bookings.tsx
@@ -308,10 +308,13 @@ function BookingCard({ booking, now, vehicles, onCancel, cancelling, onShowPass,
   const isUpcoming = isActiveOrConfirmed && isFuture(new Date(booking.start_time));
 
   const statusCfg: Record<Booking['status'], { label: string; cls: string }> = {
+    pending: { label: t('bookings.statusPending', 'Ausstehend'), cls: 'bg-amber-50 text-amber-700 dark:bg-amber-900/20 dark:text-amber-400' },
     active: { label: t('bookings.statusActive'), cls: 'bg-emerald-50 text-emerald-700 dark:bg-emerald-900/20 dark:text-emerald-400' },
     confirmed: { label: t('bookings.statusActive'), cls: 'bg-emerald-50 text-emerald-700 dark:bg-emerald-900/20 dark:text-emerald-400' },
     completed: { label: t('bookings.statusCompleted'), cls: 'bg-surface-100 text-surface-600 dark:bg-surface-800 dark:text-surface-400' },
     cancelled: { label: t('bookings.statusCancelled'), cls: 'bg-red-50 text-red-700 dark:bg-red-900/20 dark:text-red-400' },
+    expired: { label: t('bookings.statusExpired', 'Abgelaufen'), cls: 'bg-surface-100 text-surface-600 dark:bg-surface-800 dark:text-surface-400' },
+    no_show: { label: t('bookings.statusNoShow', 'Nicht erschienen'), cls: 'bg-orange-50 text-orange-700 dark:bg-orange-900/20 dark:text-orange-400' },
   };
   const cfg = statusCfg[booking.status];
 

--- a/parkhub-web/src/views/Dashboard.test.tsx
+++ b/parkhub-web/src/views/Dashboard.test.tsx
@@ -119,7 +119,7 @@ vi.mock('@phosphor-icons/react', () => ({
 }));
 
 vi.mock('../components/KineticObservatory', () => ({
-  KpiCard: ({ label, value, live, delta, ...rest }: any) => {
+  KpiCard: ({ label, value, suffix, live, delta, ...rest }: any) => {
     // Honor a caller-provided data-testid (Dashboard sets kpi-active-bookings,
     // kpi-credits, kpi-this-month, kpi-total, kpi-co2-saved). Fall back to a
     // label-derived id so tests can still find ad-hoc cards by label.
@@ -127,7 +127,7 @@ vi.mock('../components/KineticObservatory', () => ({
     return (
       <div data-testid={testid}>
         <span>{label}</span>
-        <span>{value}</span>
+        <span>{value}{suffix ?? ''}</span>
         {live && <span data-testid="live-badge">Live</span>}
         {delta && <span data-testid="delta-badge">{delta.value}{delta.suffix || '%'}</span>}
       </div>
@@ -262,6 +262,81 @@ describe('DashboardPage', () => {
     expect(within(screen.getByTestId('kpi-total')).getByText('10')).toBeInTheDocument();
     // This Month from userStats
     expect(within(screen.getByTestId('kpi-this-month')).getByText('3')).toBeInTheDocument();
+  });
+
+  it('renders CO2 saved_kg directly when the API provides it', async () => {
+    mockGetBookings.mockResolvedValue({ success: true, data: [] });
+    mockGetUserStats.mockResolvedValue({ success: true, data: null });
+    mockGetCo2Summary.mockResolvedValue({
+      success: true,
+      data: {
+        from: '2026-03-18T00:00:00Z',
+        to: '2026-04-17T00:00:00Z',
+        bookings_counted: 2,
+        total_km: 48,
+        emitted_g: 1200,
+        counterfactual_g: 2900,
+        saved_g: 1700,
+        carpool_saved_g: 0,
+        saved_kg: 1.7,
+      },
+    });
+
+    render(<DashboardPage />);
+
+    await waitFor(() => {
+      expect(within(screen.getByTestId('kpi-co2-saved')).getByText('1.7 kg')).toBeInTheDocument();
+    });
+  });
+
+  it('falls back from CO2 saved_g to kilograms when saved_kg is missing', async () => {
+    mockGetBookings.mockResolvedValue({ success: true, data: [] });
+    mockGetUserStats.mockResolvedValue({ success: true, data: null });
+    mockGetCo2Summary.mockResolvedValue({
+      success: true,
+      data: {
+        from: '2026-03-18T00:00:00Z',
+        to: '2026-04-17T00:00:00Z',
+        bookings_counted: 2,
+        total_km: 48,
+        emitted_g: 1200,
+        counterfactual_g: 2900,
+        saved_g: 1700,
+        carpool_saved_g: 0,
+      },
+    });
+
+    render(<DashboardPage />);
+
+    await waitFor(() => {
+      expect(within(screen.getByTestId('kpi-co2-saved')).getByText('1.7 kg')).toBeInTheDocument();
+    });
+  });
+
+  it('does not render NaN for malformed CO2 values', async () => {
+    mockGetBookings.mockResolvedValue({ success: true, data: [] });
+    mockGetUserStats.mockResolvedValue({ success: true, data: null });
+    mockGetCo2Summary.mockResolvedValue({
+      success: true,
+      data: {
+        from: '2026-03-18T00:00:00Z',
+        to: '2026-04-17T00:00:00Z',
+        bookings_counted: 2,
+        total_km: 48,
+        emitted_g: 1200,
+        counterfactual_g: 2900,
+        saved_g: Number.NaN,
+        carpool_saved_g: 0,
+        saved_kg: Number.NaN,
+      },
+    });
+
+    render(<DashboardPage />);
+
+    await waitFor(() => {
+      expect(within(screen.getByTestId('kpi-co2-saved')).getByText('0 kg')).toBeInTheDocument();
+    });
+    expect(screen.queryByText('NaN kg')).not.toBeInTheDocument();
   });
 
   it('shows empty state when no active bookings', async () => {

--- a/parkhub-web/src/views/Dashboard.tsx
+++ b/parkhub-web/src/views/Dashboard.tsx
@@ -21,6 +21,18 @@ import {
   type SensorEntry,
 } from '../components/KineticObservatory';
 
+function finiteNumber(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+function getCo2SavedKg(summary: Co2Summary | null): number | null {
+  if (!summary) return null;
+  const savedKg = finiteNumber(summary.saved_kg);
+  if (savedKg !== null) return savedKg;
+  const savedG = finiteNumber(summary.saved_g);
+  return savedG !== null ? savedG / 1000 : null;
+}
+
 export function DashboardPage() {
   const { t } = useTranslation();
   const { user } = useAuth();
@@ -62,6 +74,7 @@ export function DashboardPage() {
   const timeOfDay = hour < 12 ? t('dashboard.morning') : hour < 18 ? t('dashboard.afternoon') : t('dashboard.evening');
   const activeBookings = bookings.filter(b => b.status === 'active' || b.status === 'confirmed');
   const name = user?.name?.split(' ')[0] || user?.username || '';
+  const co2SavedKg = getCo2SavedKg(co2);
 
   // Trend period selector
   const [trendPeriod, setTrendPeriod] = useState<'7d' | '30d'>('7d');
@@ -206,7 +219,7 @@ export function DashboardPage() {
         />
         <KpiCard
           label={t('dashboard.co2Saved', 'CO₂ Saved (30d)')}
-          value={co2?.saved_kg ?? 0}
+          value={co2SavedKg ?? 0}
           suffix=" kg"
           icon={<Leaf weight="bold" />}
           data-testid="kpi-co2-saved"


### PR DESCRIPTION
## Summary

Rebased + revived from older slice. Tightens Dashboard + AdminReports component parity with PHP variant: client API surface harmonized, test coverage extended.

## Files

- `parkhub-web/src/api/client.ts` (+22) — API client signature fixes
- `parkhub-web/src/views/Dashboard.tsx` (+15) — dashboard data flow tightening
- `parkhub-web/src/views/AdminReports.tsx` (+45/-35) — reports parity with PHP equivalent
- `parkhub-web/src/views/Dashboard.test.tsx` (+79) — added test coverage
- `parkhub-web/src/views/AdminReports.test.tsx` (+104/-19) — extended scenarios
- `parkhub-web/src/views/Bookings.tsx` + `design-v5/screens/Buchungen.tsx` (+3 each) — small adjustments

## Verification

```
$ cd parkhub-web && npx vitest run src/views/Dashboard.test.tsx src/views/AdminReports.test.tsx
 Test Files  2 passed (2)
      Tests  21 passed (21)
```

## Test plan

- [x] Local: 21/21 vitest tests pass
- [ ] CI: Cargo Test + Frontend Build & Test + a11y + Required checks pass