### PR TITLE
fix(ci): bump fop local CI attestation statuses:read -> write

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
     timeout-minutes: 14
     permissions:
       contents: read  # checkout-only (no writes from this gate job)
-      statuses: read  # poll the `fop/local-ci/pr` commit status posted by the local CI gate
+      statuses: write  # cross-token visibility: workflow GITHUB_TOKEN with read-only cannot see PAT-posted statuses; write scope is the documented workaround per github.com/orgs/community/discussions/40769
     steps:
       - name: Require fop local CI commit status (adaptive backoff)
         env:


### PR DESCRIPTION
## Summary

Symmetric fix for parkhub-php #414 cross-token visibility quirk: workflow's GITHUB_TOKEN with read-only `statuses:read` cannot see commit statuses posted via user PAT.

Same SHA + same `gh api` query: PAT returns 'success', workflow token returns empty. Reproducible. [Documented workaround](https://github.com/orgs/community/discussions/40769) is to bump scope to `write`.

## Why

Multiple parkhub PRs in past days were blocked by 'Missing successful fop/local-ci/pr status after 30 attempts' despite status being posted as success — required `enforce_admins` toggle to merge. parkhub-php landed the same fix in #414 today.

## Change

One word: `statuses: read` → `statuses: write`. No logic changes — the adaptive-backoff polling stays the same and will succeed on first attempt.

## Test plan

Next PR after merge tests actual unblock — should auto-merge cleanly without admin-toggle.