### PR TITLE
ci: require explicit fop local attestation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,17 +138,13 @@ jobs:
                 exit 1
                 ;;
             esac
-            if [[ "${combined}" == "success" ]]; then
-              echo "Combined commit status is success after ${SECONDS}s"
-              exit 0
-            fi
             echo "Waiting ${delay}s for ${CONTEXT} on ${SHA} (current=${status:-pending}, combined=${combined:-unknown}, elapsed=${SECONDS}s)..."
             sleep "$delay"
           done
-          echo "::warning::Timed out waiting for ${CONTEXT}=success after ${SECONDS}s; treating as advisory because explicit failure/error was not observed."
+          echo "::error::Timed out waiting for ${CONTEXT}=success after ${SECONDS}s."
           echo "Run locally:"
           echo "  .github/scripts/fop-local-ci.sh --profile pr --post-status"
-          exit 0
+          exit 1
 
   cargo-deny:
     name: Cargo Deny

--- a/docs/plans/parkhub-local-first-ci-cd-2026.md
+++ b/docs/plans/parkhub-local-first-ci-cd-2026.md
@@ -27,7 +27,7 @@ Refactor ParkHub CI/CD so fop local verification is the primary PR gate, GitHub 
 
 - Local command `.github/scripts/fop-local-ci.sh --profile pr` runs the PR gate through fop.
 - Local command can publish the commit status context `fop/local-ci/pr`.
-- GitHub PR CI requires that attestation and only runs lightweight remote checks by default.
+- GitHub PR CI fails closed for same-repo human PRs until the explicit `fop/local-ci/pr` status is `success`; combined-status success is not accepted as a substitute.
 - Heavy CI and CodeQL jobs still run on `main`, by manual dispatch/schedule, or on PRs labeled `github-ci-full`.
 - CD stays release/GitOps-oriented and is not coupled to every PR push.
 
@@ -68,3 +68,4 @@ Rollback is restoring PR triggers and removing `local-ci-attestation` from `ci.y
 ## Notes
 
 - Based on current GitHub Actions primitives: workflow concurrency, reusable/lightweight workflows, and required checks remain the correct remote-side controls.
+- 2026-05-01 hardening: the `local-ci-attestation` job no longer passes on timeout or combined commit-status success. It only passes after observing the explicit `fop/local-ci/pr` status.

--- a/scripts/ci/local-security-audit.sh
+++ b/scripts/ci/local-security-audit.sh
@@ -226,7 +226,7 @@ fi
 # actionlint (MIT) is the primary workflow linter. We deliberately skip
 # yamllint (GPL-3.0) to keep the local gate strictly within Florian's
 # commercial-license-safe set (MIT/Apache-2.0/BSD/ISC).
-run_if_available actionlint "workflow lint (actionlint)" actionlint .github/workflows
+run_if_available actionlint "workflow lint (actionlint)" bash -euo pipefail -c "find .github/workflows -maxdepth 1 -type f \\( -name '*.yml' -o -name '*.yaml' \\) -print0 | xargs -0 actionlint"
 run_if_available helm "helm chart render" bash -euo pipefail -c "if [[ -d helm ]]; then for chart in helm/*/Chart.yaml; do [[ -f \"\$chart\" ]] || continue; chartdir=\"\$(dirname \"\$chart\")\"; helm lint \"\$chartdir\" && helm template parkhub \"\$chartdir\" >/dev/null; done; else echo 'no helm/ directory; skipping'; fi"
 run_if_available docker "docker compose config" bash -euo pipefail -c "if [[ -f docker-compose.yml ]]; then docker compose -f docker-compose.yml config -q; else echo 'no docker-compose.yml; skipping'; fi"
 


### PR DESCRIPTION
## Summary
- fail closed for same-repo human PRs until explicit `fop/local-ci/pr` is success
- remove combined-status fallback and timeout-as-advisory behavior
- update the local-first CI/CD plan to document the required attestation contract

## Verification
- `actionlint /var/home/florian/dev/parkhub-rust/.github/workflows/ci.yml`
- `cd /var/home/florian/dev/parkhub-rust && fop build --backend local . --preset custom -- bash -lc 'git diff --check && ./.github/scripts/fop-local-ci.sh --profile pr --dry-run'`