### PR TITLE
ci: keep changelog workflow green without bot token

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -52,12 +52,13 @@ jobs:
           GH_TOKEN: ${{ secrets.PARKHUB_CHANGELOG_TOKEN }}
         run: |
           set -euo pipefail
-          if [ -z "${GH_TOKEN:-}" ]; then
-            echo "::error::Configure PARKHUB_CHANGELOG_TOKEN with contents:write and pull-requests:write so generated changelog PRs trigger normal PR CI."
-            exit 1
-          fi
           if git diff --quiet CHANGELOG.md; then
             echo "CHANGELOG.md unchanged — skipping commit."
+            exit 0
+          fi
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "::warning::CHANGELOG.md changed, but PARKHUB_CHANGELOG_TOKEN is not configured. Skipping changelog PR creation so main stays green; configure a repo secret with contents:write and pull-requests:write to enable automated changelog PRs that trigger normal PR CI."
+            git diff -- CHANGELOG.md
             exit 0
           fi
           if [ "${GITHUB_REF_TYPE}" = "branch" ] && [ "${GITHUB_REF_NAME}" = "main" ]; then

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -52,12 +52,12 @@ jobs:
           GH_TOKEN: ${{ secrets.PARKHUB_CHANGELOG_TOKEN }}
         run: |
           set -euo pipefail
-          if git diff --quiet CHANGELOG.md; then
+          if git diff --quiet -- CHANGELOG.md; then
             echo "CHANGELOG.md unchanged — skipping commit."
             exit 0
           fi
           if [ -z "${GH_TOKEN:-}" ]; then
-            echo "::warning::CHANGELOG.md changed, but PARKHUB_CHANGELOG_TOKEN is not configured. Skipping changelog PR creation so main stays green; configure a repo secret with contents:write and pull-requests:write to enable automated changelog PRs that trigger normal PR CI."
+            echo "::warning::CHANGELOG.md changed, but PARKHUB_CHANGELOG_TOKEN is not configured. Skipping changelog PR creation so the workflow stays green; configure a repo secret with contents:write and pull-requests:write to enable automated changelog PRs that trigger normal PR CI."
             git diff -- CHANGELOG.md
             exit 0
           fi


### PR DESCRIPTION
## Summary
- skip changelog PR creation with a warning when PARKHUB_CHANGELOG_TOKEN is not configured
- still avoid using GITHUB_TOKEN to create generated changelog PRs
- keep main green until the dedicated changelog token is installed

## Verification
- git diff --check
- actionlint .github/workflows/changelog.yml
- pre-push local CI via lefthook/fop passed