### PR TITLE
fix(security): allow OpenStreetMap tiles in CSP

### DIFF
--- a/parkhub-server/src/api/system.rs
+++ b/parkhub-server/src/api/system.rs
@@ -482,7 +482,7 @@ pub async fn security_headers_middleware(request: Request<Body>, next: Next) -> 
             "default-src 'self'; \
              script-src 'self' 'unsafe-inline'; \
              style-src 'self' 'unsafe-inline'; \
-             img-src 'self' data: blob:; \
+             img-src 'self' data: blob: https://a.tile.openstreetmap.org https://b.tile.openstreetmap.org https://c.tile.openstreetmap.org; \
              font-src 'self' data:; \
              connect-src 'self' ws: wss:; \
              frame-ancestors 'none'; \

--- a/parkhub-server/src/integration_tests.rs
+++ b/parkhub-server/src/integration_tests.rs
@@ -809,9 +809,14 @@ async fn responses_include_security_headers() {
         .expect("content-security-policy header")
         .to_str()
         .unwrap();
-    assert!(csp.contains("https://a.tile.openstreetmap.org"));
-    assert!(csp.contains("https://b.tile.openstreetmap.org"));
-    assert!(csp.contains("https://c.tile.openstreetmap.org"));
+    let img_src = csp
+        .split(';')
+        .map(str::trim)
+        .find(|directive| directive.starts_with("img-src "))
+        .expect("img-src directive");
+    assert!(img_src.contains("https://a.tile.openstreetmap.org"));
+    assert!(img_src.contains("https://b.tile.openstreetmap.org"));
+    assert!(img_src.contains("https://c.tile.openstreetmap.org"));
     assert!(headers.get("referrer-policy").is_some());
     assert!(headers.get("strict-transport-security").is_some());
     assert!(headers.get("permissions-policy").is_some());

--- a/parkhub-server/src/integration_tests.rs
+++ b/parkhub-server/src/integration_tests.rs
@@ -804,7 +804,14 @@ async fn responses_include_security_headers() {
     let headers = resp.headers();
     assert_eq!(headers.get("x-content-type-options").unwrap(), "nosniff");
     assert_eq!(headers.get("x-frame-options").unwrap(), "DENY");
-    assert!(headers.get("content-security-policy").is_some());
+    let csp = headers
+        .get("content-security-policy")
+        .expect("content-security-policy header")
+        .to_str()
+        .unwrap();
+    assert!(csp.contains("https://a.tile.openstreetmap.org"));
+    assert!(csp.contains("https://b.tile.openstreetmap.org"));
+    assert!(csp.contains("https://c.tile.openstreetmap.org"));
     assert!(headers.get("referrer-policy").is_some());
     assert!(headers.get("strict-transport-security").is_some());
     assert!(headers.get("permissions-policy").is_some());

--- a/parkhub-web/scripts/spa-preview.mjs
+++ b/parkhub-web/scripts/spa-preview.mjs
@@ -35,7 +35,7 @@ const DEFAULT_HEADERS = {
 
 const HTML_HEADERS = {
   ...DEFAULT_HEADERS,
-  'content-security-policy': "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' ws: wss:; base-uri 'self'; form-action 'self';",
+  'content-security-policy': "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://a.tile.openstreetmap.org https://b.tile.openstreetmap.org https://c.tile.openstreetmap.org; font-src 'self' data:; connect-src 'self' ws: wss:; base-uri 'self'; form-action 'self';",
 };
 
 function send(res, statusCode, body, contentType = 'text/plain; charset=utf-8', headers = DEFAULT_HEADERS) {

--- a/parkhub-web/src/pages/index.astro
+++ b/parkhub-web/src/pages/index.astro
@@ -9,7 +9,7 @@ import '../styles/global.css';
     <meta name="color-scheme" content="light dark" />
     <meta name="theme-color" content="#0d9488" media="(prefers-color-scheme: light)" />
     <meta name="theme-color" content="#042f2e" media="(prefers-color-scheme: dark)" />
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' ws: wss:; base-uri 'self'; form-action 'self';" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://a.tile.openstreetmap.org https://b.tile.openstreetmap.org https://c.tile.openstreetmap.org; font-src 'self' data:; connect-src 'self' ws: wss:; base-uri 'self'; form-action 'self';" />
     <meta name="description" content="ParkHub — Smart Parking Management. Book, manage and optimize parking with real-time occupancy, team scheduling, and GDPR-compliant analytics." />
     <!-- Open Graph -->
     <meta property="og:type" content="website" />

--- a/parkhub-web/src/pages/v5.astro
+++ b/parkhub-web/src/pages/v5.astro
@@ -7,7 +7,7 @@ import '../styles/global.css';
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <meta name="color-scheme" content="light dark" />
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' ws: wss:; base-uri 'self'; form-action 'self';" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://a.tile.openstreetmap.org https://b.tile.openstreetmap.org https://c.tile.openstreetmap.org; font-src 'self' data:; connect-src 'self' ws: wss:; base-uri 'self'; form-action 'self';" />
     <meta name="description" content="ParkHub v5 — the 2026 urban mobility command center. Dashboard, bookings, fleet, admin — all in one keyboard-first surface." />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="manifest" href="/manifest.webmanifest" />


### PR DESCRIPTION
## Summary
- allow the concrete OpenStreetMap tile hosts in server, static, and SPA preview CSP img-src
- add a Rust integration assertion for the map tile CSP contract

## Verification
- git diff --check
- fop build --backend local . --preset custom -- cargo fmt --all -- --check
- fop build --backend local . --preset custom -- cargo test --locked --package parkhub-server responses_include_security_headers -- --nocapture
- lefthook pre-push: cargo-check, cargo-clippy, cargo-test-fast, openapi-drift, osv-scanner, trivy-fs, types-drift, zizmor

Fixes the main E2E failure in run 25230800320 where Chromium reported CSP image blocks for a.tile/b.tile/c.tile.openstreetmap.org on protected pages.