### PR TITLE
fix(auth): allow dev http cookies

### DIFF
--- a/parkhub-server/src/api/auth.rs
+++ b/parkhub-server/src/api/auth.rs
@@ -34,16 +34,40 @@ use super::{
 /// Cookie name for the auth token.
 pub const AUTH_COOKIE_NAME: &str = "parkhub_token";
 
+/// Return whether auth cookies should include `Secure` for the configured URL.
+///
+/// Plain HTTP is allowed only for explicit local development hosts.
+pub(super) fn auth_cookie_secure_flag(app_url: Option<&str>) -> bool {
+    let Some(url) = app_url else {
+        return true;
+    };
+
+    let Some(authority) = url.strip_prefix("http://") else {
+        return true;
+    };
+
+    let host = authority
+        .split(['/', '?', '#'])
+        .next()
+        .and_then(|authority| authority.rsplit('@').next())
+        .unwrap_or_default();
+    let host = if let Some(ipv6) = host.strip_prefix('[') {
+        ipv6.split(']').next().unwrap_or_default()
+    } else {
+        host.split(':').next().unwrap_or_default()
+    };
+
+    let is_test_host = host
+        .rsplit_once('.')
+        .is_some_and(|(_, suffix)| suffix.eq_ignore_ascii_case("test"));
+
+    !(host == "localhost" || host == "127.0.0.1" || host == "::1" || is_test_host)
+}
+
 /// Build a `Set-Cookie` header value for the auth token.
 ///
 /// The cookie is `HttpOnly`, `SameSite=Lax`, `Path=/`, and `Secure` unless
 /// `APP_URL` points at a plain-HTTP dev origin.
-pub(super) fn auth_cookie_secure_flag(app_url: Option<&str>) -> bool {
-    app_url
-        .map(|url| !url.starts_with("http://"))
-        .unwrap_or(true)
-}
-
 pub(super) fn build_auth_cookie(token: &str, max_age_secs: i64) -> String {
     let app_url = std::env::var("APP_URL").ok();
     let secure_flag = auth_cookie_secure_flag(app_url.as_deref());
@@ -1139,13 +1163,19 @@ mod tests {
     fn test_auth_cookie_secure_flag_allows_plain_http_dev_origins() {
         assert!(!auth_cookie_secure_flag(Some("http://localhost:3000")));
         assert!(!auth_cookie_secure_flag(Some("http://127.0.0.1:39080")));
+        assert!(!auth_cookie_secure_flag(Some("http://[::1]:39080")));
         assert!(!auth_cookie_secure_flag(Some("http://parkhub-rust.test")));
+        assert!(!auth_cookie_secure_flag(Some(
+            "http://parkhub-rust.test:39080"
+        )));
+        assert!(!auth_cookie_secure_flag(Some("http://parkhub-rust.TEST")));
     }
 
     #[test]
     fn test_auth_cookie_secure_flag_keeps_https_and_missing_url_secure() {
         assert!(auth_cookie_secure_flag(None));
         assert!(auth_cookie_secure_flag(Some("https://parkhub.example.com")));
+        assert!(auth_cookie_secure_flag(Some("http://staging.example.com")));
     }
 
     #[test]

--- a/parkhub-server/src/api/auth.rs
+++ b/parkhub-server/src/api/auth.rs
@@ -37,11 +37,16 @@ pub const AUTH_COOKIE_NAME: &str = "parkhub_token";
 /// Build a `Set-Cookie` header value for the auth token.
 ///
 /// The cookie is `HttpOnly`, `SameSite=Lax`, `Path=/`, and `Secure` unless
-/// running on localhost (detected via `APP_URL` env var).
+/// `APP_URL` points at a plain-HTTP dev origin.
+pub(super) fn auth_cookie_secure_flag(app_url: Option<&str>) -> bool {
+    app_url
+        .map(|url| !url.starts_with("http://"))
+        .unwrap_or(true)
+}
+
 pub(super) fn build_auth_cookie(token: &str, max_age_secs: i64) -> String {
-    let secure_flag = std::env::var("APP_URL")
-        .map(|u| !u.starts_with("http://localhost") && !u.starts_with("http://127.0.0.1"))
-        .unwrap_or(true);
+    let app_url = std::env::var("APP_URL").ok();
+    let secure_flag = auth_cookie_secure_flag(app_url.as_deref());
 
     let mut cookie = format!(
         "{AUTH_COOKIE_NAME}={token}; HttpOnly; SameSite=Lax; Path=/; Max-Age={max_age_secs}"
@@ -1128,6 +1133,19 @@ mod tests {
         unsafe { std::env::remove_var("APP_URL") };
         let cookie = build_auth_cookie("tok", 7200);
         assert!(cookie.contains("Secure"));
+    }
+
+    #[test]
+    fn test_auth_cookie_secure_flag_allows_plain_http_dev_origins() {
+        assert!(!auth_cookie_secure_flag(Some("http://localhost:3000")));
+        assert!(!auth_cookie_secure_flag(Some("http://127.0.0.1:39080")));
+        assert!(!auth_cookie_secure_flag(Some("http://parkhub-rust.test")));
+    }
+
+    #[test]
+    fn test_auth_cookie_secure_flag_keeps_https_and_missing_url_secure() {
+        assert!(auth_cookie_secure_flag(None));
+        assert!(auth_cookie_secure_flag(Some("https://parkhub.example.com")));
     }
 
     #[test]

--- a/parkhub-server/src/api/oauth.rs
+++ b/parkhub-server/src/api/oauth.rs
@@ -186,9 +186,8 @@ const OAUTH_STATE_MAX_AGE: u32 = 600;
 
 /// Build a `Set-Cookie` header value for the OAuth CSRF state nonce.
 fn build_oauth_state_cookie(state_nonce: &str) -> String {
-    let secure_flag = std::env::var("APP_URL")
-        .map(|u| !u.starts_with("http://localhost") && !u.starts_with("http://127.0.0.1"))
-        .unwrap_or(true);
+    let app_url = std::env::var("APP_URL").ok();
+    let secure_flag = super::auth::auth_cookie_secure_flag(app_url.as_deref());
     let mut cookie = format!(
         "{OAUTH_STATE_COOKIE}={state_nonce}; HttpOnly; SameSite=Lax; Path=/api/v1/auth/oauth; Max-Age={OAUTH_STATE_MAX_AGE}"
     );


### PR DESCRIPTION
## Summary
- allow plain-HTTP dev origins such as http://parkhub-rust.test to receive auth/OAuth cookies without the Secure flag
- keep HTTPS and missing APP_URL secure by default
- add regression coverage for localhost, 127.0.0.1, .test, HTTPS, and missing APP_URL

## Verification
- env -u RUSTC_WRAPPER fop build --backend local . --preset custom -- cargo test --locked --package parkhub-server test_auth_cookie_secure_flag_ -- --nocapture
- env -u RUSTC_WRAPPER fop build --backend local . --preset custom -- cargo fmt --all -- --check
- env -u RUSTC_WRAPPER fop build --backend local . --preset custom -- cargo build --locked --package parkhub-server
- local browser smoke: http://parkhub-rust.test/admin/chargers and /admin/updates render authenticated after login
- pre-push gate: cargo-check, cargo-clippy, cargo-test-fast, openapi-drift, osv-scanner, trivy-fs, types-drift, zizmor