### PR TITLE
design(admin): SOTA-2026 sidebar nav pill (slice 3/3 — final)

### DIFF
--- a/parkhub-web/src/styles/global.css
+++ b/parkhub-web/src/styles/global.css
@@ -979,3 +979,57 @@ body {
 .v11-meter--success { --meter-tone: oklch(0.72 0.16 145); /* emerald */ }
 .v11-meter--warn    { --meter-tone: oklch(0.78 0.16 75);  /* amber */ }
 .v11-meter--danger  { --meter-tone: oklch(0.65 0.22 25);  /* red */ }
+
+/* ── v11 SOTA sidebar nav pill (slice 3) ────────────────────────────
+ * Replaces the plain `bg-primary-50 text-primary-700` active fill with
+ * the v11 chrome vocabulary: 3px colored left-edge bar + tone glow,
+ * color-mix(oklab) gradient wash, intensified hover transitions.
+ * Pairs with .admin-hero (PR #489) + .v11-meter (PR #490).
+ */
+.v11-nav-link {
+  position: relative;
+  border-radius: 8px;
+  color: var(--color-surface-700, #404040);
+  transition:
+    color 120ms ease-out,
+    background-color 120ms ease-out;
+}
+.dark .v11-nav-link { color: var(--color-surface-300, #d4d4d4); }
+.v11-nav-link:hover {
+  background: color-mix(in oklab, var(--color-surface-100, #f4f4f5) 80%, transparent);
+  color: var(--color-surface-900, #18181b);
+}
+.dark .v11-nav-link:hover {
+  background: color-mix(in oklab, var(--color-surface-800, #27272a) 70%, transparent);
+  color: #fff;
+}
+.v11-nav-link.is-active {
+  color: var(--color-primary-700);
+  background: linear-gradient(
+    90deg,
+    color-mix(in oklab, var(--color-primary-500) 14%, transparent) 0%,
+    color-mix(in oklab, var(--color-primary-500) 4%, transparent) 70%,
+    transparent 100%
+  );
+  font-weight: 600;
+}
+.dark .v11-nav-link.is-active {
+  color: var(--color-primary-300, var(--color-primary-500));
+  background: linear-gradient(
+    90deg,
+    color-mix(in oklab, var(--color-primary-500) 22%, transparent) 0%,
+    color-mix(in oklab, var(--color-primary-500) 6%, transparent) 70%,
+    transparent 100%
+  );
+}
+.v11-nav-link.is-active::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 6px;
+  bottom: 6px;
+  width: 3px;
+  border-radius: 2px;
+  background: var(--color-primary-500);
+  box-shadow: 0 0 10px color-mix(in oklab, var(--color-primary-500) 50%, transparent);
+}

--- a/parkhub-web/src/views/Admin.tsx
+++ b/parkhub-web/src/views/Admin.tsx
@@ -117,11 +117,11 @@ function AdminSidebar({ sections, onNavigate }: { sections: NavSection[]; onNavi
             {section.items.map(item => {
               const active = !item.external && isActivePath(location.pathname, item.to);
               const Icon = item.icon;
-              const linkClass = `group flex items-center gap-2.5 px-3 py-2 rounded-lg text-sm font-medium transition-colors ${
-                active
-                  ? 'bg-primary-50 text-primary-700 dark:bg-primary-900/30 dark:text-primary-300'
-                  : 'text-surface-700 dark:text-surface-300 hover:bg-surface-100 dark:hover:bg-surface-800 hover:text-surface-900 dark:hover:text-white'
-              }`;
+              // v11 SOTA active state — gradient wash + 3px left-edge bar
+              // with primary glow + soft inner-tone tint. Replaces the
+              // plain bg-primary-50 fill so the sidebar matches the new
+              // .admin-hero + .v11-meter chrome shipped in #489 + #490.
+              const linkClass = `v11-nav-link ${active ? 'is-active' : ''} group flex items-center gap-2.5 px-3 py-2 text-sm font-medium`;
               const content = (
                 <>
                   <Icon weight={active ? 'fill' : 'regular'} className="w-4 h-4 shrink-0" />


### PR DESCRIPTION
Final SOTA-2026 slice. Replaces plain bg-primary-50 active fill with v11 chrome:

- 3px colored left-edge bar with primary glow
- color-mix(oklab) gradient wash (left→right)
- font-weight 600 + primary-700 text
- Existing framer-motion active-dot animation preserved
- Refined hover: surface-100/800 + color flip

Pairs with #489 (admin-hero) + #490 (v11-meter). The whole admin shell now speaks one SOTA-2026 visual language.

3/3 slices shipped. astro check: 0 errors.