### PR TITLE
design(admin/billing): SOTA-2026 hero + meters with emerald tone

### DIFF
--- a/parkhub-web/src/styles/global.css
+++ b/parkhub-web/src/styles/global.css
@@ -1033,3 +1033,82 @@ body {
   background: var(--color-primary-500);
   box-shadow: 0 0 10px color-mix(in oklab, var(--color-primary-500) 50%, transparent);
 }
+
+/* ── Admin hero tone variants + action buttons ─────────────────────
+ * Lets per-page hero use a different accent (emerald for billing,
+ * blue for reports, etc.) while reusing the .admin-hero chrome.
+ */
+.admin-hero--emerald {
+  border-color: color-mix(in oklab, oklch(0.72 0.16 145) 32%, transparent);
+  background:
+    linear-gradient(
+      180deg,
+      color-mix(in oklab, oklch(0.72 0.16 145) 8%, transparent) 0%,
+      color-mix(in oklab, oklch(0.72 0.16 145) 3%, transparent) 60%,
+      transparent 100%
+    ),
+    var(--color-surface-50, #fafafa);
+}
+.admin-hero--emerald::before {
+  background: oklch(0.72 0.16 145);
+  box-shadow: 0 0 24px color-mix(in oklab, oklch(0.72 0.16 145) 50%, transparent);
+}
+.admin-hero--emerald .admin-hero-eyebrow,
+.admin-hero--emerald .admin-hero-dot { color: oklch(0.55 0.18 145); }
+.admin-hero--emerald .admin-hero-dot { background: oklch(0.72 0.16 145); box-shadow: 0 0 10px oklch(0.72 0.16 145); }
+.dark .admin-hero--emerald {
+  background:
+    linear-gradient(
+      180deg,
+      color-mix(in oklab, oklch(0.72 0.16 145) 12%, transparent) 0%,
+      color-mix(in oklab, oklch(0.72 0.16 145) 4%, transparent) 60%,
+      transparent 100%
+    ),
+    var(--color-surface-900, #18181b);
+}
+
+.admin-hero-actions {
+  display: flex;
+  gap: 8px;
+  align-self: flex-start;
+}
+.admin-hero-iconbtn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 8px;
+  border: 1px solid color-mix(in oklab, var(--color-surface-200, #e4e4e7) 80%, transparent);
+  background: var(--color-surface-50, #fafafa);
+  color: var(--color-surface-500, #71717a);
+  cursor: pointer;
+  transition: background 120ms ease-out, color 120ms ease-out;
+}
+.admin-hero-iconbtn:hover {
+  background: var(--color-surface-100, #f4f4f5);
+  color: var(--color-surface-900, #18181b);
+}
+.dark .admin-hero-iconbtn {
+  background: var(--color-surface-800, #27272a);
+  border-color: color-mix(in oklab, var(--color-surface-700, #3f3f46) 80%, transparent);
+}
+.admin-hero-action {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 14px;
+  border-radius: 8px;
+  border: 1px solid color-mix(in oklab, var(--color-primary-500) 32%, transparent);
+  background: color-mix(in oklab, var(--color-primary-500) 12%, transparent);
+  color: var(--color-primary-700);
+  font: 600 13px/1 ui-sans-serif, system-ui, sans-serif;
+  cursor: pointer;
+  transition: background 120ms ease-out;
+}
+.admin-hero-action:hover {
+  background: color-mix(in oklab, var(--color-primary-500) 22%, transparent);
+}
+.dark .admin-hero-action {
+  color: var(--color-primary-300, var(--color-primary-500));
+}

--- a/parkhub-web/src/views/AdminBilling.tsx
+++ b/parkhub-web/src/views/AdminBilling.tsx
@@ -77,26 +77,35 @@ export function AdminBillingPage() {
 
   return (
     <div className="space-y-6">
-      {/* Header */}
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-3">
-          <div className="p-2 bg-emerald-100 dark:bg-emerald-900/30 rounded-lg">
-            <CurrencyDollar weight="bold" className="w-5 h-5 text-emerald-600 dark:text-emerald-400" />
+      {/* v11 SOTA hero — replaces plain h2/subtitle. Pairs with the
+          .admin-hero shipped on the Admin shell. Emerald tone matches
+          the Cost Center Billing identity. */}
+      <section className="admin-hero admin-hero--emerald">
+        <div className="admin-hero-left">
+          <div className="admin-hero-eyebrow">
+            <span className="admin-hero-dot" aria-hidden="true"></span>
+            <CurrencyDollar weight="bold" className="w-3.5 h-3.5" />
+            {t('billing.eyebrow', 'COST CENTER BILLING')}
           </div>
-          <div>
-            <h2 className="text-lg font-bold text-surface-900 dark:text-white">{t('billing.title', 'Cost Center Billing')}</h2>
-            <p className="text-sm text-surface-500 dark:text-surface-400">{t('billing.subtitle', 'Billing breakdown by cost center and department')}</p>
-          </div>
+          <h1 className="admin-hero-headline">{t('billing.title', 'Cost Center Billing')}</h1>
+          <p className="admin-hero-sub">
+            {t('billing.subtitle', 'Billing breakdown by cost center and department')}
+          </p>
         </div>
-        <div className="flex items-center gap-2">
-          <button onClick={() => setShowHelp(!showHelp)} className="p-2 rounded-lg hover:bg-surface-100 dark:hover:bg-surface-800 text-surface-400">
-            <Question weight="bold" className="w-5 h-5" />
+        <div className="admin-hero-actions">
+          <button
+            onClick={() => setShowHelp(!showHelp)}
+            className="admin-hero-iconbtn"
+            aria-label={t('billing.help_toggle', 'Toggle help')}
+          >
+            <Question weight="bold" className="w-4 h-4" />
           </button>
-          <button onClick={handleExport} className="btn btn-secondary btn-sm" data-testid="export-btn">
-            <DownloadSimple weight="bold" className="w-4 h-4" /> {t('billing.export', 'CSV Export')}
+          <button onClick={handleExport} className="admin-hero-action" data-testid="export-btn">
+            <DownloadSimple weight="bold" className="w-4 h-4" />
+            {t('billing.export', 'CSV Export')}
           </button>
         </div>
-      </div>
+      </section>
 
       {/* Help */}
       {showHelp && (
@@ -107,11 +116,11 @@ export function AdminBillingPage() {
         </motion.div>
       )}
 
-      {/* Summary cards */}
+      {/* v11 SOTA summary meters — emerald/blue/purple tones for visual rhythm. */}
       <div className="grid grid-cols-1 sm:grid-cols-3 gap-4" data-testid="billing-summary">
-        <SummaryCard label={t('billing.totalSpending', 'Total Spending')} value={`EUR ${totalAmount.toFixed(2)}`} icon={<CurrencyDollar weight="bold" className="w-5 h-5 text-emerald-500" />} />
-        <SummaryCard label={t('billing.totalBookings', 'Total Bookings')} value={totalBookings} icon={<ChartBar weight="bold" className="w-5 h-5 text-blue-500" />} />
-        <SummaryCard label={t('billing.totalUsers', 'Total Users')} value={totalUsers} icon={<Buildings weight="bold" className="w-5 h-5 text-purple-500" />} />
+        <SummaryCard tone="success" label={t('billing.totalSpending', 'Total Spending')} value={`EUR ${totalAmount.toFixed(2)}`} icon={<CurrencyDollar weight="bold" className="w-3.5 h-3.5" />} />
+        <SummaryCard tone="info" label={t('billing.totalBookings', 'Total Bookings')} value={totalBookings} icon={<ChartBar weight="bold" className="w-3.5 h-3.5" />} />
+        <SummaryCard tone="accent" label={t('billing.totalUsers', 'Total Users')} value={totalUsers} icon={<Buildings weight="bold" className="w-3.5 h-3.5" />} />
       </div>
 
       {/* Tab switcher */}
@@ -177,11 +186,20 @@ export function AdminBillingPage() {
   );
 }
 
-function SummaryCard({ label, value, icon }: { label: string; value: string | number; icon: React.ReactNode }) {
+function SummaryCard({ label, value, icon, tone = 'primary' }: {
+  label: string;
+  value: string | number;
+  icon: React.ReactNode;
+  tone?: 'primary' | 'accent' | 'info' | 'success' | 'warn' | 'danger';
+}) {
+  // v11 SOTA meter from PR #490 — same pattern as AdminReports stat cards.
   return (
-    <div className="bg-white dark:bg-surface-900 rounded-xl border border-surface-200 dark:border-surface-800 p-4">
-      <div className="flex items-center gap-2 mb-2">{icon}<span className="text-xs font-medium text-surface-500 dark:text-surface-400">{label}</span></div>
-      <p className="text-2xl font-bold text-surface-900 dark:text-white">{value}</p>
+    <div className={`v11-meter v11-meter--${tone}`}>
+      <div className="v11-meter-eyebrow">
+        {icon}
+        {label}
+      </div>
+      <div className="v11-meter-value">{value}</div>
     </div>
   );
 }


### PR DESCRIPTION
Applies v11 chrome (PRs #489/#490/#491) to AdminBilling. Adds .admin-hero--emerald tone variant + .admin-hero-actions for header action groups. SummaryCard rewritten as v11-meter (success/info/accent tones). astro check: 0 errors.