### PR TITLE
design(admin): SOTA-2026 batch4 — Analytics+Dashboard+Settings+Roles+SSO+Zones+DataMgmt+RateLimits (19/24)

### DIFF
--- a/parkhub-web/src/views/AdminAnalytics.tsx
+++ b/parkhub-web/src/views/AdminAnalytics.tsx
@@ -144,15 +144,18 @@ export function AdminAnalyticsPage() {
 
   return (
     <div className="space-y-6" data-testid="admin-analytics">
-      <div className="flex items-center justify-between flex-wrap gap-4">
-        <div>
-          <h1 className="text-2xl font-bold text-surface-900 dark:text-white flex items-center gap-2">
-            <ChartBar weight="fill" className="w-6 h-6 text-primary-500" />
-            Analytics
-          </h1>
-          <p className="text-sm text-surface-500 dark:text-surface-400">Comprehensive parking analytics and trends</p>
+      {/* v11 SOTA hero — emerald tone (data + insights). */}
+      <section className="admin-hero admin-hero--emerald">
+        <div className="admin-hero-left">
+          <div className="admin-hero-eyebrow">
+            <span className="admin-hero-dot" aria-hidden="true"></span>
+            <ChartBar weight="bold" className="w-3.5 h-3.5" />
+            USAGE & TRENDS
+          </div>
+          <h1 className="admin-hero-headline">Analytics</h1>
+          <p className="admin-hero-sub">Comprehensive parking analytics and trends</p>
         </div>
-        <div className="flex items-center gap-2">
+        <div className="admin-hero-actions">
           {(['7', '30', '90', '365'] as DateRange[]).map(r => (
             <button
               key={r}
@@ -166,15 +169,12 @@ export function AdminAnalyticsPage() {
               {r === '365' ? '1y' : `${r}d`}
             </button>
           ))}
-          <button
-            onClick={exportCsv}
-            className="flex items-center gap-1.5 px-3 py-1.5 text-sm bg-surface-100 dark:bg-surface-800 text-surface-600 dark:text-surface-400 hover:bg-surface-200 dark:hover:bg-surface-700 rounded-lg transition-colors"
-          >
+          <button onClick={exportCsv} className="admin-hero-action">
             <Export weight="bold" className="w-4 h-4" />
             CSV
           </button>
         </div>
-      </div>
+      </section>
 
       {loading ? (
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">

--- a/parkhub-web/src/views/AdminDashboard.tsx
+++ b/parkhub-web/src/views/AdminDashboard.tsx
@@ -107,21 +107,27 @@ export function AdminDashboardPage() {
 
   return (
     <div className="space-y-6">
-      {/* Header */}
-      <div className="flex items-center justify-between">
-        <div>
-          <h1 className="text-2xl font-bold text-surface-900 dark:text-white">{t('widgets.title')}</h1>
-          <p className="text-surface-500 dark:text-surface-400 text-sm">{t('widgets.subtitle')}</p>
+      {/* v11 SOTA hero — primary tone (operations view). */}
+      <section className="admin-hero">
+        <div className="admin-hero-left">
+          <div className="admin-hero-eyebrow">
+            <span className="admin-hero-dot" aria-hidden="true"></span>
+            <ChartBar weight="bold" className="w-3.5 h-3.5" />
+            OPERATIONS VIEW
+          </div>
+          <h1 className="admin-hero-headline">{t('widgets.title')}</h1>
+          <p className="admin-hero-sub">{t('widgets.subtitle')}</p>
         </div>
-        <div className="flex items-center gap-2">
-          <button onClick={() => setShowHelp(!showHelp)} className="p-2 rounded-lg hover:bg-surface-100 dark:hover:bg-surface-800 text-surface-500" title={t('widgets.helpLabel')}>
-            <Question size={20} />
+        <div className="admin-hero-actions">
+          <button onClick={() => setShowHelp(!showHelp)} className="admin-hero-iconbtn" title={t('widgets.helpLabel')}>
+            <Question size={16} />
           </button>
-          <button onClick={() => setShowCatalog(!showCatalog)} className="flex items-center gap-1.5 px-3 py-2 rounded-lg bg-primary-600 text-white text-sm font-medium hover:bg-primary-700">
-            <GearSix size={16} /> {t('widgets.customize')}
+          <button onClick={() => setShowCatalog(!showCatalog)} className="admin-hero-action">
+            <GearSix size={16} weight="bold" />
+            {t('widgets.customize')}
           </button>
         </div>
-      </div>
+      </section>
 
       {/* Help tooltip */}
       <AnimatePresence>

--- a/parkhub-web/src/views/AdminDataManagement.tsx
+++ b/parkhub-web/src/views/AdminDataManagement.tsx
@@ -20,14 +20,18 @@ export function AdminDataManagementPage() {
 
   return (
     <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} className="space-y-6">
-      {/* Header */}
-      <div className="flex items-center gap-3">
-        <Table weight="duotone" className="w-6 h-6 text-primary-500" />
-        <div>
-          <h2 className="text-xl font-bold text-surface-900 dark:text-white">{t('dataManagement.title', 'Data Management')}</h2>
-          <p className="text-sm text-surface-500">{t('dataManagement.subtitle', 'Import and export your ParkHub data')}</p>
+      {/* v11 SOTA hero — amber tone (bulk ops touch many rows, double-check before running). */}
+      <section className="admin-hero admin-hero--amber">
+        <div className="admin-hero-left">
+          <div className="admin-hero-eyebrow">
+            <span className="admin-hero-dot" aria-hidden="true"></span>
+            <Table weight="bold" className="w-3.5 h-3.5" />
+            {t('dataManagement.eyebrow', 'BULK OPERATIONS')}
+          </div>
+          <h1 className="admin-hero-headline">{t('dataManagement.title', 'Data Management')}</h1>
+          <p className="admin-hero-sub">{t('dataManagement.subtitle', 'Import and export your ParkHub data')}</p>
         </div>
-      </div>
+      </section>
 
       {/* Tabs */}
       <div className="flex gap-2" data-testid="data-tabs">

--- a/parkhub-web/src/views/AdminRateLimits.tsx
+++ b/parkhub-web/src/views/AdminRateLimits.tsx
@@ -59,24 +59,31 @@ export function AdminRateLimitsPage() {
 
   return (
     <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} className="space-y-6">
-      <div className="flex items-center justify-between">
-        <h2 className="text-xl font-bold text-surface-900 dark:text-white">
-          {t('rateLimits.title', 'Rate Limits')}
-        </h2>
-        <div className="flex items-center gap-2 text-sm">
+      {/* v11 SOTA hero — amber tone (throttle = traffic-shaping caution). */}
+      <section className="admin-hero admin-hero--amber">
+        <div className="admin-hero-left">
+          <div className="admin-hero-eyebrow">
+            <span className="admin-hero-dot" aria-hidden="true"></span>
+            <Warning weight="bold" className="w-3.5 h-3.5" />
+            {t('rateLimits.eyebrow', 'API THROTTLE')}
+          </div>
+          <h1 className="admin-hero-headline">{t('rateLimits.title', 'Rate Limits')}</h1>
+          <p className="admin-hero-sub">{t('rateLimits.subtitle', 'Per-group request budgets and recent block history')}</p>
+        </div>
+        <div className="admin-hero-actions">
           {totalBlocked > 0 ? (
-            <span className="flex items-center gap-1 text-amber-600 dark:text-amber-400">
-              <Warning weight="bold" className="w-4 h-4" />
+            <span className="flex items-center gap-1.5 text-xs font-medium text-amber-700 dark:text-amber-300 px-3 py-1.5 rounded-full bg-amber-100/70 dark:bg-amber-900/30">
+              <Warning weight="bold" className="w-3.5 h-3.5" />
               {t('rateLimits.blockedTotal', '{{count}} blocked (last hour)', { count: totalBlocked })}
             </span>
           ) : (
-            <span className="flex items-center gap-1 text-emerald-600 dark:text-emerald-400">
-              <ShieldCheck weight="bold" className="w-4 h-4" />
+            <span className="flex items-center gap-1.5 text-xs font-medium text-emerald-700 dark:text-emerald-300 px-3 py-1.5 rounded-full bg-emerald-100/70 dark:bg-emerald-900/30">
+              <ShieldCheck weight="bold" className="w-3.5 h-3.5" />
               {t('rateLimits.allClear', 'No blocked requests')}
             </span>
           )}
         </div>
-      </div>
+      </section>
 
       {/* Rate limit group cards */}
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">

--- a/parkhub-web/src/views/AdminRoles.tsx
+++ b/parkhub-web/src/views/AdminRoles.tsx
@@ -132,34 +132,31 @@ export function AdminRolesPage() {
 
   return (
     <div className="space-y-6">
-      {/* Header */}
-      <div className="flex items-center justify-between">
-        <div>
-          <h2 className="text-xl font-bold text-surface-900 dark:text-white flex items-center gap-2">
-            <ShieldCheck weight="duotone" className="w-6 h-6 text-primary-500" />
-            {t('rbac.title')}
-          </h2>
-          <p className="text-sm text-surface-500 dark:text-surface-400 mt-1">
-            {t('rbac.subtitle')}
-          </p>
+      {/* v11 SOTA hero — info tone (access control = security-critical). */}
+      <section className="admin-hero admin-hero--info">
+        <div className="admin-hero-left">
+          <div className="admin-hero-eyebrow">
+            <span className="admin-hero-dot" aria-hidden="true"></span>
+            <ShieldCheck weight="bold" className="w-3.5 h-3.5" />
+            ACCESS CONTROL
+          </div>
+          <h1 className="admin-hero-headline">{t('rbac.title')}</h1>
+          <p className="admin-hero-sub">{t('rbac.subtitle')}</p>
         </div>
-        <div className="flex items-center gap-2">
+        <div className="admin-hero-actions">
           <button
             onClick={() => setShowHelp(h => !h)}
-            className="p-2 rounded-lg text-surface-400 hover:bg-surface-100 dark:hover:bg-surface-800"
+            className="admin-hero-iconbtn"
             title={t('rbac.helpLabel')}
           >
-            <Question className="w-5 h-5" />
+            <Question className="w-4 h-4" />
           </button>
-          <button
-            onClick={() => { resetForm(); setShowForm(true); }}
-            className="flex items-center gap-2 px-4 py-2 bg-primary-600 text-white rounded-xl hover:bg-primary-700 transition-colors"
-          >
+          <button onClick={() => { resetForm(); setShowForm(true); }} className="admin-hero-action">
             <Plus className="w-4 h-4" />
             {t('rbac.createRole')}
           </button>
         </div>
-      </div>
+      </section>
 
       {/* Help tooltip */}
       <AnimatePresence>

--- a/parkhub-web/src/views/AdminSSO.tsx
+++ b/parkhub-web/src/views/AdminSSO.tsx
@@ -120,32 +120,35 @@ export function AdminSSOPage() {
 
   return (
     <div className="space-y-6 max-w-4xl">
-      {/* Header */}
-      <div className="flex items-center justify-between">
-        <div>
-          <h2 className="text-xl font-semibold text-surface-900 dark:text-surface-100 flex items-center gap-2">
-            <ShieldCheck size={24} weight="bold" className="text-primary-500" />
-            {t('sso.title')}
-          </h2>
-          <p className="text-sm text-surface-500 mt-1">{t('sso.subtitle')}</p>
+      {/* v11 SOTA hero — info tone (identity federation = security boundary). */}
+      <section className="admin-hero admin-hero--info">
+        <div className="admin-hero-left">
+          <div className="admin-hero-eyebrow">
+            <span className="admin-hero-dot" aria-hidden="true"></span>
+            <ShieldCheck weight="bold" className="w-3.5 h-3.5" />
+            {t('sso.eyebrow', 'IDENTITY FEDERATION')}
+          </div>
+          <h1 className="admin-hero-headline">{t('sso.title')}</h1>
+          <p className="admin-hero-sub">{t('sso.subtitle')}</p>
         </div>
-        <div className="flex items-center gap-2">
+        <div className="admin-hero-actions">
           <button
             onClick={() => setShowHelp(!showHelp)}
-            className="p-2 rounded-lg hover:bg-surface-100 dark:hover:bg-surface-800 text-surface-500"
+            className="admin-hero-iconbtn"
             aria-label={t('sso.helpLabel')}
+            title={t('sso.helpLabel')}
           >
-            <Question size={20} />
+            <Question className="w-4 h-4" />
           </button>
           <button
             onClick={() => { resetForm(); setShowForm(true); }}
-            className="flex items-center gap-2 px-4 py-2 rounded-lg bg-primary-500 text-white hover:bg-primary-600 transition-colors text-sm font-medium"
+            className="admin-hero-action"
           >
-            <Plus size={16} weight="bold" />
+            <Plus weight="bold" className="w-4 h-4" />
             {t('sso.addProvider')}
           </button>
         </div>
-      </div>
+      </section>
 
       {/* Help */}
       <AnimatePresence>

--- a/parkhub-web/src/views/AdminSettings.tsx
+++ b/parkhub-web/src/views/AdminSettings.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import { motion } from 'framer-motion';
-import { SpinnerGap, Check } from '@phosphor-icons/react';
+import { SpinnerGap, Check, GearSix } from '@phosphor-icons/react';
 import { api } from '../api/client';
 import { useTranslation } from 'react-i18next';
 import toast from 'react-hot-toast';
@@ -117,7 +117,18 @@ export function AdminSettingsPage() {
 
   return (
     <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} className="space-y-8">
-      <h2 className="text-xl font-semibold text-surface-900 dark:text-white">{t('admin.systemSettings')}</h2>
+      {/* v11 SOTA hero — amber tone (config requires deliberate caution). */}
+      <section className="admin-hero admin-hero--amber">
+        <div className="admin-hero-left">
+          <div className="admin-hero-eyebrow">
+            <span className="admin-hero-dot" aria-hidden="true"></span>
+            <GearSix weight="bold" className="w-3.5 h-3.5" />
+            SYSTEM CONFIG
+          </div>
+          <h1 className="admin-hero-headline">{t('admin.systemSettings')}</h1>
+          <p className="admin-hero-sub">{t('settings.subtitle', 'Booking rules, credits, and tenant policy')}</p>
+        </div>
+      </section>
 
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
         {/* Left column */}

--- a/parkhub-web/src/views/AdminZones.tsx
+++ b/parkhub-web/src/views/AdminZones.tsx
@@ -98,25 +98,27 @@ export function AdminZonesPage() {
 
   return (
     <div className="space-y-6">
-      {/* Header */}
-      <div className="flex items-center justify-between">
-        <div>
-          <h2 className="text-xl font-bold text-surface-900 dark:text-white flex items-center gap-2">
-            <MapTrifold weight="duotone" className="w-6 h-6 text-primary-500" />
-            {t('parkingZones.title')}
-          </h2>
-          <p className="text-sm text-surface-500 dark:text-surface-400 mt-1">
-            {t('parkingZones.subtitle')}
-          </p>
+      {/* v11 SOTA hero — emerald tone (spatial pricing = revenue lever). */}
+      <section className="admin-hero admin-hero--emerald">
+        <div className="admin-hero-left">
+          <div className="admin-hero-eyebrow">
+            <span className="admin-hero-dot" aria-hidden="true"></span>
+            <MapTrifold weight="bold" className="w-3.5 h-3.5" />
+            {t('parkingZones.eyebrow', 'SPATIAL PRICING')}
+          </div>
+          <h1 className="admin-hero-headline">{t('parkingZones.title')}</h1>
+          <p className="admin-hero-sub">{t('parkingZones.subtitle')}</p>
         </div>
-        <button
-          onClick={() => setShowHelp(h => !h)}
-          className="p-2 rounded-lg text-surface-400 hover:bg-surface-100 dark:hover:bg-surface-800"
-          title={t('parkingZones.helpLabel')}
-        >
-          <Question className="w-5 h-5" />
-        </button>
-      </div>
+        <div className="admin-hero-actions">
+          <button
+            onClick={() => setShowHelp(h => !h)}
+            className="admin-hero-iconbtn"
+            title={t('parkingZones.helpLabel')}
+          >
+            <Question className="w-4 h-4" />
+          </button>
+        </div>
+      </section>
 
       {/* Help */}
       <AnimatePresence>


### PR DESCRIPTION
## Summary
Continues the SOTA-2026 admin chrome rollout. After this batch the parkhub-web admin shell uses the v11 hero pattern on **19 of 24 pages**.

| Page | Tone | Eyebrow |
|------|------|---------|
| AdminAnalytics | emerald | USAGE & TRENDS |
| AdminDashboard | primary | OPERATIONS VIEW |
| AdminSettings  | amber   | SYSTEM CONFIG (+ \`GearSix\` import) |
| AdminRoles     | info    | ACCESS CONTROL |
| AdminSSO       | info    | IDENTITY FEDERATION |
| AdminZones     | emerald | SPATIAL PRICING |
| AdminDataMgmt  | amber   | BULK OPERATIONS |
| AdminRateLimits | amber  | API THROTTLE (+ status chip in hero-actions) |

Tone follows the page's risk profile — info=security boundary, amber=destructive/careful, emerald=revenue/insight, primary=ops view.

## Test plan
- [x] \`npx astro check\` — 0 errors / 0 warnings
- [x] lefthook + all pre-push gates green (cargo-test-fast, openapi-drift, osv-scanner, trivy-fs, types-drift, zizmor)
- [ ] Visual smoke once \`dist\` is rebuilt and reverse-proxied via parkhub-rust.test/admin

No behaviour changes — header markup only.

Remaining batch5 candidates: AdminPlugins, AdminWebhooks, AdminTranslations, AdminUpdates, AdminGraphQL.