### PR TITLE
design(admin): SOTA-2026 batch5 — Plugins+Webhooks+Translations+Updates (24/24 complete)

### DIFF
--- a/parkhub-web/src/views/AdminPlugins.tsx
+++ b/parkhub-web/src/views/AdminPlugins.tsx
@@ -124,25 +124,33 @@ export function AdminPluginsPage() {
 
   return (
     <div className="space-y-6">
-      {/* Header */}
-      <div className="flex items-center justify-between">
-        <div>
-          <h1 className="text-2xl font-bold text-surface-900 dark:text-white">
-            {t('plugins.title')}
-          </h1>
-          <p className="text-surface-500 dark:text-surface-400 mt-1">
-            {t('plugins.subtitle')}
-          </p>
+      {/* v11 SOTA hero — info tone (extension surface = expand cluster trust boundary). */}
+      <section className="admin-hero admin-hero--info">
+        <div className="admin-hero-left">
+          <div className="admin-hero-eyebrow">
+            <span className="admin-hero-dot" aria-hidden="true"></span>
+            <PuzzlePiece weight="bold" className="w-3.5 h-3.5" />
+            {t('plugins.eyebrow', 'EXTENSIONS')}
+          </div>
+          <h1 className="admin-hero-headline">{t('plugins.title')}</h1>
+          <p className="admin-hero-sub">{t('plugins.subtitle')}</p>
         </div>
-        <button
-          onClick={() => setShowHelp(!showHelp)}
-          className="p-2 rounded-lg hover:bg-surface-100 dark:hover:bg-surface-700"
-          aria-label={t('plugins.helpLabel')}
-          data-testid="plugins-help-btn"
-        >
-          <Question size={20} />
-        </button>
-      </div>
+        <div className="admin-hero-actions">
+          <span className="hidden sm:inline-flex items-center gap-1.5 text-xs font-medium text-surface-600 dark:text-surface-300 px-3 py-1.5 rounded-full bg-surface-100/70 dark:bg-surface-800/60" data-testid="plugins-counter">
+            <Lightning weight="bold" className="w-3.5 h-3.5" />
+            {enabled}/{total} {t('plugins.enabled', 'enabled')}
+          </span>
+          <button
+            onClick={() => setShowHelp(!showHelp)}
+            className="admin-hero-iconbtn"
+            aria-label={t('plugins.helpLabel')}
+            data-testid="plugins-help-btn"
+            title={t('plugins.helpLabel')}
+          >
+            <Question className="w-4 h-4" />
+          </button>
+        </div>
+      </section>
 
       {/* Help tooltip */}
       {showHelp && (

--- a/parkhub-web/src/views/AdminTranslations.tsx
+++ b/parkhub-web/src/views/AdminTranslations.tsx
@@ -209,37 +209,38 @@ export function AdminTranslationsPage() {
 
   return (
     <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} className="space-y-6">
-      {/* Header */}
-      <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3">
-        <div className="flex items-center gap-3">
-          <h2 className="text-xl font-semibold text-surface-900 dark:text-white flex items-center gap-2">
-            <Translate weight="fill" className="w-5 h-5 text-primary-600" />
-            {t('translations.admin.title')}
-          </h2>
+      {/* v11 SOTA hero — emerald tone (community-driven content moderation). */}
+      <section className="admin-hero admin-hero--emerald">
+        <div className="admin-hero-left">
+          <div className="admin-hero-eyebrow">
+            <span className="admin-hero-dot" aria-hidden="true"></span>
+            <Translate weight="bold" className="w-3.5 h-3.5" />
+            {t('translations.admin.eyebrow', 'LOCALE CURATION')}
+          </div>
+          <h1 className="admin-hero-headline">{t('translations.admin.title')}</h1>
+          <p className="admin-hero-sub">{t('translations.admin.subtitle', 'Review community translation proposals before they ship')}</p>
+        </div>
+        <div className="admin-hero-actions">
           {pendingCount > 0 && (
-            <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-semibold bg-amber-100 dark:bg-amber-900/30 text-amber-600 dark:text-amber-400 tabular-nums">
+            <span className="inline-flex items-center gap-1.5 text-xs font-semibold tabular-nums px-3 py-1.5 rounded-full bg-amber-100/80 dark:bg-amber-900/30 text-amber-700 dark:text-amber-300">
               {pendingCount} {t('translations.admin.pendingReview')}
             </span>
           )}
-        </div>
-        <div className="flex items-center gap-2">
           {pendingCount > 0 && (
             <>
-              <button onClick={() => handleBulkAction('approved')} className="btn btn-sm btn-secondary text-emerald-600">
+              <button onClick={() => handleBulkAction('approved')} className="admin-hero-iconbtn text-emerald-600 dark:text-emerald-400" title={t('translations.admin.approveAll')}>
                 <CheckCircle weight="bold" className="w-4 h-4" />
-                {t('translations.admin.approveAll')}
               </button>
-              <button onClick={() => handleBulkAction('rejected')} className="btn btn-sm btn-secondary text-red-600">
+              <button onClick={() => handleBulkAction('rejected')} className="admin-hero-iconbtn text-red-500 dark:text-red-400" title={t('translations.admin.rejectAll')}>
                 <XCircle weight="bold" className="w-4 h-4" />
-                {t('translations.admin.rejectAll')}
               </button>
             </>
           )}
-          <button onClick={loadProposals} className="btn btn-sm btn-ghost" aria-label={t('common.refresh')}>
+          <button onClick={loadProposals} className="admin-hero-iconbtn" aria-label={t('common.refresh')} title={t('common.refresh')}>
             <ArrowsClockwise weight="bold" className="w-4 h-4" />
           </button>
         </div>
-      </div>
+      </section>
 
       {/* Filters */}
       <div className="flex flex-col sm:flex-row gap-3">

--- a/parkhub-web/src/views/AdminUpdates.tsx
+++ b/parkhub-web/src/views/AdminUpdates.tsx
@@ -220,20 +220,26 @@ export function AdminUpdatesPage() {
 
   return (
     <div className="space-y-6">
-      {/* Header */}
-      <div className="flex items-center gap-3">
-        <div className="p-2 bg-primary-100 dark:bg-primary-900/30 rounded-lg">
-          <ArrowsClockwise weight="bold" className="w-5 h-5 text-primary-600 dark:text-primary-400" />
+      {/* v11 SOTA hero — amber tone (in-place upgrades carry rollback risk). */}
+      <section className="admin-hero admin-hero--amber">
+        <div className="admin-hero-left">
+          <div className="admin-hero-eyebrow">
+            <span className="admin-hero-dot" aria-hidden="true"></span>
+            <CloudArrowDown weight="bold" className="w-3.5 h-3.5" />
+            {t('updates.eyebrow', 'RELEASE CHANNEL')}
+          </div>
+          <h1 className="admin-hero-headline">{t('updates.title', 'System Updates')}</h1>
+          <p className="admin-hero-sub">{t('updates.subtitle', 'Manage application updates and versioning')}</p>
         </div>
-        <div>
-          <h2 className="text-lg font-bold text-surface-900 dark:text-white">
-            {t('updates.title', 'System Updates')}
-          </h2>
-          <p className="text-sm text-surface-500 dark:text-surface-400">
-            {t('updates.subtitle', 'Manage application updates and versioning')}
-          </p>
+        <div className="admin-hero-actions">
+          {versionInfo?.version && (
+            <span className="inline-flex items-center gap-1.5 text-xs font-medium tabular-nums px-3 py-1.5 rounded-full bg-surface-100/70 dark:bg-surface-800/60 text-surface-600 dark:text-surface-300" data-testid="hero-version">
+              <Info weight="bold" className="w-3.5 h-3.5" />
+              v{versionInfo.version}
+            </span>
+          )}
         </div>
-      </div>
+      </section>
 
       {/* Current Version Card */}
       <div className="bg-white dark:bg-surface-900 rounded-xl border border-surface-200 dark:border-surface-800 shadow-sm p-5" data-testid="version-card">

--- a/parkhub-web/src/views/AdminWebhooks.tsx
+++ b/parkhub-web/src/views/AdminWebhooks.tsx
@@ -150,24 +150,32 @@ export function AdminWebhooksPage() {
 
   return (
     <div className="space-y-6 max-w-4xl">
-      <div className="flex items-center justify-between">
-        <div>
-          <h2 className="text-xl font-semibold text-surface-900 dark:text-surface-100 flex items-center gap-2">
-            <WebhooksLogo size={24} weight="bold" className="text-primary-500" />
-            {t('webhooksV2.title')}
-          </h2>
-          <p className="text-sm text-surface-500 mt-1">{t('webhooksV2.subtitle')}</p>
+      {/* v11 SOTA hero — info tone (event egress = trust boundary, secrets in payloads). */}
+      <section className="admin-hero admin-hero--info">
+        <div className="admin-hero-left">
+          <div className="admin-hero-eyebrow">
+            <span className="admin-hero-dot" aria-hidden="true"></span>
+            <WebhooksLogo weight="bold" className="w-3.5 h-3.5" />
+            {t('webhooksV2.eyebrow', 'EVENT FAN-OUT')}
+          </div>
+          <h1 className="admin-hero-headline">{t('webhooksV2.title')}</h1>
+          <p className="admin-hero-sub">{t('webhooksV2.subtitle')}</p>
         </div>
-        <div className="flex items-center gap-2">
-          <button onClick={() => setShowHelp(!showHelp)} className="p-2 rounded-lg hover:bg-surface-100 dark:hover:bg-surface-800 text-surface-500" aria-label={t('webhooksV2.helpLabel')}>
-            <Question size={20} />
+        <div className="admin-hero-actions">
+          <button
+            onClick={() => setShowHelp(!showHelp)}
+            className="admin-hero-iconbtn"
+            aria-label={t('webhooksV2.helpLabel')}
+            title={t('webhooksV2.helpLabel')}
+          >
+            <Question className="w-4 h-4" />
           </button>
-          <button onClick={() => { resetForm(); setShowForm(true); }} className="flex items-center gap-2 px-4 py-2 rounded-lg bg-primary-500 text-white hover:bg-primary-600 text-sm font-medium">
-            <Plus size={16} weight="bold" />
+          <button onClick={() => { resetForm(); setShowForm(true); }} className="admin-hero-action">
+            <Plus weight="bold" className="w-4 h-4" />
             {t('webhooksV2.create')}
           </button>
         </div>
-      </div>
+      </section>
 
       <AnimatePresence>
         {showHelp && (


### PR DESCRIPTION
## Summary
Completes the SOTA-2026 admin chrome rollout. **All 24 admin pages now render with the v11 hero pattern.**

| Page | Tone | Eyebrow |
|------|------|---------|
| AdminPlugins      | info    | EXTENSIONS (+ enabled/total counter chip) |
| AdminWebhooks     | info    | EVENT FAN-OUT |
| AdminTranslations | emerald | LOCALE CURATION (+ pending-count chip) |
| AdminUpdates      | amber   | RELEASE CHANNEL (+ version chip) |

\`AdminGraphQL\` is **not** a page — only an external sidebar link to \`/api/v1/graphql/playground\` (verified in \`Admin.tsx:96\`), so it doesn't need its own hero.

Tone language (now consistent across all 24 pages):
- **info** → trust boundary or identity (Roles, SSO, Tenants, Plugins, Webhooks, Accessible)
- **amber** → hard-to-reverse / careful (Settings, Maintenance, DataMgmt, RateLimits, Updates)
- **emerald** → curation / insight / revenue (Analytics, Billing, Zones, Translations)
- **primary** → ops view (Dashboard, Users, Lots, Fleet, etc.)

## Test plan
- [x] \`npx astro check\` — 0 errors / 0 warnings
- [x] lefthook + pre-push gates green
- [ ] Visual smoke once \`dist\` is rebuilt and reverse-proxied via parkhub-rust.test/admin

No behaviour changes — header markup only.