### PR TITLE
design(admin): SOTA-2026 batch6 — Reports/Modules/ScheduledReports stragglers (true 26/26)

### DIFF
--- a/parkhub-web/src/views/AdminModules.tsx
+++ b/parkhub-web/src/views/AdminModules.tsx
@@ -24,6 +24,7 @@ import { type ModuleInfo } from '../api/client';
 import { useAuth } from '../context/AuthContext';
 import { useModuleToggle } from '../hooks/useModuleToggle';
 import { ConfigEditorModal } from '../components/ConfigEditorModal';
+import { PuzzlePiece } from '@phosphor-icons/react';
 
 const CATEGORY_ORDER = [
   'core',
@@ -294,19 +295,23 @@ export function AdminModulesPage() {
 
   return (
     <div className="p-6 space-y-6" data-testid="modules-dashboard">
-      <header className="flex items-center gap-4 flex-wrap">
-        <div>
-          <h1 className="text-2xl font-bold">{t('admin.modules.title', 'Modules')}</h1>
-          <p className="text-sm text-surface-600 dark:text-surface-400">
-            {t('admin.modules.subtitle', 'Feature modules compiled into this deployment.')}
-          </p>
+      {/* v11 SOTA hero — info tone (compiled feature surface = build-time decisions). */}
+      <section className="admin-hero admin-hero--info">
+        <div className="admin-hero-left">
+          <div className="admin-hero-eyebrow">
+            <span className="admin-hero-dot" aria-hidden="true"></span>
+            <PuzzlePiece weight="bold" className="w-3.5 h-3.5" />
+            {t('admin.modules.eyebrow', 'COMPILED FEATURES')}
+          </div>
+          <h1 className="admin-hero-headline">{t('admin.modules.title', 'Modules')}</h1>
+          <p className="admin-hero-sub">{t('admin.modules.subtitle', 'Feature modules compiled into this deployment.')}</p>
         </div>
-        <div className="ml-auto flex items-center gap-2 text-sm">
-          <span className="rounded-full bg-emerald-500/10 px-3 py-1 text-emerald-600 dark:text-emerald-400">
+        <div className="admin-hero-actions">
+          <span className="inline-flex items-center gap-1.5 text-xs font-medium tabular-nums px-3 py-1.5 rounded-full bg-emerald-500/10 text-emerald-700 dark:text-emerald-400">
             {enabledCount}/{total} {t('admin.modules.active', 'active')}
           </span>
         </div>
-      </header>
+      </section>
 
       <div className="flex flex-wrap gap-3 items-center">
         <input

--- a/parkhub-web/src/views/AdminReports.tsx
+++ b/parkhub-web/src/views/AdminReports.tsx
@@ -115,11 +115,21 @@ export function AdminReportsPage() {
 
   return (
     <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} className="space-y-8">
-      {/* Header */}
-      <div className="flex items-center justify-between">
-        <h2 className="text-xl font-semibold text-surface-900 dark:text-white">{t('admin.reports')}</h2>
-        <ExportButton />
-      </div>
+      {/* v11 SOTA hero — emerald tone (data + insight, paired with v11-meter stats below). */}
+      <section className="admin-hero admin-hero--emerald">
+        <div className="admin-hero-left">
+          <div className="admin-hero-eyebrow">
+            <span className="admin-hero-dot" aria-hidden="true"></span>
+            <CalendarCheck weight="bold" className="w-3.5 h-3.5" />
+            {t('admin.reportsEyebrow', 'BUSINESS METRICS')}
+          </div>
+          <h1 className="admin-hero-headline">{t('admin.reports')}</h1>
+          <p className="admin-hero-sub">{t('admin.reportsSubtitle', 'Booking volume, occupancy heatmaps, and revenue trends')}</p>
+        </div>
+        <div className="admin-hero-actions">
+          <ExportButton />
+        </div>
+      </section>
 
       {/* Stats Cards */}
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">

--- a/parkhub-web/src/views/AdminScheduledReports.tsx
+++ b/parkhub-web/src/views/AdminScheduledReports.tsx
@@ -155,35 +155,37 @@ export function AdminScheduledReportsPage() {
 
   return (
     <div className="space-y-6" data-testid="scheduled-reports-page">
-      {/* Header */}
-      <div className="flex items-center justify-between">
-        <div>
-          <h1 className="text-2xl font-bold text-surface-900 dark:text-white">
-            {t('scheduledReports.title')}
-          </h1>
-          <p className="text-surface-500 dark:text-surface-400 mt-1">
-            {t('scheduledReports.subtitle')}
-          </p>
+      {/* v11 SOTA hero — emerald tone (recurring report delivery, insight workflow). */}
+      <section className="admin-hero admin-hero--emerald">
+        <div className="admin-hero-left">
+          <div className="admin-hero-eyebrow">
+            <span className="admin-hero-dot" aria-hidden="true"></span>
+            <Clock weight="bold" className="w-3.5 h-3.5" />
+            {t('scheduledReports.eyebrow', 'AUTOMATED DELIVERY')}
+          </div>
+          <h1 className="admin-hero-headline">{t('scheduledReports.title')}</h1>
+          <p className="admin-hero-sub">{t('scheduledReports.subtitle')}</p>
         </div>
-        <div className="flex items-center gap-2">
+        <div className="admin-hero-actions">
           <button
             onClick={() => setShowHelp(!showHelp)}
-            className="p-2 rounded-lg hover:bg-surface-100 dark:hover:bg-surface-700"
+            className="admin-hero-iconbtn"
             aria-label={t('scheduledReports.helpLabel')}
             data-testid="reports-help-btn"
+            title={t('scheduledReports.helpLabel')}
           >
-            <Question size={20} />
+            <Question className="w-4 h-4" />
           </button>
           <button
             onClick={() => { resetForm(); setShowForm(true); }}
-            className="flex items-center gap-2 px-4 py-2 rounded-lg bg-primary-500 text-white hover:bg-primary-600"
+            className="admin-hero-action"
             data-testid="create-schedule-btn"
           >
-            <Plus size={16} />
+            <Plus weight="bold" className="w-4 h-4" />
             {t('scheduledReports.create')}
           </button>
         </div>
-      </div>
+      </section>
 
       {/* Help */}
       <AnimatePresence>


### PR DESCRIPTION
## Summary
Smoke-test of the rebuilt dist after #498 found 3 admin pages whose **header** was never migrated to the v11 hero pattern, even though most of their surrounding chrome was already SOTA. This batch closes that gap.

| Page | Tone | Eyebrow | Notes |
|------|------|---------|-------|
| AdminReports | emerald | BUSINESS METRICS | StatCards were already on \`v11-meter\` from #490; only the header was still on the legacy \`<h2>\`. ExportButton survives in \`admin-hero-actions\`. |
| AdminModules | info | COMPILED FEATURES | Added \`PuzzlePiece\` import — file had no phosphor dep yet. enabled/total chip survives in \`admin-hero-actions\`. |
| AdminScheduledReports | emerald | AUTOMATED DELIVERY | Help + Create buttons survive. |

After this PR **every admin page in parkhub-web renders with the v11 hero** — 26/26 (24 distinct ops surfaces + 2 reports surfaces). \`AdminGraphQL\` is intentionally sidebar-link-only (\`Admin.tsx:96\`) and has no page of its own.

## Test plan
- [x] \`npx astro check\` — 0 errors / 0 warnings
- [x] lefthook + pre-push gates green
- [ ] After merge: \`npm run build\` and re-grep \`admin-hero\` across \`dist/Admin*.js\` → expect 26/26