### PR TITLE
design(user): SOTA-2026 v11 hero on Profile + Settings + Bookings (UF batch1)

### DIFF
--- a/parkhub-web/src/styles/global.css
+++ b/parkhub-web/src/styles/global.css
@@ -882,7 +882,16 @@ body {
 }
 
 @media (max-width: 1024px) {
-  .admin-hero { display: none; } /* Mobile uses the slim sticky header above */
+  .admin-hero { display: none; } /* Admin pages hide hero on mobile — slim sticky header is shown above */
+  /* User-facing pages opt in to a mobile-visible hero by adding .page-hero. */
+  .admin-hero.page-hero {
+    display: grid;
+    grid-template-columns: 1fr;
+    padding: 16px 20px;
+    gap: 12px;
+  }
+  .admin-hero.page-hero .admin-hero-headline { font-size: 22px; }
+  .admin-hero.page-hero .admin-hero-sub { font-size: 13px; }
 }
 @media (max-width: 1280px) {
   .admin-hero { grid-template-columns: 1fr; }

--- a/parkhub-web/src/views/Bookings.tsx
+++ b/parkhub-web/src/views/Bookings.tsx
@@ -131,15 +131,23 @@ export function BookingsPage() {
   return (
     <AnimatePresence mode="wait">
     <motion.div key="bookings-loaded" variants={container} initial="hidden" animate="show" className="space-y-6">
-      <motion.div variants={item} className="flex flex-col sm:flex-row sm:items-center justify-between gap-3">
-        <div>
-          <h1 className="text-2xl font-bold text-surface-900 dark:text-white">{t('bookings.title')}</h1>
-          <p className="text-sm text-surface-500 dark:text-surface-400 mt-1">{t('bookings.subtitle')}</p>
+      {/* v11 SOTA hero — primary tone, page-hero variant (visible on mobile). */}
+      <motion.section variants={item} className="admin-hero page-hero">
+        <div className="admin-hero-left">
+          <div className="admin-hero-eyebrow">
+            <span className="admin-hero-dot" aria-hidden="true"></span>
+            <Clock weight="bold" className="w-3.5 h-3.5" />
+            {t('bookings.eyebrow', 'MY RESERVATIONS')}
+          </div>
+          <h1 className="admin-hero-headline">{t('bookings.title')}</h1>
+          <p className="admin-hero-sub">{t('bookings.subtitle')}</p>
         </div>
-        <button onClick={loadData} className="btn btn-secondary self-start sm:self-auto">
-          <ArrowClockwise weight="bold" className="w-4 h-4" /> {t('common.refresh')}
-        </button>
-      </motion.div>
+        <div className="admin-hero-actions">
+          <button onClick={loadData} className="admin-hero-iconbtn" title={t('common.refresh')} aria-label={t('common.refresh')}>
+            <ArrowClockwise weight="bold" className="w-4 h-4" />
+          </button>
+        </div>
+      </motion.section>
 
       {/* Filters */}
       <motion.div variants={item} className="bg-white/80 dark:bg-surface-900/80 backdrop-blur-lg border border-surface-200/60 dark:border-surface-800/60 rounded-xl p-4">

--- a/parkhub-web/src/views/Profile.tsx
+++ b/parkhub-web/src/views/Profile.tsx
@@ -131,10 +131,18 @@ export function ProfilePage() {
 
   return (
     <motion.div variants={container} initial="hidden" animate="show" className="max-w-3xl mx-auto space-y-6">
-      <motion.div variants={item}>
-        <h1 className="text-2xl font-bold text-surface-900 dark:text-white">{t('profile.title', 'Profil')}</h1>
-        <p className="text-sm text-surface-500 dark:text-surface-400 mt-1">{t('profile.subtitle', 'Pers\u00f6nliche Daten verwalten')}</p>
-      </motion.div>
+      {/* v11 SOTA hero \u2014 primary tone, page-hero variant (visible on mobile). */}
+      <motion.section variants={item} className="admin-hero page-hero">
+        <div className="admin-hero-left">
+          <div className="admin-hero-eyebrow">
+            <span className="admin-hero-dot" aria-hidden="true"></span>
+            <UserCircle weight="bold" className="w-3.5 h-3.5" />
+            {t('profile.eyebrow', 'ACCOUNT')}
+          </div>
+          <h1 className="admin-hero-headline">{t('profile.title', 'Profil')}</h1>
+          <p className="admin-hero-sub">{t('profile.subtitle', 'Pers\u00f6nliche Daten verwalten')}</p>
+        </div>
+      </motion.section>
 
       {/* Profile card */}
       <motion.div variants={item} className="bg-white dark:bg-surface-900 rounded-xl border border-surface-200 dark:border-surface-800 p-6">

--- a/parkhub-web/src/views/Settings.tsx
+++ b/parkhub-web/src/views/Settings.tsx
@@ -82,17 +82,21 @@ export function SettingsPage() {
 
   return (
     <div className="max-w-4xl mx-auto p-4 sm:p-6 pb-20">
-      <header className="mb-5">
-        <h1
-          className="text-2xl sm:text-3xl font-bold text-surface-900 dark:text-white"
-          style={{ letterSpacing: '-0.02em' }}
-        >
-          {t('settings.title', 'Settings')}
-        </h1>
-        <p className="text-sm text-surface-500 dark:text-surface-400 mt-1">
-          {t('settings.subtitle', 'Control how ParkHub looks, feels, and behaves — for you and your workspace.')}
-        </p>
-      </header>
+      {/* v11 SOTA hero — primary tone, page-hero variant. User-level settings
+          (workspace + appearance), distinct from amber AdminSettings. */}
+      <section className="admin-hero page-hero mb-5">
+        <div className="admin-hero-left">
+          <div className="admin-hero-eyebrow">
+            <span className="admin-hero-dot" aria-hidden="true"></span>
+            <User weight="bold" className="w-3.5 h-3.5" />
+            {t('settings.eyebrow', 'PREFERENCES')}
+          </div>
+          <h1 className="admin-hero-headline">{t('settings.title', 'Settings')}</h1>
+          <p className="admin-hero-sub">
+            {t('settings.subtitle', 'Control how ParkHub looks, feels, and behaves — for you and your workspace.')}
+          </p>
+        </div>
+      </section>
 
       {/* Scope switcher */}
       <div


### PR DESCRIPTION
## Summary
After admin chrome reached 26/26, the user opened \`parkhub-php.test/admin\` (legacy Laravel app) and confused it for the new chrome being broken. Two fixes here:

1. \`parkhub-local-sites\` router now hard-redirects \`parkhub-php.test/admin*\` → \`parkhub-rust.test/admin*\` (out-of-repo, in /var/home/florian/dev/parkhub-local-sites — already live via systemd).
2. **Start the user-facing v11 chrome rollout** so the pages a normal user actually visits feel as polished as the admin shell.

## What this PR ships (UF batch1)
| Page | Tone | Eyebrow |
|------|------|---------|
| Profile  | primary | ACCOUNT (\`UserCircle\`) |
| Settings | primary | PREFERENCES (\`User\`) — distinct from amber AdminSettings (system-level config) |
| Bookings | primary | MY RESERVATIONS (\`Clock\`) — refresh button moved to \`admin-hero-iconbtn\` |

**Dashboard NOT migrated** — it already has a custom time-of-day greeting hero that is more personal than the generic v11 chrome.

## New CSS: \`.page-hero\` modifier
The existing \`.admin-hero\` hides itself below 1024px (admin pages use a slim sticky header on mobile). User-facing pages can't do that — users on mobile still need a header. So \`.page-hero\` is a modifier that keeps the chrome visible on mobile with single-column layout + smaller padding.

\`\`\`css
@media (max-width: 1024px) {
  .admin-hero { display: none; }
  .admin-hero.page-hero { display: grid; grid-template-columns: 1fr; padding: 16px 20px; }
}
\`\`\`

Admin pages keep \`<section className=\"admin-hero ...\">\`. User pages add \`page-hero\`: \`<section className=\"admin-hero page-hero\">\`.

## Test plan
- [x] \`npx astro check\` — 0 errors / 0 warnings
- [x] lefthook + pre-push gates green
- [ ] Browser smoke after merge: visit /profile, /settings, /bookings on desktop + mobile

Remaining UF batches: Vehicles, Calendar, Map, Credits, Absences, Team, etc. Tracked as task #43.