### PR TITLE
design(user): SOTA-2026 v11 hero on Book + Calendar + MapView (UF batch2 — 6/24)

### DIFF
--- a/parkhub-web/src/views/Book.tsx
+++ b/parkhub-web/src/views/Book.tsx
@@ -132,19 +132,26 @@ export function BookPage() {
     <div className="space-y-6">
       {confirmed && <ConfettiOverlay />}
 
-      <div className="flex items-center gap-3">
-        {step > 1 && (
-          <button onClick={goBack} className="btn btn-ghost btn-sm p-1.5" aria-label={t('common.back', 'Go back')}>
-            <ArrowLeft weight="bold" className="w-5 h-5" aria-hidden="true" />
-          </button>
-        )}
-        <div>
-          <h1 className="text-2xl font-bold text-surface-900 dark:text-white" style={{ letterSpacing: '-0.02em' }}>
-            {t('book.title')}
-          </h1>
-          <p className="text-sm text-surface-500 dark:text-surface-400 mt-0.5">{t(`book.step${step}Label`)}</p>
+      {/* v11 SOTA hero — primary tone, page-hero variant. Step subtitle changes
+          per booking step; back button lives in hero-actions when applicable. */}
+      <section className="admin-hero page-hero">
+        <div className="admin-hero-left">
+          <div className="admin-hero-eyebrow">
+            <span className="admin-hero-dot" aria-hidden="true"></span>
+            <MapPin weight="bold" className="w-3.5 h-3.5" />
+            {t('book.eyebrow', 'RESERVE A SPOT')}
+          </div>
+          <h1 className="admin-hero-headline">{t('book.title')}</h1>
+          <p className="admin-hero-sub">{t(`book.step${step}Label`)}</p>
         </div>
-      </div>
+        {step > 1 && (
+          <div className="admin-hero-actions">
+            <button onClick={goBack} className="admin-hero-iconbtn" aria-label={t('common.back', 'Go back')} title={t('common.back', 'Go back')}>
+              <ArrowLeft weight="bold" className="w-4 h-4" aria-hidden="true" />
+            </button>
+          </div>
+        )}
+      </section>
 
       {/* Step indicator — animated progress */}
       <nav aria-label={t('book.progress', 'Booking progress')} className="relative">

--- a/parkhub-web/src/views/Calendar.tsx
+++ b/parkhub-web/src/views/Calendar.tsx
@@ -235,29 +235,41 @@ export function CalendarPage() {
 
   return (
     <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} className="space-y-6">
-      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
-        <h1 className="text-2xl font-bold text-surface-900 dark:text-white">{t('calendar.title', 'Kalender')}</h1>
-        <div className="flex items-center gap-2 self-start sm:self-auto">
-          <button onClick={() => setShowHelp(!showHelp)} className="p-2 rounded-xl hover:bg-surface-100 dark:hover:bg-surface-800 text-surface-500 min-w-[44px] min-h-[44px] flex items-center justify-center" title={t('calendarDrag.helpLabel')}>
-            <Question size={20} />
+      {/* v11 SOTA hero — primary tone, page-hero variant. Help + Subscribe live
+          in hero-actions; the prev/month/next month nav row sits below. */}
+      <section className="admin-hero page-hero">
+        <div className="admin-hero-left">
+          <div className="admin-hero-eyebrow">
+            <span className="admin-hero-dot" aria-hidden="true"></span>
+            <CalendarBlank weight="bold" className="w-3.5 h-3.5" />
+            {t('calendar.eyebrow', 'SCHEDULE')}
+          </div>
+          <h1 className="admin-hero-headline">{t('calendar.title', 'Kalender')}</h1>
+          <p className="admin-hero-sub">{t('calendar.subtitle', 'See and manage your reservations across the month')}</p>
+        </div>
+        <div className="admin-hero-actions">
+          <button onClick={() => setShowHelp(!showHelp)} className="admin-hero-iconbtn" title={t('calendarDrag.helpLabel')}>
+            <Question className="w-4 h-4" />
           </button>
           <button
             onClick={handleSubscribe}
             disabled={generatingToken}
             aria-label={t('calendar.subscribe', 'Subscribe to Calendar')}
-            className="flex items-center gap-1.5 px-3 py-2 text-xs font-medium rounded-xl bg-primary-600 text-white hover:bg-primary-700 transition-colors disabled:opacity-50 min-h-[44px]"
+            className="admin-hero-action disabled:opacity-50"
           >
             <LinkSimple weight="bold" className="w-4 h-4" aria-hidden="true" />
             {t('calendar.subscribe', 'Subscribe')}
           </button>
-          <button onClick={prevMonth} aria-label={t('calendar.previousMonth', 'Previous month')} className="p-2 rounded-xl hover:bg-surface-100 dark:hover:bg-surface-800 transition-colors min-w-[44px] min-h-[44px] flex items-center justify-center">
-            <CaretLeft weight="bold" className="w-5 h-5 text-surface-600 dark:text-surface-400" aria-hidden="true" />
-          </button>
-          <span aria-live="polite" className="text-sm font-medium text-surface-700 dark:text-surface-300 min-w-[140px] text-center">{monthLabel}</span>
-          <button onClick={nextMonth} aria-label={t('calendar.nextMonth', 'Next month')} className="p-2 rounded-xl hover:bg-surface-100 dark:hover:bg-surface-800 transition-colors min-w-[44px] min-h-[44px] flex items-center justify-center">
-            <CaretRight weight="bold" className="w-5 h-5 text-surface-600 dark:text-surface-400" aria-hidden="true" />
-          </button>
         </div>
+      </section>
+      <div className="flex items-center gap-2 justify-end">
+        <button onClick={prevMonth} aria-label={t('calendar.previousMonth', 'Previous month')} className="p-2 rounded-xl hover:bg-surface-100 dark:hover:bg-surface-800 transition-colors min-w-[44px] min-h-[44px] flex items-center justify-center">
+          <CaretLeft weight="bold" className="w-5 h-5 text-surface-600 dark:text-surface-400" aria-hidden="true" />
+        </button>
+        <span aria-live="polite" className="text-sm font-medium text-surface-700 dark:text-surface-300 min-w-[140px] text-center">{monthLabel}</span>
+        <button onClick={nextMonth} aria-label={t('calendar.nextMonth', 'Next month')} className="p-2 rounded-xl hover:bg-surface-100 dark:hover:bg-surface-800 transition-colors min-w-[44px] min-h-[44px] flex items-center justify-center">
+          <CaretRight weight="bold" className="w-5 h-5 text-surface-600 dark:text-surface-400" aria-hidden="true" />
+        </button>
       </div>
 
       {/* Calendar grid */}

--- a/parkhub-web/src/views/MapView.tsx
+++ b/parkhub-web/src/views/MapView.tsx
@@ -124,15 +124,18 @@ export function MapViewPage() {
 
   return (
     <motion.div variants={container} initial="hidden" animate="show" className="space-y-6">
-      <motion.div variants={item}>
-        <h1 className="text-2xl font-bold text-surface-900 dark:text-white flex items-center gap-3">
-          <MapPin weight="fill" className="w-7 h-7 text-primary-500" />
-          {t('map.title')}
-        </h1>
-        <p className="text-surface-500 dark:text-surface-400 mt-1">
-          {t('map.subtitle')}
-        </p>
-      </motion.div>
+      {/* v11 SOTA hero — primary tone, page-hero variant. */}
+      <motion.section variants={item} className="admin-hero page-hero">
+        <div className="admin-hero-left">
+          <div className="admin-hero-eyebrow">
+            <span className="admin-hero-dot" aria-hidden="true"></span>
+            <MapPin weight="bold" className="w-3.5 h-3.5" />
+            {t('map.eyebrow', 'LIVE AVAILABILITY')}
+          </div>
+          <h1 className="admin-hero-headline">{t('map.title')}</h1>
+          <p className="admin-hero-sub">{t('map.subtitle')}</p>
+        </div>
+      </motion.section>
 
       {markers.length === 0 ? (
         <motion.div variants={item} className="card p-12 text-center">


### PR DESCRIPTION
## Summary
Continues the user-facing chrome rollout from #500. Three of the most visible non-admin surfaces:

| Page | Tone | Eyebrow | Notes |
|------|------|---------|-------|
| Book     | primary | RESERVE A SPOT (\`MapPin\`)   | \`book.step{N}Label\` becomes the hero sub. Back button moved into \`admin-hero-actions\` when \`step > 1\`. |
| Calendar | primary | SCHEDULE (\`CalendarBlank\`)  | Help + Subscribe live in \`admin-hero-actions\`; prev/month/next nav row now sits below the hero (cleaner than the single dense row before). |
| MapView  | primary | LIVE AVAILABILITY (\`MapPin\`) | Replaces the inline-icon h1. |

All use the \`page-hero\` modifier from #500 so they render on mobile too.

After this PR: **6 of 24** user-facing routed pages on v11 chrome (Profile/Settings/Bookings from #500 + Book/Calendar/MapView here).

## Test plan
- [x] \`npx astro check\` — 0 errors / 0 warnings
- [x] lefthook + pre-push gates green
- [ ] Browser smoke after merge: visit /book, /calendar, /map on desktop + mobile

Remaining UF batches: Vehicles + Credits + Absences (UF3), Team + TeamLeaderboard + Notifications + Favorites (UF4), Visitors + EVCharging + ParkingHistory + SwapRequests + QRCheckIn + GuestPass (UF5).