### PR TITLE
design(user): SOTA-2026 v11 hero on Vehicles + Credits + Absences (UF batch3 — 9/24)

### DIFF
--- a/parkhub-web/src/views/Absences.tsx
+++ b/parkhub-web/src/views/Absences.tsx
@@ -123,19 +123,24 @@ export function AbsencesPage() {
 
   return (
     <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} className="space-y-6">
-      {/* Header */}
-      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
-        <div>
-          <h1 className="text-2xl font-bold text-surface-900 dark:text-white flex items-center gap-3">
-            <Calendar weight="fill" className="w-7 h-7 text-primary-600" />
-            {t('absences.title', 'Abwesenheiten')}
-          </h1>
-          <p className="text-surface-500 dark:text-surface-400 mt-1">{t('absences.subtitle', 'Homeoffice, Urlaub & mehr verwalten')}</p>
+      {/* v11 SOTA hero — primary tone, page-hero variant. */}
+      <section className="admin-hero page-hero">
+        <div className="admin-hero-left">
+          <div className="admin-hero-eyebrow">
+            <span className="admin-hero-dot" aria-hidden="true"></span>
+            <Calendar weight="bold" className="w-3.5 h-3.5" />
+            {t('absences.eyebrow', 'TIME OFF')}
+          </div>
+          <h1 className="admin-hero-headline">{t('absences.title', 'Abwesenheiten')}</h1>
+          <p className="admin-hero-sub">{t('absences.subtitle', 'Homeoffice, Urlaub & mehr verwalten')}</p>
         </div>
-        <button onClick={() => setShowAdd(true)} className="btn btn-primary">
-          <Plus weight="bold" className="w-4 h-4" /> {t('absences.addAbsence', 'Eintragen')}
-        </button>
-      </div>
+        <div className="admin-hero-actions">
+          <button onClick={() => setShowAdd(true)} className="admin-hero-action">
+            <Plus weight="bold" className="w-4 h-4" />
+            {t('absences.addAbsence', 'Eintragen')}
+          </button>
+        </div>
+      </section>
 
       <div className="grid grid-cols-1 lg:grid-cols-5 gap-6">
         {/* Calendar */}

--- a/parkhub-web/src/views/Credits.tsx
+++ b/parkhub-web/src/views/Credits.tsx
@@ -41,14 +41,18 @@ export function CreditsPage() {
 
   return (
     <motion.div variants={container} initial="hidden" animate="show" className="space-y-8">
-      {/* Header */}
-      <motion.div variants={item}>
-        <h1 className="text-2xl font-bold text-surface-900 dark:text-white flex items-center gap-3">
-          <Coins weight="fill" className="w-7 h-7 text-accent-500" />
-          {t('credits.title')}
-        </h1>
-        <p className="text-surface-500 dark:text-surface-400 mt-1">{t('credits.subtitle')}</p>
-      </motion.div>
+      {/* v11 SOTA hero — primary tone, page-hero variant. */}
+      <motion.section variants={item} className="admin-hero page-hero">
+        <div className="admin-hero-left">
+          <div className="admin-hero-eyebrow">
+            <span className="admin-hero-dot" aria-hidden="true"></span>
+            <Coins weight="bold" className="w-3.5 h-3.5" />
+            {t('credits.eyebrow', 'BOOKING WALLET')}
+          </div>
+          <h1 className="admin-hero-headline">{t('credits.title')}</h1>
+          <p className="admin-hero-sub">{t('credits.subtitle')}</p>
+        </div>
+      </motion.section>
 
       {/* Balance display */}
       <motion.div variants={item}>

--- a/parkhub-web/src/views/Vehicles.tsx
+++ b/parkhub-web/src/views/Vehicles.tsx
@@ -112,15 +112,24 @@ export function VehiclesPage() {
   return (
     <AnimatePresence mode="wait">
     <motion.div key="vehicles-loaded" variants={container} initial="hidden" animate="show" className="space-y-8">
-      <motion.div variants={item} className="flex flex-col sm:flex-row sm:items-center justify-between gap-3">
-        <div>
-          <h1 className="text-2xl font-bold text-surface-900 dark:text-white">{t('vehicles.title', 'Meine Fahrzeuge')}</h1>
-          <p className="text-surface-500 dark:text-surface-400 mt-1">{t('vehicles.subtitle', 'Fahrzeuge verwalten')}</p>
+      {/* v11 SOTA hero \u2014 primary tone, page-hero variant. */}
+      <motion.section variants={item} className="admin-hero page-hero">
+        <div className="admin-hero-left">
+          <div className="admin-hero-eyebrow">
+            <span className="admin-hero-dot" aria-hidden="true"></span>
+            <Car weight="bold" className="w-3.5 h-3.5" />
+            {t('vehicles.eyebrow', 'MY FLEET')}
+          </div>
+          <h1 className="admin-hero-headline">{t('vehicles.title', 'Meine Fahrzeuge')}</h1>
+          <p className="admin-hero-sub">{t('vehicles.subtitle', 'Fahrzeuge verwalten')}</p>
         </div>
-        <button onClick={() => setShowForm(true)} className="btn btn-primary self-start sm:self-auto">
-          <Plus weight="bold" className="w-4 h-4" /> {t('vehicles.add', 'Hinzuf\u00fcgen')}
-        </button>
-      </motion.div>
+        <div className="admin-hero-actions">
+          <button onClick={() => setShowForm(true)} className="admin-hero-action">
+            <Plus weight="bold" className="w-4 h-4" />
+            {t('vehicles.add', 'Hinzuf\u00fcgen')}
+          </button>
+        </div>
+      </motion.section>
 
       {/* Add vehicle modal */}
       <AnimatePresence>


### PR DESCRIPTION
## Summary
User-management trio:
- **Vehicles** — primary, "MY FLEET" + \`Car\`. Add button → \`admin-hero-action\`.
- **Credits** — primary, "BOOKING WALLET" + \`Coins\`.
- **Absences** — primary, "TIME OFF" + \`Calendar\`. Add button → \`admin-hero-action\`.

After this PR: **9 of 24** user-facing routed pages on v11 chrome.

## Test plan
- [x] \`npx astro check\` — 0 errors / 0 warnings
- [x] lefthook + pre-push gates green
- [ ] Browser smoke after merge: visit /vehicles, /credits, /absences

Remaining batches: UF4 (Team + TeamLeaderboard + Notifications + Favorites) and UF5 (Visitors + EVCharging + ParkingHistory + SwapRequests + QRCheckIn + GuestPass).