### PR TITLE
design(user): SOTA-2026 v11 hero on Team + Leaderboard + Notifications + Favorites (UF batch4 — 13/24)

### DIFF
--- a/parkhub-web/src/views/Favorites.tsx
+++ b/parkhub-web/src/views/Favorites.tsx
@@ -88,17 +88,25 @@ export function FavoritesPage() {
   return (
     <AnimatePresence mode="wait">
       <motion.div key="favorites-loaded" variants={container} initial="hidden" animate="show" className="space-y-8">
-        <motion.div variants={item} className="flex flex-col sm:flex-row sm:items-center justify-between gap-3">
-          <div>
-            <h1 className="text-2xl font-bold text-surface-900 dark:text-white">{t('favorites.title')}</h1>
-            <p className="text-surface-500 dark:text-surface-400 mt-1">{t('favorites.subtitle')}</p>
+        {/* v11 SOTA hero — primary tone, page-hero variant. Count chip in hero-actions. */}
+        <motion.section variants={item} className="admin-hero page-hero">
+          <div className="admin-hero-left">
+            <div className="admin-hero-eyebrow">
+              <span className="admin-hero-dot" aria-hidden="true"></span>
+              <Star weight="bold" className="w-3.5 h-3.5" />
+              {t('favorites.eyebrow', 'SAVED LOTS')}
+            </div>
+            <h1 className="admin-hero-headline">{t('favorites.title')}</h1>
+            <p className="admin-hero-sub">{t('favorites.subtitle')}</p>
           </div>
           {favorites.length > 0 && (
-            <span className="text-sm text-surface-500 dark:text-surface-400">
-              {t('favorites.count', { count: favorites.length })}
-            </span>
+            <div className="admin-hero-actions">
+              <span className="inline-flex items-center text-xs font-medium px-3 py-1.5 rounded-full bg-surface-100/70 dark:bg-surface-800/60 text-surface-600 dark:text-surface-300 tabular-nums">
+                {t('favorites.count', { count: favorites.length })}
+              </span>
+            </div>
           )}
-        </motion.div>
+        </motion.section>
 
         {enriched.length === 0 ? (
           <motion.div variants={item} className="bg-white dark:bg-surface-900 rounded-2xl border border-surface-200 dark:border-surface-800 p-16 text-center">

--- a/parkhub-web/src/views/Notifications.tsx
+++ b/parkhub-web/src/views/Notifications.tsx
@@ -95,26 +95,31 @@ export function NotificationsPage() {
 
   return (
     <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} className="space-y-8">
-      {/* Header */}
-      <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
-        <div>
-          <h1 className="text-2xl font-bold text-surface-900 dark:text-white">{t('notifications.title')}</h1>
-          <p className="text-surface-500 dark:text-surface-400 mt-1">
+      {/* v11 SOTA hero — primary tone, page-hero variant. Refresh + Mark-all-read live in hero-actions. */}
+      <section className="admin-hero page-hero">
+        <div className="admin-hero-left">
+          <div className="admin-hero-eyebrow">
+            <span className="admin-hero-dot" aria-hidden="true"></span>
+            <Bell weight="bold" className="w-3.5 h-3.5" />
+            {t('notifications.eyebrow', 'INBOX')}
+          </div>
+          <h1 className="admin-hero-headline">{t('notifications.title')}</h1>
+          <p className="admin-hero-sub">
             {unreadCount > 0 ? t('notifications.unreadCount', { count: unreadCount }) : t('notifications.allRead')}
           </p>
         </div>
-        <div className="flex items-center gap-2">
-          <button onClick={loadNotifications} className="btn btn-secondary">
-            <ArrowClockwise weight="bold" className="w-4 h-4" /> {t('common.refresh')}
+        <div className="admin-hero-actions">
+          <button onClick={loadNotifications} className="admin-hero-iconbtn" title={t('common.refresh')} aria-label={t('common.refresh')}>
+            <ArrowClockwise weight="bold" className="w-4 h-4" />
           </button>
           {unreadCount > 0 && (
-            <button onClick={markAllAsRead} disabled={isPending} className="btn btn-primary">
+            <button onClick={markAllAsRead} disabled={isPending} className="admin-hero-action disabled:opacity-50">
               {isPending ? <SpinnerGap weight="bold" className="w-4 h-4 animate-spin" /> : <Check weight="bold" className="w-4 h-4" />}
               {t('notifications.markAllRead')}
             </button>
           )}
         </div>
-      </div>
+      </section>
 
       {/* List */}
       {optimisticNotifs.length === 0 ? (

--- a/parkhub-web/src/views/Team.tsx
+++ b/parkhub-web/src/views/Team.tsx
@@ -50,13 +50,18 @@ export function TeamPage() {
 
   return (
     <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} className="space-y-8">
-      <div>
-        <h1 className="text-2xl font-bold text-surface-900 dark:text-white flex items-center gap-3">
-          <Users weight="fill" className="w-7 h-7 text-primary-600" />
-          {t('team.title', 'Team')}
-        </h1>
-        <p className="text-surface-500 dark:text-surface-400 mt-1">{t('team.subtitle', 'Abwesenheiten im Team')}</p>
-      </div>
+      {/* v11 SOTA hero — primary tone, page-hero variant. */}
+      <section className="admin-hero page-hero">
+        <div className="admin-hero-left">
+          <div className="admin-hero-eyebrow">
+            <span className="admin-hero-dot" aria-hidden="true"></span>
+            <Users weight="bold" className="w-3.5 h-3.5" />
+            {t('team.eyebrow', 'CO-WORKERS')}
+          </div>
+          <h1 className="admin-hero-headline">{t('team.title', 'Team')}</h1>
+          <p className="admin-hero-sub">{t('team.subtitle', 'Abwesenheiten im Team')}</p>
+        </div>
+      </section>
 
       {/* Today */}
       <section>

--- a/parkhub-web/src/views/TeamLeaderboard.tsx
+++ b/parkhub-web/src/views/TeamLeaderboard.tsx
@@ -165,11 +165,18 @@ export function TeamLeaderboardPage() {
     return (
       <motion.div initial={{ opacity: 0, y: 12 }} animate={{ opacity: 1, y: 0 }} className="space-y-6" data-testid="leaderboard-page">
         <div>
-          <h1 className="text-2xl font-bold text-surface-900 dark:text-white flex items-center gap-3">
-            <Trophy weight="fill" className="w-7 h-7 text-yellow-500" />
-            {t('leaderboard.title', 'Team Leaderboard')}
-          </h1>
-          <p className="text-surface-500 dark:text-surface-400 mt-1">{t('leaderboard.subtitle', 'See how your team is doing')}</p>
+          {/* v11 SOTA hero — primary tone, page-hero variant (renders on both empty + loaded states). */}
+          <section className="admin-hero page-hero">
+            <div className="admin-hero-left">
+              <div className="admin-hero-eyebrow">
+                <span className="admin-hero-dot" aria-hidden="true"></span>
+                <Trophy weight="bold" className="w-3.5 h-3.5" />
+                {t('leaderboard.eyebrow', 'TEAM RANKINGS')}
+              </div>
+              <h1 className="admin-hero-headline">{t('leaderboard.title', 'Team Leaderboard')}</h1>
+              <p className="admin-hero-sub">{t('leaderboard.subtitle', 'See how your team is doing')}</p>
+            </div>
+          </section>
         </div>
         <div className="bg-white dark:bg-surface-900 rounded-2xl border border-surface-200 dark:border-surface-800 p-12 text-center" data-testid="empty-state">
           <Trophy weight="light" className="w-12 h-12 text-surface-200 dark:text-surface-700 mx-auto mb-3" />


### PR DESCRIPTION
## Summary
Social/comms quartet:

| Page | Tone | Eyebrow | Notes |
|------|------|---------|-------|
| Team             | primary | CO-WORKERS (\`Users\`) | |
| TeamLeaderboard  | primary | TEAM RANKINGS (\`Trophy\`) | \`replace_all\` used since the same h1+p block ships in both empty and loaded states. |
| Notifications    | primary | INBOX (\`Bell\`) | Refresh + Mark-all-read buttons → \`admin-hero-actions\`. |
| Favorites        | primary | SAVED LOTS (\`Star\`) | Count chip survives in \`admin-hero-actions\`. |

After this PR: **13 of 24** user-facing routed pages on v11 chrome — past the halfway mark.

## Test plan
- [x] \`npx astro check\` — 0 errors / 0 warnings
- [x] lefthook + pre-push gates green
- [ ] Browser smoke after merge: visit /team, /leaderboard, /notifications, /favorites

Remaining: UF5 (Visitors + EVCharging + ParkingHistory + SwapRequests + QRCheckIn + GuestPass).