### PR TITLE
design(user): SOTA-2026 v11 hero on 6 feature pages (UF batch5 — 19/24)

### DIFF
--- a/parkhub-web/src/views/EVCharging.tsx
+++ b/parkhub-web/src/views/EVCharging.tsx
@@ -123,21 +123,26 @@ export function EVChargingPage() {
 
   return (
     <motion.div initial={{ opacity: 0, y: 12 }} animate={{ opacity: 1, y: 0 }} className="space-y-6">
-      <div className="flex items-center justify-between">
-        <div>
-          <h1 className="text-2xl font-bold text-surface-900 dark:text-white flex items-center gap-2">
-            <Lightning weight="duotone" className="w-7 h-7 text-yellow-500" />
-            {t('evCharging.title')}
-            <button onClick={() => setShowHelp(!showHelp)} className="text-surface-400 hover:text-primary-500" aria-label="Help">
-              <Question weight="fill" className="w-5 h-5" />
-            </button>
-          </h1>
-          <p className="text-surface-500 dark:text-surface-400 mt-1">{t('evCharging.subtitle')}</p>
+      {/* v11 SOTA hero — primary tone, page-hero variant. Help + lot-select live in admin-hero-actions. */}
+      <section className="admin-hero page-hero">
+        <div className="admin-hero-left">
+          <div className="admin-hero-eyebrow">
+            <span className="admin-hero-dot" aria-hidden="true"></span>
+            <Lightning weight="bold" className="w-3.5 h-3.5" />
+            {t('evCharging.eyebrow', 'CHARGING SESSIONS')}
+          </div>
+          <h1 className="admin-hero-headline">{t('evCharging.title')}</h1>
+          <p className="admin-hero-sub">{t('evCharging.subtitle')}</p>
         </div>
-        <select value={selectedLot} onChange={e => setSelectedLot(e.target.value)} className="rounded-xl bg-surface-50 dark:bg-surface-800 border border-surface-200 dark:border-surface-700 px-3 py-2 text-sm">
-          {lots.map(lot => <option key={lot.id} value={lot.id}>{lot.name}</option>)}
-        </select>
-      </div>
+        <div className="admin-hero-actions">
+          <button onClick={() => setShowHelp(!showHelp)} className="admin-hero-iconbtn" aria-label="Help" title="Help">
+            <Question className="w-4 h-4" />
+          </button>
+          <select value={selectedLot} onChange={e => setSelectedLot(e.target.value)} className="rounded-lg bg-surface-50 dark:bg-surface-800 border border-surface-200 dark:border-surface-700 px-3 py-1.5 text-sm">
+            {lots.map(lot => <option key={lot.id} value={lot.id}>{lot.name}</option>)}
+          </select>
+        </div>
+      </section>
 
       {showHelp && (
         <motion.div initial={{ opacity: 0, height: 0 }} animate={{ opacity: 1, height: 'auto' }} className="bg-yellow-50 dark:bg-yellow-900/20 border border-yellow-200 dark:border-yellow-800 rounded-xl p-4 text-sm text-yellow-700 dark:text-yellow-300">

--- a/parkhub-web/src/views/GuestPass.tsx
+++ b/parkhub-web/src/views/GuestPass.tsx
@@ -203,20 +203,24 @@ export function GuestPassPage() {
 
   return (
     <motion.div initial={{ opacity: 0, y: 12 }} animate={{ opacity: 1, y: 0 }} className="space-y-6" data-testid="guest-pass-page">
-      {/* Header */}
-      <div className="flex items-center justify-between">
-        <div>
-          <h1 className="text-2xl font-bold text-surface-900 dark:text-white flex items-center gap-2">
-            <UserPlus weight="duotone" className="w-7 h-7 text-primary-500" />
-            {t('guestBooking.title')}
-          </h1>
-          <p className="text-surface-500 dark:text-surface-400 mt-1">{t('guestBooking.subtitle')}</p>
+      {/* v11 SOTA hero — primary tone, page-hero variant. Create button in hero-actions. */}
+      <section className="admin-hero page-hero">
+        <div className="admin-hero-left">
+          <div className="admin-hero-eyebrow">
+            <span className="admin-hero-dot" aria-hidden="true"></span>
+            <UserPlus weight="bold" className="w-3.5 h-3.5" />
+            {t('guestBooking.eyebrow', 'GUEST CODES')}
+          </div>
+          <h1 className="admin-hero-headline">{t('guestBooking.title')}</h1>
+          <p className="admin-hero-sub">{t('guestBooking.subtitle')}</p>
         </div>
-        <button onClick={() => { setShowForm(true); setCreatedPass(null); }} className="btn btn-primary flex items-center gap-2" data-testid="create-guest-btn">
-          <UserPlus weight="bold" className="w-4 h-4" />
-          {t('guestBooking.create')}
-        </button>
-      </div>
+        <div className="admin-hero-actions">
+          <button onClick={() => { setShowForm(true); setCreatedPass(null); }} className="admin-hero-action" data-testid="create-guest-btn">
+            <UserPlus weight="bold" className="w-4 h-4" />
+            {t('guestBooking.create')}
+          </button>
+        </div>
+      </section>
 
       {/* Created pass card */}
       <AnimatePresence>

--- a/parkhub-web/src/views/ParkingHistory.tsx
+++ b/parkhub-web/src/views/ParkingHistory.tsx
@@ -68,19 +68,21 @@ export function ParkingHistoryPage() {
   return (
     <AnimatePresence mode="wait">
       <motion.div key="history" variants={container} initial="hidden" animate="show" className="space-y-8">
-        {/* Header */}
-        <motion.div variants={item} className="flex flex-col sm:flex-row sm:items-center justify-between gap-3">
-          <div className="flex items-center gap-3">
-            <div className="w-10 h-10 rounded-xl bg-primary-100 dark:bg-primary-900/30 flex items-center justify-center">
-              <ClockCounterClockwise weight="fill" className="w-5 h-5 text-primary-600 dark:text-primary-400" />
+        {/* v11 SOTA hero — primary tone, page-hero variant. */}
+        <motion.section variants={item} className="admin-hero page-hero">
+          <div className="admin-hero-left">
+            <div className="admin-hero-eyebrow">
+              <span className="admin-hero-dot" aria-hidden="true"></span>
+              <ClockCounterClockwise weight="bold" className="w-3.5 h-3.5" />
+              {t('history.eyebrow', 'PARKING ARCHIVE')}
             </div>
-            <div>
-              <h1 className="text-2xl font-bold text-surface-900 dark:text-white">{t('history.title')}</h1>
-              <p className="text-surface-500 dark:text-surface-400 mt-0.5">{t('history.subtitle')}</p>
-            </div>
+            <h1 className="admin-hero-headline">{t('history.title')}</h1>
+            <p className="admin-hero-sub">{t('history.subtitle')}</p>
           </div>
-          <OnboardingHint id="parking-history" message={t('history.help')} />
-        </motion.div>
+          <div className="admin-hero-actions">
+            <OnboardingHint id="parking-history" message={t('history.help')} />
+          </div>
+        </motion.section>
 
         {/* Stats Cards */}
         {stats && (

--- a/parkhub-web/src/views/QRCheckIn.tsx
+++ b/parkhub-web/src/views/QRCheckIn.tsx
@@ -162,19 +162,23 @@ export function QRCheckInPage() {
 
   return (
     <motion.div variants={stagger} initial="hidden" animate="show" className="space-y-6 max-w-lg mx-auto">
-      {/* Header */}
-      <motion.div variants={fadeUp} className="flex items-center justify-between">
-        <div className="flex items-center gap-3">
-          <QrCode weight="duotone" className="w-7 h-7 text-primary-500" />
-          <div>
-            <h1 className="text-2xl font-bold text-surface-900 dark:text-white">{t('checkin.title')}</h1>
-            <p className="text-sm text-surface-500 dark:text-surface-400 mt-0.5">{t('checkin.subtitle')}</p>
+      {/* v11 SOTA hero — primary tone, page-hero variant. Refresh in hero-actions. */}
+      <motion.section variants={fadeUp} className="admin-hero page-hero">
+        <div className="admin-hero-left">
+          <div className="admin-hero-eyebrow">
+            <span className="admin-hero-dot" aria-hidden="true"></span>
+            <QrCode weight="bold" className="w-3.5 h-3.5" />
+            {t('checkin.eyebrow', 'CHECK-IN')}
           </div>
+          <h1 className="admin-hero-headline">{t('checkin.title')}</h1>
+          <p className="admin-hero-sub">{t('checkin.subtitle')}</p>
         </div>
-        <button onClick={loadData} className="btn btn-secondary btn-sm">
-          <ArrowClockwise weight="bold" className="w-4 h-4" />
-        </button>
-      </motion.div>
+        <div className="admin-hero-actions">
+          <button onClick={loadData} className="admin-hero-iconbtn" title={t('common.refresh')} aria-label={t('common.refresh')}>
+            <ArrowClockwise weight="bold" className="w-4 h-4" />
+          </button>
+        </div>
+      </motion.section>
 
       {/* No active booking */}
       {!booking && (

--- a/parkhub-web/src/views/SwapRequests.tsx
+++ b/parkhub-web/src/views/SwapRequests.tsx
@@ -144,24 +144,27 @@ export function SwapRequestsPage() {
   return (
     <div className="space-y-6">
       <motion.div variants={stagger} initial="hidden" animate="show" className="space-y-6">
-        {/* Header */}
-        <motion.div variants={fadeUp} className="flex flex-col sm:flex-row sm:items-center justify-between gap-3">
-          <div className="flex items-center gap-3">
-            <Swap weight="duotone" className="w-7 h-7 text-primary-500" />
-            <div>
-              <h1 className="text-2xl font-bold text-surface-900 dark:text-white">{t('swap.title')}</h1>
-              <p className="text-sm text-surface-500 dark:text-surface-400 mt-0.5">{t('swap.subtitle')}</p>
+        {/* v11 SOTA hero — primary tone, page-hero variant. Refresh + Create in hero-actions. */}
+        <motion.section variants={fadeUp} className="admin-hero page-hero">
+          <div className="admin-hero-left">
+            <div className="admin-hero-eyebrow">
+              <span className="admin-hero-dot" aria-hidden="true"></span>
+              <Swap weight="bold" className="w-3.5 h-3.5" />
+              {t('swap.eyebrow', 'SHIFT TRADE')}
             </div>
+            <h1 className="admin-hero-headline">{t('swap.title')}</h1>
+            <p className="admin-hero-sub">{t('swap.subtitle')}</p>
           </div>
-          <div className="flex items-center gap-2 self-start sm:self-auto">
-            <button onClick={loadData} className="btn btn-secondary">
-              <ArrowClockwise weight="bold" className="w-4 h-4" /> {t('common.refresh')}
+          <div className="admin-hero-actions">
+            <button onClick={loadData} className="admin-hero-iconbtn" title={t('common.refresh')} aria-label={t('common.refresh')}>
+              <ArrowClockwise weight="bold" className="w-4 h-4" />
             </button>
-            <button onClick={() => setShowModal(true)} className="btn btn-primary">
-              <Plus weight="bold" className="w-4 h-4" /> {t('swap.create')}
+            <button onClick={() => setShowModal(true)} className="admin-hero-action">
+              <Plus weight="bold" className="w-4 h-4" />
+              {t('swap.create')}
             </button>
           </div>
-        </motion.div>
+        </motion.section>
 
         {/* Request list */}
         {requests.length === 0 ? (

--- a/parkhub-web/src/views/Visitors.tsx
+++ b/parkhub-web/src/views/Visitors.tsx
@@ -139,19 +139,21 @@ export function VisitorsPage() {
 
   return (
     <motion.div initial={{ opacity: 0, y: 12 }} animate={{ opacity: 1, y: 0 }} className="space-y-6">
-      {/* Header */}
-      <div className="flex items-center justify-between">
-        <div>
-          <h1 className="text-2xl font-bold text-surface-900 dark:text-white flex items-center gap-2">
-            <UserPlus weight="duotone" className="w-7 h-7 text-primary-500" />
-            {t('visitors.title')}
-            <button onClick={() => setShowHelp(!showHelp)} className="text-surface-400 hover:text-primary-500 transition-colors" aria-label="Help">
-              <Question weight="fill" className="w-5 h-5" />
-            </button>
-          </h1>
-          <p className="text-surface-500 dark:text-surface-400 mt-1">{t('visitors.subtitle')}</p>
+      {/* v11 SOTA hero — primary tone, page-hero variant. Help + viewMode toggle + Register live in admin-hero-actions. */}
+      <section className="admin-hero page-hero">
+        <div className="admin-hero-left">
+          <div className="admin-hero-eyebrow">
+            <span className="admin-hero-dot" aria-hidden="true"></span>
+            <UserPlus weight="bold" className="w-3.5 h-3.5" />
+            {t('visitors.eyebrow', 'GUEST INVITES')}
+          </div>
+          <h1 className="admin-hero-headline">{t('visitors.title')}</h1>
+          <p className="admin-hero-sub">{t('visitors.subtitle')}</p>
         </div>
-        <div className="flex items-center gap-2">
+        <div className="admin-hero-actions">
+          <button onClick={() => setShowHelp(!showHelp)} className="admin-hero-iconbtn" aria-label="Help" title="Help">
+            <Question className="w-4 h-4" />
+          </button>
           {isAdmin && (
             <div className="flex rounded-lg overflow-hidden border border-surface-200 dark:border-surface-700">
               <button
@@ -164,12 +166,12 @@ export function VisitorsPage() {
               >{t('visitors.allVisitors')}</button>
             </div>
           )}
-          <button onClick={() => setShowForm(true)} className="btn-primary flex items-center gap-2">
+          <button onClick={() => setShowForm(true)} className="admin-hero-action">
             <UserPlus weight="bold" className="w-4 h-4" />
             {t('visitors.register')}
           </button>
         </div>
-      </div>
+      </section>
 
       {/* Help tooltip */}
       {showHelp && (


### PR DESCRIPTION
## Summary
Final feature-rich batch of the user-facing chrome rollout. After this lands, the chrome covers every "real" user surface in parkhub-web.

| Page | Tone | Eyebrow | Notes |
|------|------|---------|-------|
| Visitors       | primary | GUEST INVITES (\`UserPlus\`)              | Help + viewMode toggle + Register all moved into \`admin-hero-actions\`. |
| EVCharging     | primary | CHARGING SESSIONS (\`Lightning\`)         | Help + lot selector in hero-actions. |
| ParkingHistory | primary | PARKING ARCHIVE (\`ClockCounterClockwise\`) | OnboardingHint moved into hero-actions. |
| SwapRequests   | primary | SHIFT TRADE (\`Swap\`)                    | Refresh + Create in hero-actions. |
| QRCheckIn      | primary | CHECK-IN (\`QrCode\`)                     | Refresh in hero-actions. |
| GuestPass      | primary | GUEST CODES (\`UserPlus\`)                | Create in hero-actions. |

After this PR: **19 of 24** user-facing routed pages on v11 chrome.

The remaining 5 are intentional skips:
- **Dashboard** — has its own personalized time-of-day greeting hero
- **Login, Register, ForgotPassword, Welcome** — full-screen auth layouts, the standard sidebar+content chrome doesn't fit

## Test plan
- [x] \`npx astro check\` — 0 errors / 0 warnings
- [x] lefthook + pre-push gates green
- [ ] Browser smoke after merge: visit /visitors, /ev, /history, /swap, /checkin, /guest