### PR TITLE
chore(qa): close 2 SOTA-2026 a11y/perf gaps — WCAG 2.2 tags + Lighthouse INP threshold

### DIFF
--- a/parkhub-web/e2e/v5-a11y.spec.ts
+++ b/parkhub-web/e2e/v5-a11y.spec.ts
@@ -31,7 +31,7 @@ test.describe('v5 a11y — WCAG 2.1 AA', () => {
       await openV5(page, screen);
 
       const results = await new AxeBuilder({ page })
-        .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'])
+        .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'wcag22a', 'wcag22aa'])
         .disableRules(['color-contrast'])
         .analyze();
 

--- a/parkhub-web/lighthouserc.json
+++ b/parkhub-web/lighthouserc.json
@@ -9,7 +9,8 @@
     "assert": {
       "assertions": {
         "categories:accessibility": ["error", {"minScore": 0.8}],
-        "categories:best-practices": ["warn", {"minScore": 0.8}]
+        "categories:best-practices": ["warn", {"minScore": 0.8}],
+        "interaction-to-next-paint": ["warn", {"maxNumericValue": 200}]
       }
     }
   }


### PR DESCRIPTION
## Summary
Audit of the local CI/CD posture found 2 real high-priority gaps:

1. **axe-core WCAG 2.2 tags missing** — `parkhub-web/e2e/v5-a11y.spec.ts` was running `withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'])`. axe-core 4.5+ ships WCAG 2.2 rules but they only fire when the tags are explicitly enabled. Missing SCs: **2.4.11** (focus-not-obscured), **2.5.7** (dragging movements), **2.5.8** (target-size 24×24). Fix: add `'wcag22a', 'wcag22aa'`.
2. **Lighthouse INP threshold absent** — `interaction-to-next-paint` replaced FID as a Core Web Vital in 2024 and is first-class in Lighthouse v12. Fix: add `"interaction-to-next-paint": ["warn", {"maxNumericValue": 200}]` (Google's "good" threshold).

The audit's third high-priority finding (`cosign verify --type spdx`) is already correct in our config (`.github/workflows/cosign-verify.yml:116` uses `--type spdxjson`).

## Test plan
- [x] `npx astro check` — 0 errors / 0 warnings
- [x] lefthook + pre-push gates green
- [ ] Next nightly Lighthouse run will report INP measurements
- [ ] Next axe-core run on PRs will catch any 2.2-only violations