### PR TITLE
feat(local-ci): change-gated local container image scan — PR-B / Slice 4 of 6

### DIFF
--- a/.github/scripts/fop-local-ci.sh
+++ b/.github/scripts/fop-local-ci.sh
@@ -102,6 +102,7 @@ diff_touch_ts_export=0
 diff_touch_workflows=0
 diff_touch_php=0
 diff_touch_e2e=0
+diff_touch_image=0
 
 compute_diff_paths() {
   if [[ "${FOP_LOCAL_CI_NO_DIFF_AWARE:-}" == "1" ]] || [[ "$profile" != "pr" ]]; then
@@ -166,10 +167,13 @@ compute_diff_paths() {
   if grep -qE '^e2e/|^playwright\.config\.(ts|js|mjs|cjs)$' <<<"$diff_paths"; then
     diff_touch_e2e=1
   fi
+  if grep -qE '^(Dockerfile|Containerfile.*|Cargo\.lock|parkhub-web/package-lock\.json)$' <<<"$diff_paths"; then
+    diff_touch_image=1
+  fi
 
-  printf 'ℹ diff-aware (vs %s): rust=%d frontend=%d ts_export=%d workflows=%d php=%d e2e=%d (%d files)\n' \
+  printf 'ℹ diff-aware (vs %s): rust=%d frontend=%d ts_export=%d workflows=%d php=%d e2e=%d image=%d (%d files)\n' \
     "$base_ref" "$diff_touch_rust" "$diff_touch_frontend" "$diff_touch_ts_export" \
-    "$diff_touch_workflows" "$diff_touch_php" "$diff_touch_e2e" "$(wc -l <<<"$diff_paths")"
+    "$diff_touch_workflows" "$diff_touch_php" "$diff_touch_e2e" "$diff_touch_image" "$(wc -l <<<"$diff_paths")"
 }
 
 # ─── pre-push hook result re-use (opt-in via FOP_LOCAL_CI_REUSE_PREPUSH=1) ───
@@ -510,6 +514,24 @@ fi
 # ─── Stage 7: cd profile extras ──────────────────────────────────────────────
 if [[ "$profile" == "cd" ]]; then
   run_step_heavy "release image preflight" "cargo test --locked --package parkhub-common --all-targets && cargo test --locked --package parkhub-server --no-default-features --features headless --all-targets"
+fi
+
+# ─── Stage 7b: container image vulnerability scan (cd, or Dockerfile touched on full) ───
+# Mirrors .github/workflows/security.yml trivy-image + grype-image jobs (which
+# only run post-publish on main). Locally we build a fresh image and scan it.
+# Stamp-cached on Dockerfile + Cargo.lock + parkhub-web/package-lock.json SHA
+# so we don't rebuild across pushes that don't touch image inputs.
+image_scan_should_run=0
+[[ "$profile" == "cd" ]] && image_scan_should_run=1
+[[ "$profile" == "full" ]] && (( diff_touch_image )) && image_scan_should_run=1
+if (( image_scan_should_run )); then
+  if [[ -x scripts/local-image-scan.sh ]]; then
+    # The script gracefully skips if podman/trivy/grype is missing, so we
+    # don't need to gate on tool presence here.
+    run_step_heavy "container image scan (build + trivy image + grype)" "./scripts/local-image-scan.sh"
+  else
+    skip_step "container image scan" "scripts/local-image-scan.sh missing"
+  fi
 fi
 
 # ─── Stage 8: trivy filesystem scan ─────────────────────────────────────────

--- a/scripts/local-image-scan.sh
+++ b/scripts/local-image-scan.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# Local container image vulnerability scan — mirrors the GHA security.yml
+# trivy-image + grype-image jobs (which only run post-publish on main).
+#
+# Mechanism:
+#   1. Compute a stable input hash from Dockerfile + Cargo.lock +
+#      parkhub-web/package-lock.json.
+#   2. If `.fop/image-scan-validated-<hash>.stamp` exists, skip (cached).
+#   3. Otherwise: podman build → trivy image → grype image, fail on critical.
+#   4. On success, write the stamp.
+#
+# Usage:
+#   scripts/local-image-scan.sh [--force] [--no-cache]
+#
+# Env:
+#   FOP_IMAGE_SCAN_TAG     image tag (default: parkhub-local:ci-<hash[0:10]>)
+#   FOP_IMAGE_SCAN_DIR     stamp dir (default: .fop)
+#
+# Skips gracefully if podman, trivy, or grype is missing on PATH.
+
+set -euo pipefail
+
+force=0
+no_cache=""
+for arg in "$@"; do
+  case "$arg" in
+    --force) force=1 ;;
+    --no-cache) no_cache="--no-cache" ;;
+    -h|--help)
+      sed -n '2,/^$/p' "$0" | sed 's/^# \?//'
+      exit 0
+      ;;
+    *) echo "Unknown arg: $arg" >&2; exit 2 ;;
+  esac
+done
+
+# Compute input hash deterministically across the 3 files that drive image
+# content. If any is missing, the missing component is hashed as empty so the
+# stamp varies when a file appears later.
+hash_input() {
+  for f in Dockerfile Cargo.lock parkhub-web/package-lock.json; do
+    if [[ -f "$f" ]]; then
+      sha256sum "$f"
+    else
+      echo "0000000000000000000000000000000000000000000000000000000000000000  $f (missing)"
+    fi
+  done | sha256sum | awk '{print $1}'
+}
+
+input_hash=$(hash_input)
+short_hash=${input_hash:0:10}
+stamp_dir="${FOP_IMAGE_SCAN_DIR:-.fop}"
+stamp_file="$stamp_dir/image-scan-validated-$short_hash.stamp"
+image_tag="${FOP_IMAGE_SCAN_TAG:-parkhub-local:ci-$short_hash}"
+
+if [[ -f "$stamp_file" ]] && (( ! force )); then
+  echo "✓ image scan skipped (stamp present: $stamp_file)"
+  echo "  image-input hash: $input_hash"
+  exit 0
+fi
+
+# Tool availability — skip stage entirely if podman missing (most common case
+# in CI runners that already validated images upstream).
+need_podman=0
+need_trivy=0
+need_grype=0
+command -v podman >/dev/null 2>&1 || need_podman=1
+command -v trivy >/dev/null 2>&1 || need_trivy=1
+command -v grype >/dev/null 2>&1 || need_grype=1
+
+if (( need_podman + need_trivy + need_grype > 0 )); then
+  echo "⊘ image scan skipped — missing tools:"
+  (( need_podman )) && echo "    podman not on PATH (install: dnf install podman)"
+  (( need_trivy )) && echo "    trivy not on PATH (install: https://aquasecurity.github.io/trivy/)"
+  (( need_grype )) && echo "    grype not on PATH (install: https://github.com/anchore/grype#installation)"
+  exit 0
+fi
+
+mkdir -p "$stamp_dir"
+
+# Build the image. --network=host is required under Bazzite Flatpak sandbox
+# (Podman default rootless networking conflicts with the sandbox).
+echo "▶ podman build $image_tag (input hash $short_hash)"
+podman build $no_cache --network=host -t "$image_tag" . >&2
+
+# Trivy image scan — same severity + ignorefile as the GHA workflow.
+echo "▶ trivy image $image_tag (CRITICAL,HIGH; .trivyignore filters applied)"
+trivy_args=(
+  image --quiet
+  --scanners=vuln,secret
+  --severity=CRITICAL,HIGH
+  --exit-code=1
+)
+[[ -f .trivyignore ]] && trivy_args+=(--ignorefile .trivyignore)
+trivy "${trivy_args[@]}" "$image_tag"
+
+# Grype image scan — defense-in-depth, fail-on critical.
+echo "▶ grype $image_tag (defense-in-depth, fail-on critical)"
+grype "$image_tag" --fail-on critical --quiet
+
+# All checks passed — write stamp.
+{
+  echo "image-input hash: $input_hash"
+  echo "image tag:        $image_tag"
+  echo "validated at:     $(date -u +%FT%TZ)"
+  echo "trivy version:    $(trivy --version 2>&1 | head -1)"
+  echo "grype version:    $(grype version 2>&1 | grep -i ^version | head -1)"
+} > "$stamp_file"
+
+echo "✓ image scan passed; stamp written to $stamp_file"


### PR DESCRIPTION
## Summary
**Slice 4 of 6** — adds local container image scan that mirrors `.github/workflows/security.yml` `trivy-image` + `grype-image` jobs (which currently only run post-publish on main). Locally we build a fresh image and scan it.

## Trigger
- `cd` profile: always runs.
- `full` profile: runs only when diff touches `Dockerfile`, `Containerfile.*`, `Cargo.lock`, or `parkhub-web/package-lock.json`.

## Stamp cache (no wasteful rebuilds)
- **Hash inputs**: `sha256sum Dockerfile Cargo.lock parkhub-web/package-lock.json` → combined `sha256sum`.
- **Stamp file**: `.fop/image-scan-validated-<hash[0:10]>.stamp` (already gitignored).
- If stamp present, scan is skipped silently.
- `--force` overrides; `--no-cache` passes through to `podman build`.

## Pipeline (in `scripts/local-image-scan.sh`)
1. Compute input hash deterministically (works even if files missing).
2. Tool-presence check (skip stage if podman/trivy/grype missing — same contributor-friendly pattern as `trivy-fs` and `osv-scanner` stages).
3. `podman build --network=host -t parkhub-local:ci-<hash> .` (host network required under Bazzite Flatpak sandbox per CLAUDE.md).
4. `trivy image --severity CRITICAL,HIGH` (`.trivyignore` filters applied).
5. `grype --fail-on critical` (defense-in-depth; different DB than trivy).
6. Write stamp on success with versions + timestamp for forensics.

## fop-local-ci.sh integration (Stage 7b, ~14 LOC)
- New `diff_touch_image` flag.
- `diff-aware` printf line extended to log `image=N`.
- Stage 7b runs `run_step_heavy` (queues through `fop build batch-medium`).

## Roadmap
- ✅ PR-A (#512, merged) — yamllint + typos + helm-validate + cargo-audit + cargo-geiger.
- ✅ PR-B (this) — change-gated local image scan.
- **PR-C (next)** — Lighthouse local runner + `--background` flag + distinct `fop/local-ci/full` attestation context.

## Test plan
- [x] `bash -n` on both scripts — clean
- [ ] After merge: `fop ci run --gate cd` (or manual `./scripts/local-image-scan.sh`) — verify image build + trivy + grype + stamp write