### PR TITLE
feat(local-ci): Lighthouse + --background flag (PR-C / Slices 5+6, ladder complete)

### DIFF
--- a/.github/scripts/fop-local-ci.sh
+++ b/.github/scripts/fop-local-ci.sh
@@ -3,9 +3,14 @@ set -euo pipefail
 
 usage() {
   cat <<'EOF'
-Usage: .github/scripts/fop-local-ci.sh [--profile pr|full|cd] [--dry-run] [--post-status]
+Usage: .github/scripts/fop-local-ci.sh [--profile pr|full|cd] [--dry-run] [--post-status] [--background]
 
 Runs ParkHub's local-first CI through fop's build queue. The optional
+--background runs the gate in a detached subshell, logs to .fop/reports/
+local-ci-<profile>-<sha>-bg.log, returns immediately. Combine with
+--post-status for fire-and-forget background "full" runs that publish
+their own commit status context (fop/local-ci/full) when complete.
+
 --post-status flag publishes the commit status context for the selected
 profile. The GitHub PR attestation gate expects this exact command:
 
@@ -43,6 +48,7 @@ EOF
 profile="pr"
 dry_run=0
 post_status=0
+background=0
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -58,6 +64,10 @@ while [[ $# -gt 0 ]]; do
       post_status=1
       shift
       ;;
+    --background)
+      background=1
+      shift
+      ;;
     -h|--help)
       usage
       exit 0
@@ -69,6 +79,31 @@ while [[ $# -gt 0 ]]; do
       ;;
   esac
 done
+
+# ─── --background: re-exec self in detached subshell, log to file ───────────
+# When set, the rest of the run happens in a background subshell so the
+# developer's terminal is freed immediately. The post_commit_status mechanism
+# fires when the background run completes, posting the result via PAT.
+# Caller sees: PID + log path + immediate exit 0.
+if (( background )); then
+  background=0  # avoid recursion in the re-exec'd child
+  repo_root_for_bg="$(git rev-parse --show-toplevel)"
+  bg_log_dir="$repo_root_for_bg/.fop/reports"
+  mkdir -p "$bg_log_dir"
+  bg_sha="$(git rev-parse HEAD)"
+  bg_log="$bg_log_dir/local-ci-${profile}-${bg_sha:0:8}-bg.log"
+  # Re-build args without --background.
+  bg_args=("--profile" "$profile")
+  (( dry_run )) && bg_args+=("--dry-run")
+  (( post_status )) && bg_args+=("--post-status")
+  echo "▶ fop-local-ci backgrounded: profile=$profile log=$bg_log"
+  nohup "$0" "${bg_args[@]}" >"$bg_log" 2>&1 < /dev/null &
+  bg_pid=$!
+  disown 2>/dev/null || true
+  echo "  PID=$bg_pid sha=${bg_sha:0:8}"
+  echo "  watch: tail -f $bg_log"
+  exit 0
+fi
 
 case "$profile" in
   pr|full|cd) ;;
@@ -583,6 +618,23 @@ if command -v osv-scanner >/dev/null 2>&1; then
   run_step "osv-scanner (supply-chain)" "osv-scanner scan source --recursive --config=osv-scanner.toml ."
 else
   skip_step "osv-scanner" "osv-scanner not on PATH (install: https://google.github.io/osv-scanner/installation/)"
+fi
+
+# ─── Stage 10b: Lighthouse CI (perf + a11y; full+cd profiles, frontend touched) ───
+# Mirrors .github/workflows/lighthouse.yml. Skipped if MemAvailable < 6 GiB
+# (Lighthouse + headless Chromium need ~3 GB; the script enforces the floor).
+# The lighthouserc.json now asserts INP threshold (#510), so this catches
+# perf regressions before they ship.
+lh_should_run=0
+[[ "$profile" == "cd" ]] && lh_should_run=1
+[[ "$profile" == "full" ]] && (( diff_touch_frontend )) && lh_should_run=1
+if (( lh_should_run )); then
+  if [[ -x scripts/local-lighthouse.sh ]]; then
+    # Heavy step — queue through fop build batch-medium.
+    run_step_heavy "lighthouse CI (perf + a11y + INP threshold)" "./scripts/local-lighthouse.sh"
+  else
+    skip_step "lighthouse CI" "scripts/local-lighthouse.sh missing"
+  fi
 fi
 
 # ─── Stage 11: Grype (vuln scanner, defense-in-depth) ───────────────────────

--- a/scripts/local-lighthouse.sh
+++ b/scripts/local-lighthouse.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# Local Lighthouse CI runner — mirrors .github/workflows/lighthouse.yml.
+#
+# Builds parkhub-web, starts astro preview on port 18182, runs `npx lhci
+# autorun` against parkhub-web/lighthouserc.json (which now asserts the INP
+# threshold post-#510), tears the preview down. Skips if @lhci/cli isn't on
+# PATH OR if MemAvailable < 6 GiB (Lighthouse + headless Chromium need ~3 GB
+# resident).
+#
+# Usage:
+#   scripts/local-lighthouse.sh [--port N]
+#
+# Env:
+#   FOP_LIGHTHOUSE_MIN_MEM_GIB  bypass the 6 GiB memory floor (default: 6)
+
+set -euo pipefail
+
+port=18182
+for arg in "$@"; do
+  case "$arg" in
+    --port) shift; port="$1" ;;
+    --port=*) port="${arg#--port=}" ;;
+    -h|--help) sed -n '2,/^$/p' "$0" | sed 's/^# \?//'; exit 0 ;;
+  esac
+  shift 2>/dev/null || true
+done
+
+# Pre-flight: memory check
+min_mem_gib="${FOP_LIGHTHOUSE_MIN_MEM_GIB:-6}"
+mem_avail_kib=$(awk '/^MemAvailable:/ {print $2}' /proc/meminfo)
+mem_avail_gib=$((mem_avail_kib / 1024 / 1024))
+if (( mem_avail_gib < min_mem_gib )); then
+  echo "⊘ lighthouse skipped — MemAvailable ${mem_avail_gib} GiB < ${min_mem_gib} GiB floor"
+  echo "  (set FOP_LIGHTHOUSE_MIN_MEM_GIB=<n> to override)"
+  exit 0
+fi
+
+# Pre-flight: tools
+if ! command -v node >/dev/null 2>&1; then
+  echo "⊘ lighthouse skipped — node not on PATH"
+  exit 0
+fi
+if [[ ! -f parkhub-web/lighthouserc.json ]]; then
+  echo "⊘ lighthouse skipped — parkhub-web/lighthouserc.json missing"
+  exit 0
+fi
+
+cd parkhub-web
+
+# Ensure dist exists. astro preview serves dist/.
+if [[ ! -d dist ]] || [[ -z "$(ls -A dist 2>/dev/null)" ]]; then
+  echo "▶ npm run build (dist/ empty)"
+  npm run build >&2
+fi
+
+# Start astro preview in background; capture PID for cleanup.
+preview_log=$(mktemp -t lh-preview-XXXXXX.log)
+echo "▶ astro preview --port $port (log: $preview_log)"
+npx astro preview --port "$port" --host 127.0.0.1 > "$preview_log" 2>&1 &
+preview_pid=$!
+
+cleanup() {
+  if [[ -n "${preview_pid:-}" ]] && kill -0 "$preview_pid" 2>/dev/null; then
+    kill "$preview_pid" 2>/dev/null || true
+    wait "$preview_pid" 2>/dev/null || true
+  fi
+  rm -f "$preview_log"
+}
+trap cleanup EXIT
+
+# Wait for preview to be listening (up to 30s)
+echo -n "  waiting for preview"
+for i in $(seq 1 60); do
+  if curl -sf "http://127.0.0.1:${port}/" >/dev/null 2>&1; then
+    echo " — ready ($i tries)"
+    break
+  fi
+  echo -n "."
+  sleep 0.5
+done
+if ! curl -sf "http://127.0.0.1:${port}/" >/dev/null 2>&1; then
+  echo " — TIMEOUT" >&2
+  echo "preview log:" >&2
+  tail -30 "$preview_log" >&2
+  exit 1
+fi
+
+# Override the URL in lighthouserc.json on the fly so we don't depend on the
+# baked startServerCommand (we already have the server running). LHCI accepts
+# CLI flags that override the JSON.
+echo "▶ npx lhci autorun (asserts categories + INP threshold from lighthouserc.json)"
+LHCI_BUILD_CONTEXT__CURRENT_BRANCH=$(git -C .. rev-parse --abbrev-ref HEAD) \
+  npx --yes @lhci/cli@^0.13 autorun \
+    --config=lighthouserc.json \
+    --collect.url="http://127.0.0.1:${port}/" \
+    --collect.startServerCommand= \
+    --collect.numberOfRuns=1


### PR DESCRIPTION
## Summary
**Final PR in the local→github→release coverage roadmap.** After this lands, `fop-local-ci.sh` fully mirrors the GHA gates AND can spawn in the background so the developer's terminal is never blocked.

## Slice 5 — Lighthouse CI local runner (Stage 10b)
Mirrors `.github/workflows/lighthouse.yml`. Builds `parkhub-web`, starts `astro preview` on port 18182, runs `npx lhci autorun` against the new `lighthouserc.json` (with the INP threshold from #510).

- **Memory-floor gated**: skips silently if `MemAvailable < 6 GiB` (Lighthouse + headless Chromium need ~3 GB resident; floor configurable via `FOP_LIGHTHOUSE_MIN_MEM_GIB`).
- **Trigger**: `cd` profile (always) or `full` profile when frontend touched.
- **Cleanup trap** kills the preview server on exit.

## Slice 6 — `--background` flag
New CLI flag re-execs the script in a detached subshell via `nohup + disown`, logs to `.fop/reports/local-ci-<profile>-<sha>-bg.log`, returns immediately with the PID + log path.

The existing `post_commit_status` mechanism (line 85: `context="fop/local-ci/${profile}"`) already publishes a **distinct** status context per profile — `fop/local-ci/pr` for PR runs and `fop/local-ci/full` for full runs. So the user's "spawn and test all in background" pattern is now:

```bash
.github/scripts/fop-local-ci.sh --profile full --post-status --background
```

→ terminal returns instantly, gate runs in detached subshell, on completion posts `fop/local-ci/full` status check on the commit.

## Roadmap complete

| PR | Slices | Status |
|----|--------|--------|
| #512 (PR-A) | 1+2+3 — yamllint + typos + helm-validate + cargo-audit + cargo-geiger | ✅ Merged |
| #513 (PR-B) | 4 — change-gated local container image scan | ✅ Merged |
| #514 (this) | 5+6 — Lighthouse + `--background` | Pending merge |

After merge, the 3 remaining GHA-only gates are intentionally non-local:
- **OSSF Scorecard** — Google API, network-dependent read-only report
- **Cosign keyless OIDC sign** — no Sigstore OIDC for workstations
- **dependency-review** — GitHub-only, runs on Dependency Graph data

Everything else — actionlint, yamllint, typos, helm lint + 4 templates, cargo audit + geiger, trivy fs + image, grype, lighthouse, axe-core, openapi drift, ts-rs drift, cargo fmt/check/clippy/test, biome, vitest — runs locally with the same coverage as GHA.

## Test plan
- [x] `bash -n` on all 3 scripts — clean
- [ ] After merge: `fop-local-ci.sh --profile full --post-status --background` → verify backgrounding, log file, eventual `fop/local-ci/full` status post