### PR TITLE
feat(local-ci): local install-smoke + multi-browser E2E runners

### DIFF
--- a/scripts/local-e2e.sh
+++ b/scripts/local-e2e.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# Local Playwright E2E runner — mirrors .github/workflows/e2e.yml.
+# Builds the Rust server with feature-flag e2e-bypass + builds the frontend,
+# starts the server on port 8081, runs the full Playwright suite (not just
+# chromium — also firefox + webkit + mobile-chrome).
+#
+# Already covered by Stage 6 of fop-local-ci.sh in `full` profile (chromium
+# only). This script lets you run the FULL multi-browser suite on demand —
+# useful before tagging a release.
+#
+# Usage:
+#   scripts/local-e2e.sh [--project chromium|firefox|webkit|mobile-chrome]
+#                        [--grep PATTERN]
+#                        [--ui]
+#
+# Skips silently if cargo/playwright not installed.
+
+set -euo pipefail
+
+project=""
+grep=""
+ui=0
+for arg in "$@"; do
+  case "$arg" in
+    --project) shift; project="$1" ;;
+    --project=*) project="${arg#--project=}" ;;
+    --grep) shift; grep="$1" ;;
+    --grep=*) grep="${arg#--grep=}" ;;
+    --ui) ui=1 ;;
+    -h|--help) sed -n '2,/^$/p' "$0" | sed 's/^# \?//'; exit 0 ;;
+  esac
+  shift 2>/dev/null || true
+done
+
+if ! command -v cargo >/dev/null 2>&1; then
+  echo "⊘ E2E skipped — cargo not on PATH"
+  exit 0
+fi
+if [[ ! -d parkhub-web ]]; then
+  echo "⊘ E2E skipped — parkhub-web/ missing"
+  exit 0
+fi
+if [[ ! -d parkhub-web/node_modules/@playwright ]]; then
+  echo "⊘ E2E skipped — @playwright not in parkhub-web/node_modules (run npm ci first)"
+  exit 0
+fi
+
+echo "▶ build frontend (parkhub-web)"
+(cd parkhub-web && npm run build)
+
+echo "▶ build server (release, full+headless+e2e-bypass)"
+cargo build --locked --release -p parkhub-server \
+  --no-default-features --features 'full,headless,e2e-bypass'
+
+target_dir=$(cargo metadata --locked --no-deps --format-version 1 | jq -r .target_directory)
+server_bin="$target_dir/release/parkhub-server"
+data_dir=$(mktemp -d -t parkhub-e2e-data-XXXXXX)
+log_file=$(mktemp -t parkhub-e2e-XXXXXX.log)
+
+cleanup() {
+  if [[ -n "${pid:-}" ]] && kill -0 "$pid" 2>/dev/null; then
+    kill "$pid" 2>/dev/null || true
+    wait "$pid" 2>/dev/null || true
+  fi
+  rm -rf "$data_dir" "$log_file"
+}
+trap cleanup EXIT
+
+echo "▶ start server on :8081 (data: $data_dir, log: $log_file)"
+DEMO_MODE=true \
+PARKHUB_ADMIN_PASSWORD=demo \
+PARKHUB_DISABLE_RATE_LIMITS=true \
+"$server_bin" --headless --unattended --port 8081 --data-dir "$data_dir" \
+  >"$log_file" 2>&1 &
+pid=$!
+
+echo -n "  waiting for /health"
+for i in $(seq 1 60); do
+  if curl -sf http://localhost:8081/health >/dev/null 2>&1; then
+    echo " — ready ($i tries)"
+    break
+  fi
+  echo -n "."
+  sleep 1
+done
+
+if ! curl -sf http://localhost:8081/health >/dev/null 2>&1; then
+  echo " — TIMEOUT" >&2
+  tail -50 "$log_file" >&2
+  exit 1
+fi
+
+cd parkhub-web
+
+# Build playwright args.
+pw_args=(test)
+[[ -n "$project" ]] && pw_args+=(--project="$project")
+[[ -n "$grep" ]] && pw_args+=(--grep="$grep")
+(( ui )) && pw_args+=(--ui)
+
+echo "▶ npx playwright ${pw_args[*]}"
+npx playwright "${pw_args[@]}"

--- a/scripts/local-install-smoke.sh
+++ b/scripts/local-install-smoke.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Local install smoke — mirrors .github/workflows/install-smoke.yml.
+# Verifies the docker-compose path documented in INSTALLATION.md actually
+# stands up a working ParkHub from a cold clone. Useful as the last step
+# of `fop ci run --gate cd` before tagging a release, AND as a quick
+# sanity check for any docker-compose.yml change.
+#
+# Usage:
+#   scripts/local-install-smoke.sh [--keep]
+#
+# Flags:
+#   --keep   Leave the smoke instance running on exit (default: teardown).
+#
+# Env:
+#   FOP_INSTALL_SMOKE_PORT  Port to bind on the host (default: 18080)
+#   FOP_INSTALL_SMOKE_DIR   Workdir for the cold clone (default: /tmp/parkhub-smoke)
+
+set -euo pipefail
+
+keep=0
+for arg in "$@"; do
+  case "$arg" in
+    --keep) keep=1 ;;
+    -h|--help) sed -n '2,/^$/p' "$0" | sed 's/^# \?//'; exit 0 ;;
+  esac
+done
+
+port="${FOP_INSTALL_SMOKE_PORT:-18080}"
+workdir="${FOP_INSTALL_SMOKE_DIR:-/tmp/parkhub-smoke}"
+
+# Container runtime — prefer podman (matches Bazzite policy).
+runtime=""
+compose=""
+if command -v podman-compose >/dev/null 2>&1; then
+  runtime=podman; compose="podman-compose"
+elif command -v podman >/dev/null 2>&1 && podman compose version >/dev/null 2>&1; then
+  runtime=podman; compose="podman compose"
+elif command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; then
+  runtime=docker; compose="docker compose"
+else
+  echo "⊘ install-smoke skipped — neither podman-compose nor docker compose available"
+  exit 0
+fi
+
+cleanup() {
+  if (( ! keep )) && [[ -d "$workdir" ]]; then
+    echo "▶ teardown"
+    (cd "$workdir" && $compose down -v 2>/dev/null) || true
+    rm -rf "$workdir"
+  elif (( keep )); then
+    echo "  (--keep set; instance left at $workdir, port $port)"
+  fi
+}
+trap cleanup EXIT
+
+# Step 0: cold clone (use the local working tree as the source — no network
+# round-trip; mirrors what a contributor following INSTALLATION.md would do).
+echo "▶ cold clone (local working tree → $workdir)"
+rm -rf "$workdir"
+git clone --depth 1 "$(pwd)" "$workdir" >/dev/null
+
+cd "$workdir"
+
+# Step 1: set admin password (matches the INSTALLATION.md step 2).
+echo "▶ generate .env (PARKHUB_ADMIN_PASSWORD)"
+echo "PARKHUB_ADMIN_PASSWORD=$(openssl rand -base64 24)" > .env
+
+# Override the host port so we don't clash with anything running on 8080.
+if grep -qE '^\s*-\s*"8080:' docker-compose.yml; then
+  echo "▶ patching host port: 8080 → $port"
+  sed -i.bak -E "s|^(\s*-\s*\")8080:|\1${port}:|" docker-compose.yml
+fi
+
+# Step 2: start
+echo "▶ $compose up -d"
+$compose up -d
+
+# Step 3: wait for /health/ready
+echo "▶ waiting for /health/ready on :$port"
+for i in $(seq 1 60); do
+  if curl -sf "http://localhost:${port}/health/ready" >/dev/null 2>&1; then
+    echo "✓ READY after ${i}s ($runtime/$compose)"
+    exit 0
+  fi
+  sleep 2
+done
+
+echo "✗ FAIL: /health/ready never green after 120s" >&2
+$compose logs
+exit 1


### PR DESCRIPTION
## Summary
Two more workflow mirrors for the local→github→release coverage.

### `scripts/local-install-smoke.sh`
Mirrors `install-smoke.yml`. Verifies the docker-compose path documented in `INSTALLATION.md` actually stands up a working ParkHub from a cold clone. Useful as the last step of `fop ci run --gate cd` before tagging a release, AND as a quick sanity check for any `docker-compose.yml` change.

- Cold-clones the **local working tree** to `/tmp/parkhub-smoke` (no network round-trip; matches what a contributor following INSTALLATION.md would do).
- Generates `.env` with random `PARKHUB_ADMIN_PASSWORD`.
- Patches host port 8080 → 18080 to avoid clashes with the Astro dev server.
- Runs `podman compose up -d` (or `docker compose`; runtime auto-detected).
- Waits up to 120s for `/health/ready`.
- `--keep` flag leaves instance running; default tears down on exit.

### `scripts/local-e2e.sh`
Mirrors `e2e.yml` (the **multi-browser** suite — chromium-only is already in `fop-local-ci.sh` full profile). Builds server with `full+headless+e2e-bypass` features, starts on :8081, runs the full Playwright suite.

- Supports `--project`, `--grep`, `--ui` flags for targeted runs.
- Cleanup trap kills the server process + rms temp data dir.
- Skips silently if cargo/playwright missing or `parkhub-web/node_modules/@playwright` absent.

Both scripts are **standalone** (not wired into `fop-local-ci.sh` by default) — invoke manually before a release tag or after a dependent change. Could be added to `cd` profile or lefthook later if desired.

## Test plan
- [x] `bash -n` on both scripts — clean
- [ ] After merge: `./scripts/local-install-smoke.sh --keep` then curl `http://localhost:18080/health/ready` → expect 200
- [ ] After merge: `./scripts/local-e2e.sh --project=chromium --grep="login"` → run a single auth spec