### PR TITLE
feat(devcontainer): prebuilt image publish workflow → ghcr.io (10× faster first-time devcontainer up)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,16 @@
 {
   "name": "parkhub-rust full local CI/CD",
-  "build": {
+
+  "// image vs build": [
+    "We default to the prebuilt image at ghcr.io/nash87/parkhub-rust-devcontainer:latest",
+    "(published by .github/workflows/devcontainer-publish.yml on every push to .devcontainer/",
+    "and weekly to pick up base-image security patches). This makes first-time `devcontainer up`",
+    "~10× faster — no local 5–10 min build. To force a local build instead (e.g. testing a new",
+    "Containerfile), comment out `image:` and uncomment `build:` below."
+  ],
+  "image": "ghcr.io/nash87/parkhub-rust-devcontainer:latest",
+
+  "// build": {
     "context": ".",
     "dockerfile": "Containerfile"
   },

--- a/.github/workflows/devcontainer-publish.yml
+++ b/.github/workflows/devcontainer-publish.yml
@@ -1,0 +1,113 @@
+name: Publish dev container image
+
+# Builds .devcontainer/Containerfile and pushes to ghcr.io so contributors
+# (and Codespaces) can pull the pre-built image instead of waiting 5-10 min
+# on first `devcontainer up`. Triggers on changes to .devcontainer/, on
+# manual dispatch, and weekly to pick up base-image security updates.
+#
+# Security note: this workflow uses ZERO user-controlled inputs (no
+# github.event.issue/pull_request/comment/* fields). All template
+# expressions reference workflow-controlled steps.* outputs or static
+# secrets/env. Safe per github.blog workflow-injection guidance.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.devcontainer/**'
+      - '.github/workflows/devcontainer-publish.yml'
+  schedule:
+    # Weekly on Sunday 04:30 UTC to pick up base-image security patches.
+    - cron: '30 4 * * 0'
+  workflow_dispatch:
+
+concurrency:
+  group: devcontainer-publish-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  packages: write
+  id-token: write   # for cosign keyless OIDC sign of the image
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}-devcontainer
+
+jobs:
+  build-and-push:
+    name: Build & push devcontainer image
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+
+      - name: Log in to ghcr.io
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=schedule,pattern=weekly
+            type=sha,prefix=git-
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push
+        id: build
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        with:
+          context: .devcontainer
+          file: .devcontainer/Containerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          provenance: false
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@d58896d6a1865668819e1d91763c7751a165e159 # v3.9.2
+
+      - name: Sign image (keyless OIDC)
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+          TAGS: ${{ steps.meta.outputs.tags }}
+        run: |
+          set -euo pipefail
+          for tag in $TAGS; do
+            echo "▶ cosign sign $tag@$DIGEST"
+            cosign sign --yes "$tag@$DIGEST"
+          done
+
+      - name: Summary
+        env:
+          TAGS: ${{ steps.meta.outputs.tags }}
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          {
+            echo "## devcontainer image published"
+            echo ""
+            echo "**Tags**:"
+            for tag in $TAGS; do echo "- \`$tag\`"; done
+            echo ""
+            echo "**Digest**: \`$DIGEST\`"
+            echo ""
+            echo "**Pull**: \`podman pull ${REGISTRY}/${IMAGE_NAME}:latest\`"
+            echo ""
+            echo "Devcontainer.json now defaults to this prebuilt image; first-time"
+            echo "\`devcontainer up\` should be ~10× faster (no local build)."
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary
After #515 added the dev container, first-time `devcontainer up` takes 5-10 min to build the Containerfile (rust + node + helm + trivy + grype + ... toolchain). This PR adds a workflow that publishes a prebuilt image to ghcr.io and switches `devcontainer.json` to default to it. Subsequent up calls are just `podman pull` — ~10× faster.

## Triggers
- **push to main** when `.devcontainer/**` or the workflow itself changes
- **weekly cron** (Sunday 04:30 UTC) to pick up `rust:1.94.1-bookworm` security patches without manual dispatch
- **workflow_dispatch**

## Pipeline (`.github/workflows/devcontainer-publish.yml`)
1. setup-buildx-action (SHA-pinned)
2. login to ghcr.io via `GITHUB_TOKEN`
3. metadata-action with tags: `weekly` (schedule), `git-<sha>`, `latest` (default branch only)
4. build-push-action with GHA cache (`cache-from + cache-to mode=max`)
5. cosign sign `--yes` (keyless OIDC) for every published tag

## Permissions (least-privilege)
- `contents: read` (checkout)
- `packages: write` (push to ghcr)
- `id-token: write` (cosign keyless OIDC)

## `.devcontainer/devcontainer.json` change
Now defaults to:
```json
"image": "ghcr.io/nash87/parkhub-rust-devcontainer:latest"
```
The local `build:` block is kept commented out for first-time users who want to test a Containerfile change without waiting for the publish workflow.

## Security
Workflow uses **zero user-controlled inputs** (no `github.event.issue/pull_request/comment/*` fields). All template expressions reference workflow-controlled `steps.*` outputs or static `secrets`/`env`. Safe per [github.blog workflow-injection guidance](https://github.blog/security/vulnerability-research/how-to-catch-github-actions-workflow-injections-before-attackers-do/).

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(...)"` clean
- [x] `python3 -m json.tool .devcontainer/devcontainer.json` clean
- [ ] After merge: workflow fires on push, image visible at `ghcr.io/nash87/parkhub-rust-devcontainer:latest`
- [ ] After image published: `devcontainer up` from a fresh clone uses pulled image (no local build)