### PR TITLE
ci: bot-friendly + non-spammy + professional workflow polish

### DIFF
--- a/.gitea/workflows/ci.yaml
+++ b/.gitea/workflows/ci.yaml
@@ -13,8 +13,28 @@ name: CI
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - '**/*.md'
+      - docs/**
+      - CHANGELOG*
+      - LICENSE*
+      - .gitignore
+      - .editorconfig
+      - .github/ISSUE_TEMPLATE/**
+      - .github/PULL_REQUEST_TEMPLATE.md
+      - .github/agents/**
   pull_request:
     branches: [main]
+    paths-ignore:
+      - '**/*.md'
+      - docs/**
+      - CHANGELOG*
+      - LICENSE*
+      - .gitignore
+      - .editorconfig
+      - .github/ISSUE_TEMPLATE/**
+      - .github/PULL_REQUEST_TEMPLATE.md
+      - .github/agents/**
   workflow_dispatch:
 
 concurrency:

--- a/.gitea/workflows/openapi-drift.yaml
+++ b/.gitea/workflows/openapi-drift.yaml
@@ -5,6 +5,16 @@ name: OpenAPI Drift
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - '**/*.md'
+      - docs/**
+      - CHANGELOG*
+      - LICENSE*
+      - .gitignore
+      - .editorconfig
+      - .github/ISSUE_TEMPLATE/**
+      - .github/PULL_REQUEST_TEMPLATE.md
+      - .github/agents/**
   workflow_dispatch:
 
 concurrency:

--- a/.gitea/workflows/security.yaml
+++ b/.gitea/workflows/security.yaml
@@ -6,8 +6,28 @@ name: Security
 on:
   pull_request:
     branches: [main]
+    paths-ignore:
+      - '**/*.md'
+      - docs/**
+      - CHANGELOG*
+      - LICENSE*
+      - .gitignore
+      - .editorconfig
+      - .github/ISSUE_TEMPLATE/**
+      - .github/PULL_REQUEST_TEMPLATE.md
+      - .github/agents/**
   push:
     branches: [main]
+    paths-ignore:
+      - '**/*.md'
+      - docs/**
+      - CHANGELOG*
+      - LICENSE*
+      - .gitignore
+      - .editorconfig
+      - .github/ISSUE_TEMPLATE/**
+      - .github/PULL_REQUEST_TEMPLATE.md
+      - .github/agents/**
   schedule:
     - cron: '0 8 * * 1'
   workflow_dispatch:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,28 @@ name: CI
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - '**/*.md'
+      - docs/**
+      - CHANGELOG*
+      - LICENSE*
+      - .gitignore
+      - .editorconfig
+      - .github/ISSUE_TEMPLATE/**
+      - .github/PULL_REQUEST_TEMPLATE.md
+      - .github/agents/**
   pull_request:
     branches: [main]
+    paths-ignore:
+      - '**/*.md'
+      - docs/**
+      - CHANGELOG*
+      - LICENSE*
+      - .gitignore
+      - .editorconfig
+      - .github/ISSUE_TEMPLATE/**
+      - .github/PULL_REQUEST_TEMPLATE.md
+      - .github/agents/**
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -3,6 +3,16 @@ name: Lighthouse CI
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - '**/*.md'
+      - docs/**
+      - CHANGELOG*
+      - LICENSE*
+      - .gitignore
+      - .editorconfig
+      - .github/ISSUE_TEMPLATE/**
+      - .github/PULL_REQUEST_TEMPLATE.md
+      - .github/agents/**
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/openapi-drift.yml
+++ b/.github/workflows/openapi-drift.yml
@@ -3,6 +3,16 @@ name: OpenAPI Drift
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - '**/*.md'
+      - docs/**
+      - CHANGELOG*
+      - LICENSE*
+      - .gitignore
+      - .editorconfig
+      - .github/ISSUE_TEMPLATE/**
+      - .github/PULL_REQUEST_TEMPLATE.md
+      - .github/agents/**
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -1,0 +1,60 @@
+name: PR title lint
+
+# Enforce Conventional Commits in PR titles so the auto-generated changelog
+# (.github/release-drafter.yml + git-cliff) categorizes correctly. Runs on
+# every PR open / edit / sync.
+#
+# Examples that pass:
+#   feat(admin): add tenant scoping to lots
+#   fix(auth): refresh-token race in /me
+#   chore(deps): bump tokio 1.42 → 1.43
+#
+# Bot PRs (Dependabot, Copilot) are exempt — they use proper prefixes.
+
+on:
+  pull_request_target:
+    types: [opened, edited, reopened, synchronize]
+
+permissions: {}
+
+concurrency:
+  group: pr-title-lint-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: Conventional Commits PR title
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    permissions:
+      pull-requests: read
+    if: github.event.pull_request.user.type != 'Bot'
+    steps:
+      - name: Lint title
+        uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017 # v5.5.3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            perf
+            refactor
+            test
+            docs
+            build
+            ci
+            chore
+            revert
+            security
+            i18n
+            design
+          requireScope: false
+          subjectPattern: ^(?![A-Z]).+$
+          subjectPatternError: |
+            The subject "{subject}" must start with a lowercase letter.
+
+            Examples that pass:
+              feat(admin): add tenant scoping to lots
+              fix(auth): refresh-token race in /me
+              chore(deps): bump tokio 1.42 → 1.43

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -3,8 +3,28 @@ name: Security
 on:
   pull_request:
     branches: [main]
+    paths-ignore:
+      - '**/*.md'
+      - docs/**
+      - CHANGELOG*
+      - LICENSE*
+      - .gitignore
+      - .editorconfig
+      - .github/ISSUE_TEMPLATE/**
+      - .github/PULL_REQUEST_TEMPLATE.md
+      - .github/agents/**
   push:
     branches: [main]
+    paths-ignore:
+      - '**/*.md'
+      - docs/**
+      - CHANGELOG*
+      - LICENSE*
+      - .gitignore
+      - .editorconfig
+      - .github/ISSUE_TEMPLATE/**
+      - .github/PULL_REQUEST_TEMPLATE.md
+      - .github/agents/**
   schedule:
     - cron: '0 8 * * 1'
   workflow_dispatch:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,55 @@
+name: Stale PR closer
+
+# Close stale PRs that have had no activity for 60 days (mark) + 14 days
+# (close). Issues are NOT touched (we triage those manually). Bot PRs are
+# exempt — Dependabot's own scheduling handles its PR lifecycle.
+
+on:
+  schedule:
+    - cron: '0 2 * * *'
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: stale-${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  stale:
+    name: Mark + close stale PRs
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9.1.0
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+          # PR-only: issues exempted via -1
+          days-before-issue-stale: -1
+          days-before-issue-close: -1
+
+          days-before-pr-stale: 60
+          days-before-pr-close: 14
+
+          stale-pr-label: stale
+          stale-pr-message: |
+            This PR has been inactive for 60 days. It will close in 14 days
+            if there is no further activity. To keep it open, push a commit
+            or remove the `stale` label.
+
+            If this PR is still relevant but blocked, leave a comment with
+            the blocker — the maintainers will look.
+
+          close-pr-message: |
+            Closing this PR after 60 + 14 days of inactivity. Reopen and
+            push a commit if you'd like to revive it.
+
+          exempt-pr-labels: 'pinned,security,wip,blocked,help-wanted'
+          exempt-all-pr-milestones: true
+
+          ascending: true
+          operations-per-run: 30
+          exempt-bot-author-pr: true


### PR DESCRIPTION
## Summary
Three coordinated improvements to make the CI/CD pipeline less noisy when bot PRs land + safer to operate at scale.

### 1. `paths-ignore` on heavy workflows (7 files, 11 trigger blocks)
Most workflows previously ran on every push including docs-only changes. Now skipped paths:
- `**/*.md`, `docs/**`, `CHANGELOG*`, `LICENSE*`, `.gitignore`, `.editorconfig`
- `.github/ISSUE_TEMPLATE/**`, `.github/PULL_REQUEST_TEMPLATE.md`
- `.github/agents/**`

Files updated (each has paths-ignore on `push:` AND/OR `pull_request:`):
- `.github/workflows/{ci,security,openapi-drift,lighthouse}.yml`
- `.gitea/workflows/{ci,security,openapi-drift}.yaml`

`helm.yml`, `mutants.yml`, `fuzz-smoke.yml` already had explicit `paths:` filters and were intentionally skipped (more restrictive than this exclusion list).

### 2. PR title lint (`.github/workflows/pr-title-lint.yml`)
Enforces Conventional Commits in PR titles via `amannn/action-semantic-pull-request@v5.5.3` (SHA-pinned). Allowed types match the changelog release-drafter categorizer: `feat, fix, perf, refactor, test, docs, build, ci, chore, revert, security, i18n, design`.

Subject must start with lowercase letter. **Bot PRs are exempt** — they already use proper prefixes and we don't want to block automated dep bumps on a title-format technicality.

### 3. Stale PR closer (`.github/workflows/stale.yml`)
Daily 02:00 UTC scan via `actions/stale@v9.1.0` (SHA-pinned). PRs only (issues exempted) — 60d to mark stale, +14d to close.

Conservative exemptions: `pinned, security, wip, blocked, help-wanted`, all milestones, all bot-authored PRs (Dependabot's own scheduling handles those). `operations-per-run: 30` caps a runaway closer.

## Security
PR-title-lint + stale workflows use **zero** untrusted-input interpolation. Only `github.event.pull_request.{number,user.type}` (an integer + an enum) flow through `env` / `if` conditions. Safe per the [github.blog workflow-injection guidance](https://github.blog/security/vulnerability-research/how-to-catch-github-actions-workflow-injections-before-attackers-do/).

## Expected impact after merge
- Docs-only PRs skip 7 heavy workflows → saves ~15min CI per such PR
- Bot PRs flow through cleanly without title-lint friction
- The PR queue self-tidies after 60d inactivity (with polite warning)

## Test plan
- [x] YAML validate clean on all 9 modified/new files
- [x] Pre-push gates green (lefthook + zizmor)
- [ ] After merge: open a docs-only PR → verify ci.yml + security.yml + lighthouse.yml + openapi-drift.yml don't fire
- [ ] After merge: open a `Sentence Case` PR title (non-bot) → verify pr-title-lint posts a friendly error
- [ ] After 24h: stale.yml runs daily — observe first scan