### PR TITLE
feat(local-ci): wire fop ci-audit + workflow-drift detector into Stage 2

### DIFF
--- a/.github/scripts/fop-local-ci.sh
+++ b/.github/scripts/fop-local-ci.sh
@@ -417,6 +417,17 @@ if (( diff_touch_workflows )) || [[ "${FOP_LOCAL_CI_RUN_LINTERS:-}" == "1" ]]; t
         [[ -f \$f ]] && yamllint -d 'rules: {line-length: disable, document-start: disable, truthy: disable}' \"\$f\"; \
       done"
   fi
+  # fop ci-audit: gitea+github workflow audit (missing --add-host, hardcoded
+  # localhost, etc). Advisory — surfaces findings but doesn't fail the gate.
+  if command -v fop >/dev/null 2>&1; then
+    run_direct "fop ci-audit (advisory)" \
+      "fop ci-audit . 2>&1 | grep -E '\\[(WARN|ERROR|FAIL)\\]' | head -30 || echo '✓ fop ci-audit: no findings'"
+  fi
+  # workflow drift detector — gitea ↔ github workflow file pairing.
+  # Gating: missing files fail the gate; trigger/job drift is advisory.
+  if [[ -x scripts/local-workflow-drift.sh ]]; then
+    run_direct "workflow drift (gitea ↔ github)" "./scripts/local-workflow-drift.sh"
+  fi
 fi
 
 # ─── Stage 2b: spell-check via typos (advisory, all profiles) ───────────────


### PR DESCRIPTION
## Summary
After #519 (workflow drift detector) and the existing `fop ci-audit` CLI, Stage 2 of `fop-local-ci.sh` now runs both automatically when `.github/workflows/` or `.gitea/workflows/` files are touched. No more manual invocation needed.

## Stage 2 additions (alongside actionlint + zizmor + yamllint)
- **`fop ci-audit .`** — flags missing-add-host, hardcoded-localhost, template-injection patterns across both `.github` + `.gitea` workflow trees. Advisory.
- **`scripts/local-workflow-drift.sh`** — gating: missing files between gitea + github fail; trigger/job-key drift is advisory.

Both skip silently if tools missing — keeps the contributor-friendly pattern.

## Test plan
- [x] `bash -n` clean
- [ ] After merge: touch a workflow file → push → see Stage 2 run both new advisory steps