### PR TITLE
feat(local-ci): mutation testing + fuzz smoke local mirrors

### DIFF
--- a/scripts/local-fuzz-smoke.sh
+++ b/scripts/local-fuzz-smoke.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Local fuzz smoke — mirrors .github/workflows/fuzz-smoke.yml.
+# Runs cargo-fuzz against parkhub's two fuzz targets (jwt_parse,
+# webhook_hmac) for FUZZ_SECONDS each. Surfaces crashes as artifact
+# files in the fuzz/artifacts/ directory.
+#
+# Usage:
+#   scripts/local-fuzz-smoke.sh [--target jwt_parse|webhook_hmac|all] [--seconds N]
+#
+# Defaults: --target all --seconds 60 (matches GHA FUZZ_SECONDS=60).
+
+set -euo pipefail
+
+target="all"
+seconds=60
+for arg in "$@"; do
+  case "$arg" in
+    --target) shift; target="$1" ;;
+    --target=*) target="${arg#--target=}" ;;
+    --seconds) shift; seconds="$1" ;;
+    --seconds=*) seconds="${arg#--seconds=}" ;;
+    -h|--help) sed -n '2,/^$/p' "$0" | sed 's/^# \?//'; exit 0 ;;
+  esac
+  shift 2>/dev/null || true
+done
+
+# cargo-fuzz needs nightly. Skip if rustup nightly not installed (don't
+# auto-install — that's a 600 MB download the user should consent to).
+if ! command -v cargo-fuzz >/dev/null 2>&1 && ! cargo +nightly fuzz --version >/dev/null 2>&1; then
+  echo "⊘ fuzz skipped — cargo-fuzz not installed"
+  echo "  install: rustup install nightly && cargo +nightly install cargo-fuzz"
+  exit 0
+fi
+if ! cargo +nightly --version >/dev/null 2>&1; then
+  echo "⊘ fuzz skipped — rust nightly toolchain not installed"
+  echo "  install: rustup install nightly"
+  exit 0
+fi
+
+cd parkhub-server/fuzz 2>/dev/null || {
+  echo "⊘ fuzz skipped — parkhub-server/fuzz/ missing"
+  exit 0
+}
+
+case "$target" in
+  jwt_parse|webhook_hmac)
+    targets=("$target")
+    ;;
+  all)
+    targets=(jwt_parse webhook_hmac)
+    ;;
+  *)
+    echo "✗ unknown target: $target (allowed: jwt_parse, webhook_hmac, all)" >&2
+    exit 2
+    ;;
+esac
+
+for t in "${targets[@]}"; do
+  echo "▶ cargo +nightly fuzz run $t — ${seconds}s"
+  cargo +nightly fuzz run "$t" -- -max_total_time="$seconds" || {
+    echo "⚠ fuzz target '$t' surfaced a crash (artifacts in $(pwd)/artifacts/$t/)"
+  }
+done
+
+echo "✓ fuzz smoke complete (artifacts in parkhub-server/fuzz/artifacts/ if any)"

--- a/scripts/local-mutants.sh
+++ b/scripts/local-mutants.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Local mutation testing — mirrors .github/workflows/mutants.yml.
+# Runs cargo-mutants against parkhub-common and writes results to
+# .fop/reports/mutants-<sha>/. Not a gating step; surfaces escaped
+# mutants (mutations that pass the test suite — i.e., coverage gaps).
+#
+# v1 scope matches the workflow: parkhub-common only. parkhub-server
+# is too big for a single 3-hour run; expand once baseline kill rate
+# is known.
+#
+# Usage:
+#   scripts/local-mutants.sh [--package PKG] [--timeout N]
+#
+# Defaults match the GHA workflow: --package parkhub-common --timeout 300.
+
+set -euo pipefail
+
+package="parkhub-common"
+timeout=300
+for arg in "$@"; do
+  case "$arg" in
+    --package) shift; package="$1" ;;
+    --package=*) package="${arg#--package=}" ;;
+    --timeout) shift; timeout="$1" ;;
+    --timeout=*) timeout="${arg#--timeout=}" ;;
+    -h|--help) sed -n '2,/^$/p' "$0" | sed 's/^# \?//'; exit 0 ;;
+  esac
+  shift 2>/dev/null || true
+done
+
+if ! command -v cargo-mutants >/dev/null 2>&1; then
+  echo "⊘ mutants skipped — cargo-mutants not installed (cargo install cargo-mutants)"
+  exit 0
+fi
+
+sha=$(git rev-parse --short HEAD)
+out=".fop/reports/mutants-$sha"
+mkdir -p "$out"
+
+echo "▶ cargo mutants --json --timeout $timeout --test-package $package"
+cargo mutants \
+  --json \
+  --timeout "$timeout" \
+  --test-package "$package" \
+  --output "$out" \
+  || true   # mutants exit non-zero on missed mutants — surface, don't gate
+
+if [[ -f "$out/outcomes.json" ]]; then
+  total=$(jq '[.outcomes[] | .summary] | length' < "$out/outcomes.json" 2>/dev/null || echo "?")
+  caught=$(jq '[.outcomes[] | select(.summary == "CAUGHT")] | length' < "$out/outcomes.json" 2>/dev/null || echo "?")
+  missed=$(jq '[.outcomes[] | select(.summary == "MISSED")] | length' < "$out/outcomes.json" 2>/dev/null || echo "?")
+  echo "✓ mutants done: $total total, $caught caught, $missed escaped"
+  echo "  full report: $out/"
+else
+  echo "⚠ mutants ran but no outcomes.json — check $out/ for raw output"
+fi


### PR DESCRIPTION
## Summary
Two more workflow mirrors for the local→github→release coverage.

### `scripts/local-mutants.sh` — mirrors `mutants.yml`
Runs `cargo-mutants` against `parkhub-common` (matches the workflow's v1 scope; parkhub-server is too big for a single 3-hour run). Writes results to `.fop/reports/mutants-<sha>/`. Surfaces escaped mutants (mutations that pass the test suite — coverage gaps) but does **NOT** gate (matches workflow's advisory posture).

Flags: `--package PKG`, `--timeout N` (defaults match the GHA workflow).

### `scripts/local-fuzz-smoke.sh` — mirrors `fuzz-smoke.yml`
Runs `cargo-fuzz` against the two parkhub fuzz targets (`jwt_parse`, `webhook_hmac`) for `FUZZ_SECONDS` each (default 60s, matches GHA env). Skip-on-missing for rustup nightly + cargo-fuzz (don't auto-install — that's a 600 MB consent moment).

Flags: `--target {jwt_parse,webhook_hmac,all}`, `--seconds N`.

Both **standalone** — not wired into a profile (mutants is nightly in GHA, fuzz is also nightly). Invoke manually or via cron when you want a local equivalent of the morning triage.

## Test plan
- [x] `bash -n` on both scripts — clean
- [ ] After merge: `cargo install cargo-mutants && ./scripts/local-mutants.sh --timeout 60` runs against parkhub-common
- [ ] After merge: `rustup install nightly && cargo +nightly install cargo-fuzz && ./scripts/local-fuzz-smoke.sh --seconds 10` runs both targets briefly