### PR TITLE
feat(local-ci): release-rehearsal + visual-regression local mirrors

### DIFF
--- a/scripts/local-release-rehearsal.sh
+++ b/scripts/local-release-rehearsal.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Local release rehearsal — mirrors .github/workflows/release-rehearsal.yml.
+# Exercises the release path (validate-tag, headless+client builds,
+# Syft SBOM, optional cosign sign-blob) WITHOUT pushing tags or creating
+# a GitHub release. Use before pushing a `v*` tag so Tauri/cosign/Syft
+# bugs surface locally instead of after a 30-min GHA round-trip.
+#
+# Usage:
+#   scripts/local-release-rehearsal.sh [--tag v5.0.9-rc1]
+#
+# Skips Tauri builds locally (require macOS/Windows runners). Server +
+# client headless builds run on this Linux box.
+#
+# Requires: cargo, syft. Optional: cosign + FOP_LOCAL_REL_SIGN_KEY for
+# the signing rehearsal (otherwise SBOM gen runs unsigned).
+
+set -euo pipefail
+
+tag="v0.0.0-rc.local"
+for arg in "$@"; do
+  case "$arg" in
+    --tag) shift; tag="$1" ;;
+    --tag=*) tag="${arg#--tag=}" ;;
+    -h|--help) sed -n '2,/^$/p' "$0" | sed 's/^# \?//'; exit 0 ;;
+  esac
+  shift 2>/dev/null || true
+done
+
+# ── Stage 1: validate-tag ──────────────────────────────────────────────
+# Mirrors the synthetic-ref check in release.yml — verifies the tag name
+# parses, doesn't already exist as a real release, and is on the expected
+# format pattern.
+echo "▶ validate-tag: $tag"
+if ! [[ "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta|rc)\.[0-9]+|-rc\.local|-rc[0-9]+)?$ ]]; then
+  echo "✗ tag '$tag' does not match v<MAJOR>.<MINOR>.<PATCH>[-prerelease]" >&2
+  exit 1
+fi
+if git tag -l | grep -qx "$tag"; then
+  echo "⚠ tag '$tag' already exists locally (rehearsal continues; real release.yml would FAIL)"
+fi
+
+# ── Stage 2: server headless build ─────────────────────────────────────
+echo "▶ cargo build --release -p parkhub-server --no-default-features --features headless"
+cargo build --locked --release -p parkhub-server --no-default-features --features headless
+
+# ── Stage 3: client build ──────────────────────────────────────────────
+if [[ -d parkhub-client ]]; then
+  echo "▶ cargo build --release -p parkhub-client"
+  cargo build --locked --release -p parkhub-client
+else
+  echo "⊘ parkhub-client/ missing — skipping client build"
+fi
+
+target_dir=$(cargo metadata --locked --no-deps --format-version 1 | jq -r .target_directory)
+
+# ── Stage 4: SBOM via syft ────────────────────────────────────────────
+out_dir=".fop/reports/release-rehearsal-$tag"
+mkdir -p "$out_dir"
+if command -v syft >/dev/null 2>&1; then
+  echo "▶ syft scan release artifacts → $out_dir/"
+  for bin in "$target_dir/release/parkhub-server" "$target_dir/release/parkhub-client"; do
+    [[ -f "$bin" ]] || continue
+    name=$(basename "$bin")
+    syft scan "file:$bin" -o "spdx-json=$out_dir/sbom-$name.json" --quiet
+    echo "  ✓ $out_dir/sbom-$name.json"
+  done
+else
+  echo "⊘ syft not on PATH — skipping SBOM"
+fi
+
+# ── Stage 5: optional cosign sign-blob ────────────────────────────────
+if [[ -n "${FOP_LOCAL_REL_SIGN_KEY:-}" ]] && command -v cosign >/dev/null 2>&1; then
+  echo "▶ cosign sign-blob (key: $FOP_LOCAL_REL_SIGN_KEY)"
+  for bin in "$target_dir/release/parkhub-server" "$target_dir/release/parkhub-client"; do
+    [[ -f "$bin" ]] || continue
+    cosign sign-blob \
+      --key "$FOP_LOCAL_REL_SIGN_KEY" \
+      --output-signature "$bin.sig" \
+      --output-certificate "$bin.cert" \
+      --yes \
+      "$bin"
+    echo "  ✓ $bin.{sig,cert}"
+  done
+else
+  echo "⊘ cosign sign-blob skipped (set FOP_LOCAL_REL_SIGN_KEY + install cosign)"
+fi
+
+echo "✓ release rehearsal complete for $tag"
+echo "  artifacts: $out_dir/"
+echo "  binaries:  $target_dir/release/{parkhub-server,parkhub-client}"
+echo "  next:      git tag -a $tag && git push github $tag"

--- a/scripts/local-visual-regression.sh
+++ b/scripts/local-visual-regression.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Local visual regression — mirrors visual-regression.yml. Runs Playwright
+# snapshot tests against the local server, compares against
+# parkhub-web/test-results/baselines/. Catches chrome drift on demand
+# (the GHA workflow is nightly + advisory because GHA-runner antialiasing
+# differs from local; LOCAL runs are the canonical reference).
+#
+# Usage:
+#   scripts/local-visual-regression.sh [--update-snapshots]
+#
+# --update-snapshots rebases ALL snapshots (use only after intentional
+# UI changes — review the diff carefully before committing).
+
+set -euo pipefail
+
+update=0
+for arg in "$@"; do
+  case "$arg" in
+    --update-snapshots) update=1 ;;
+    -h|--help) sed -n '2,/^$/p' "$0" | sed 's/^# \?//'; exit 0 ;;
+  esac
+done
+
+if ! command -v cargo >/dev/null 2>&1; then
+  echo "⊘ visual-regression skipped — cargo not on PATH"
+  exit 0
+fi
+if [[ ! -d parkhub-web/node_modules/@playwright ]]; then
+  echo "⊘ visual-regression skipped — @playwright not installed (run npm ci in parkhub-web)"
+  exit 0
+fi
+
+# Build server with e2e-bypass + frontend.
+echo "▶ build frontend"
+(cd parkhub-web && npm run build)
+
+echo "▶ build server (release, full+headless+e2e-bypass)"
+cargo build --locked --release -p parkhub-server \
+  --no-default-features --features 'full,headless,e2e-bypass'
+
+target_dir=$(cargo metadata --locked --no-deps --format-version 1 | jq -r .target_directory)
+server_bin="$target_dir/release/parkhub-server"
+data_dir=$(mktemp -d -t parkhub-vr-data-XXXXXX)
+log_file=$(mktemp -t parkhub-vr-XXXXXX.log)
+
+cleanup() {
+  if [[ -n "${pid:-}" ]] && kill -0 "$pid" 2>/dev/null; then
+    kill "$pid" 2>/dev/null || true
+    wait "$pid" 2>/dev/null || true
+  fi
+  rm -rf "$data_dir" "$log_file"
+}
+trap cleanup EXIT
+
+echo "▶ start server on :18181 (data: $data_dir)"
+DEMO_MODE=true \
+PARKHUB_ADMIN_PASSWORD=demo \
+PARKHUB_DISABLE_RATE_LIMITS=true \
+"$server_bin" --headless --unattended --port 18181 --data-dir "$data_dir" \
+  >"$log_file" 2>&1 &
+pid=$!
+
+echo -n "  waiting for /health"
+for i in $(seq 1 60); do
+  if curl -sf http://127.0.0.1:18181/health >/dev/null 2>&1; then
+    echo " — ready ($i tries)"
+    break
+  fi
+  echo -n "."
+  sleep 1
+done
+
+if ! curl -sf http://127.0.0.1:18181/health >/dev/null 2>&1; then
+  echo " — TIMEOUT" >&2
+  tail -50 "$log_file" >&2
+  exit 1
+fi
+
+cd parkhub-web
+
+# Discover the visual spec — same scope as visual-regression.yml.
+spec_glob="e2e/v5-visual.spec.ts"
+[[ ! -f "$spec_glob" ]] && spec_glob="e2e/visual.spec.ts"
+[[ ! -f "$spec_glob" ]] && {
+  echo "⊘ no visual spec found at e2e/v5-visual.spec.ts or e2e/visual.spec.ts"
+  exit 0
+}
+
+E2E_BASE_URL="http://127.0.0.1:18181"
+export E2E_BASE_URL
+
+if (( update )); then
+  echo "▶ npx playwright test --update-snapshots $spec_glob"
+  npx playwright test --update-snapshots "$spec_glob" --project=chromium
+  echo "✓ snapshots updated. Review with: git diff parkhub-web/e2e/__snapshots__/ && commit"
+else
+  echo "▶ npx playwright test $spec_glob (chromium)"
+  npx playwright test "$spec_glob" --project=chromium
+fi


### PR DESCRIPTION
## Summary
Two more workflow mirrors closing out the local→github→release coverage.

### `scripts/local-release-rehearsal.sh` — mirrors `release-rehearsal.yml`
Exercises the release path (validate-tag, headless+client builds, Syft SBOM, optional cosign sign-blob) WITHOUT pushing tags or creating a GitHub release. Use **before** pushing a `v*` tag so Tauri/cosign/Syft bugs surface locally instead of after a 30-min GHA round-trip.

5 stages mirror the workflow:
1. **validate-tag** — synthetic-ref regex + collision check
2. **server headless build** (release, headless feature)
3. **client build** (parkhub-client; skipped if missing)
4. **syft SBOM** scan of release binaries → `.fop/reports/release-rehearsal-<tag>/`
5. **optional cosign sign-blob** via `FOP_LOCAL_REL_SIGN_KEY` (developer key — keyless OIDC has no workstation analog)

Skips Tauri builds locally (require macOS/Windows runners — intentionally not mirrored).

### `scripts/local-visual-regression.sh` — mirrors `visual-regression.yml`
Builds frontend + server with `full+headless+e2e-bypass`, starts on :18181, runs Playwright snapshot tests.

**LOCAL runs are the canonical reference** (GHA is nightly + advisory because runner antialiasing differs from local rendering — documented in the workflow header). `--update-snapshots` rebases ALL snapshots.

## Test plan
- [x] `bash -n` on both scripts — clean
- [ ] After merge: `./scripts/local-release-rehearsal.sh --tag v5.0.9-rc1` runs all 5 stages
- [ ] After merge: `./scripts/local-visual-regression.sh` runs the chromium snapshot suite against local server