### PR TITLE
refactor(web): extract <V11Meter> component — single source of truth for stat-card chrome

### DIFF
--- a/parkhub-web/src/components/v11/V11Meter.tsx
+++ b/parkhub-web/src/components/v11/V11Meter.tsx
@@ -1,0 +1,70 @@
+/**
+ * V11Meter — SOTA-2026 stat-card primitive.
+ *
+ * Single source of truth for the .v11-meter chrome (PR #490). Replaces the
+ * 3 near-identical local StatCard re-implementations in AdminReports,
+ * AdminBilling, AdminAccessible (and any future copies).
+ *
+ * Tone modifiers map to the global CSS:
+ *   primary, accent, info, success, warn, danger
+ *
+ * Example:
+ *   <V11Meter
+ *     icon={<Users weight="bold" className="w-3.5 h-3.5" />}
+ *     label="Total users"
+ *     value={201}
+ *     tone="primary"
+ *     bar={201 / 1000}    // optional: 0..1 fill
+ *   />
+ */
+
+import type { ReactNode } from 'react';
+
+export type V11MeterTone =
+  | 'primary'
+  | 'accent'
+  | 'info'
+  | 'success'
+  | 'warn'
+  | 'danger';
+
+export interface V11MeterProps {
+  /** UPPERCASE eyebrow label rendered next to the icon. */
+  label: string;
+  /** Hero-size value (number → rendered as-is; string → use for $ / units). */
+  value: string | number;
+  /** Eyebrow icon — pass a Phosphor `<Foo weight="bold" className="w-3.5 h-3.5" />`. */
+  icon: ReactNode;
+  /** Color tone — drives the .v11-meter--{tone} CSS modifier. */
+  tone?: V11MeterTone;
+  /** Optional 0..1 fill for the bottom progress bar. Omit to hide the bar. */
+  bar?: number;
+  /** Optional `data-testid` for E2E hooks. */
+  testId?: string;
+}
+
+export function V11Meter({
+  label,
+  value,
+  icon,
+  tone = 'primary',
+  bar,
+  testId,
+}: V11MeterProps) {
+  const showBar = typeof bar === 'number';
+  const fillPct = showBar ? Math.min(Math.max(bar, 0), 1) * 100 : 0;
+  return (
+    <div className={`v11-meter v11-meter--${tone}`} data-testid={testId}>
+      <div className="v11-meter-eyebrow">
+        {icon}
+        {label}
+      </div>
+      <div className="v11-meter-value">{value}</div>
+      {showBar && (
+        <div className="v11-meter-bar" aria-hidden="true">
+          <i style={{ width: `${fillPct}%` }}></i>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/parkhub-web/src/views/AdminAccessible.tsx
+++ b/parkhub-web/src/views/AdminAccessible.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState, useCallback } from 'react';
 import { motion } from 'framer-motion';
 import { Wheelchair, Question, ToggleLeft, ToggleRight, ChartBar, UsersIcon } from '@phosphor-icons/react';
+import { V11Meter } from '../components/v11/V11Meter';
 import { useTranslation } from 'react-i18next';
 import toast from 'react-hot-toast';
 
@@ -213,14 +214,6 @@ function StatCard({ label, value, icon, tone = 'primary' }: {
   icon: React.ReactNode;
   tone?: 'primary' | 'accent' | 'info' | 'success' | 'warn' | 'danger';
 }) {
-  // v11 SOTA meter (PR #490) — same pattern as AdminReports + AdminBilling.
-  return (
-    <div className={`v11-meter v11-meter--${tone}`}>
-      <div className="v11-meter-eyebrow">
-        {icon}
-        {label}
-      </div>
-      <div className="v11-meter-value">{value}</div>
-    </div>
-  );
+  // Delegates to the shared V11Meter primitive.
+  return <V11Meter icon={icon} label={label} value={value} tone={tone} />;
 }

--- a/parkhub-web/src/views/AdminBilling.tsx
+++ b/parkhub-web/src/views/AdminBilling.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState, useCallback } from 'react';
 import { motion } from 'framer-motion';
 import { CurrencyDollar, ChartBar, DownloadSimpleIcon, Question, Buildings } from '@phosphor-icons/react';
+import { V11Meter } from '../components/v11/V11Meter';
 import { useTranslation } from 'react-i18next';
 import toast from 'react-hot-toast';
 
@@ -192,14 +193,6 @@ function SummaryCard({ label, value, icon, tone = 'primary' }: {
   icon: React.ReactNode;
   tone?: 'primary' | 'accent' | 'info' | 'success' | 'warn' | 'danger';
 }) {
-  // v11 SOTA meter from PR #490 — same pattern as AdminReports stat cards.
-  return (
-    <div className={`v11-meter v11-meter--${tone}`}>
-      <div className="v11-meter-eyebrow">
-        {icon}
-        {label}
-      </div>
-      <div className="v11-meter-value">{value}</div>
-    </div>
-  );
+  // Delegates to the shared V11Meter primitive (no local bar variant needed).
+  return <V11Meter icon={icon} label={label} value={value} tone={tone} />;
 }

--- a/parkhub-web/src/views/AdminReports.tsx
+++ b/parkhub-web/src/views/AdminReports.tsx
@@ -9,27 +9,27 @@ import { ExportButton } from '../components/ExportButton';
 
 const HEATMAP_STATUSES = new Set(['confirmed', 'active', 'completed']);
 
+// StatCard now delegates to the shared V11Meter primitive (extracted into
+// parkhub-web/src/components/v11/). Local wrapper preserves the previous
+// API (color prop + value-derived bar) so call sites don't change.
+import { V11Meter, type V11MeterTone } from '../components/v11/V11Meter';
+
 function StatCard({ icon: Icon, label, value, color = 'primary' }: {
   icon: Icon;
   label: string;
   value: number;
-  color?: 'primary' | 'accent' | 'info' | 'success' | 'warn' | 'danger';
+  color?: V11MeterTone;
 }) {
-  // v11 SOTA stat meter: colored left-edge bar, mono UPPERCASE eyebrow,
-  // hero-size value with color-mix(oklab) gradient wash. Pairs with the
-  // admin-hero card landed in PR #489. Color tone drives the semantic
-  // wash via the .v11-meter--{color} modifier.
+  // Bar fill: 0..1 derived from the value (legacy heuristic — same as before).
+  const bar = value > 0 ? Math.max(value / 200, 0.05) : 0;
   return (
-    <div className={`v11-meter v11-meter--${color}`}>
-      <div className="v11-meter-eyebrow">
-        <Icon weight="bold" className="w-3.5 h-3.5" />
-        {label}
-      </div>
-      <div className="v11-meter-value">{value}</div>
-      <div className="v11-meter-bar" aria-hidden="true">
-        <i style={{ width: `${Math.min(value > 0 ? Math.max(value / 200, 0.05) * 100 : 0, 100)}%` }}></i>
-      </div>
-    </div>
+    <V11Meter
+      icon={<Icon weight="bold" className="w-3.5 h-3.5" />}
+      label={label}
+      value={value}
+      tone={color}
+      bar={bar}
+    />
   );
 }
 


### PR DESCRIPTION
## Summary
The deep-dive audit found **3 near-identical local StatCard reimplementations** of the `.v11-meter` chrome (PR #490) across `AdminReports`, `AdminBilling`, `AdminAccessible`. Drift risk + maintenance overhead. This PR extracts the canonical implementation and refactors all 3 call sites to delegate.

## New: `parkhub-web/src/components/v11/V11Meter.tsx` (~70 LOC)
- Props: `label`, `value`, `icon` (ReactNode for max flexibility), `tone` (primary|accent|info|success|warn|danger), `bar` (optional 0..1 fill), `testId`.
- The optional `bar` prop unifies the AdminReports variant (with bottom progress bar) with the simpler AdminBilling/AdminAccessible variant (no bar).
- Public `V11MeterTone` type for downstream consumers.

## Refactored call sites
- **AdminReports.StatCard** — now a 6-line wrapper that maps the legacy (`icon: Icon`, value-derived bar) API onto V11Meter. Bar formula preserved exactly (0..1 normalized from `value/200`).
- **AdminBilling.SummaryCard** — now a 1-line delegate.
- **AdminAccessible.StatCard** — now a 1-line delegate.

## Net effect
3 files lost ~30 lines of duplicate JSX; +1 new component file with comprehensive types + jsdoc. Wash on LOC, big win on maintainability. Future stat-card uses (and the 13+ `<V11Meter>`-shape inline blocks the deep-dive flagged) can switch to the import.

## Follow-on PRs (per deep-dive plan)
- `<HeroEyebrow>` component (eyebrow + dot + icon + label, 26+ inline copies across admin + user-facing pages)
- Convert remaining inline `<div className="v11-meter ...">` blocks to `<V11Meter>`

## Test plan
- [x] `npx astro check` — 0 errors / 0 warnings / 994 hints (unchanged from main)
- [ ] After merge: visual smoke of /admin (AdminReports) → meter cards still render with bar; /admin/billing → no bar; /admin/accessible → no bar