### PR TITLE
refactor(web): extract <HeroEyebrow> component + 3-page PoC migration

### DIFF
--- a/parkhub-web/src/components/v11/HeroEyebrow.tsx
+++ b/parkhub-web/src/components/v11/HeroEyebrow.tsx
@@ -1,0 +1,37 @@
+/**
+ * HeroEyebrow — SOTA-2026 hero eyebrow primitive.
+ *
+ * Single source of truth for the .admin-hero-eyebrow chrome (PR #489).
+ * Renders the pulsing dot + icon + UPPERCASE label group used at the top
+ * of every v11 hero across all 45 admin + user-facing pages.
+ *
+ * Replaces the inline 4-line block:
+ *
+ *   <div className="admin-hero-eyebrow">
+ *     <span className="admin-hero-dot" aria-hidden="true"></span>
+ *     <Icon weight="bold" className="w-3.5 h-3.5" />
+ *     LABEL
+ *   </div>
+ *
+ * Example:
+ *   <HeroEyebrow icon={ShieldCheck} label={t('rbac.eyebrow', 'ACCESS CONTROL')} />
+ */
+
+import type { Icon as PhosphorIcon } from '@phosphor-icons/react';
+
+export interface HeroEyebrowProps {
+  /** Phosphor icon component (e.g. `ShieldCheck`, `MapPin`, `UserPlus`). */
+  icon: PhosphorIcon;
+  /** UPPERCASE eyebrow text — typically t('section.eyebrow', 'FALLBACK'). */
+  label: string;
+}
+
+export function HeroEyebrow({ icon: Icon, label }: HeroEyebrowProps) {
+  return (
+    <div className="admin-hero-eyebrow">
+      <span className="admin-hero-dot" aria-hidden="true"></span>
+      <Icon weight="bold" className="w-3.5 h-3.5" />
+      {label}
+    </div>
+  );
+}

--- a/parkhub-web/src/views/AdminPlugins.tsx
+++ b/parkhub-web/src/views/AdminPlugins.tsx
@@ -3,6 +3,7 @@ import { motion } from 'framer-motion';
 import { PuzzlePiece, ToggleLeft, ToggleRight, Gear, Question, Lightning } from '@phosphor-icons/react';
 import { useTranslation } from 'react-i18next';
 import toast from 'react-hot-toast';
+import { HeroEyebrow } from '../components/v11/HeroEyebrow';
 
 interface PluginRoute {
   path: string;
@@ -127,11 +128,7 @@ export function AdminPluginsPage() {
       {/* v11 SOTA hero — info tone (extension surface = expand cluster trust boundary). */}
       <section className="admin-hero admin-hero--info">
         <div className="admin-hero-left">
-          <div className="admin-hero-eyebrow">
-            <span className="admin-hero-dot" aria-hidden="true"></span>
-            <PuzzlePiece weight="bold" className="w-3.5 h-3.5" />
-            {t('plugins.eyebrow', 'EXTENSIONS')}
-          </div>
+          <HeroEyebrow icon={PuzzlePiece} label={t('plugins.eyebrow', 'EXTENSIONS')} />
           <h1 className="admin-hero-headline">{t('plugins.title')}</h1>
           <p className="admin-hero-sub">{t('plugins.subtitle')}</p>
         </div>

--- a/parkhub-web/src/views/AdminRoles.tsx
+++ b/parkhub-web/src/views/AdminRoles.tsx
@@ -3,6 +3,7 @@ import { motion, AnimatePresence } from 'framer-motion';
 import { ShieldCheck, Plus, Trash, PencilIcon, Question, UserCircleIcon } from '@phosphor-icons/react';
 import { useTranslation } from 'react-i18next';
 import toast from 'react-hot-toast';
+import { HeroEyebrow } from '../components/v11/HeroEyebrow';
 
 const ALL_PERMISSIONS = [
   'manage_users',
@@ -135,11 +136,7 @@ export function AdminRolesPage() {
       {/* v11 SOTA hero — info tone (access control = security-critical). */}
       <section className="admin-hero admin-hero--info">
         <div className="admin-hero-left">
-          <div className="admin-hero-eyebrow">
-            <span className="admin-hero-dot" aria-hidden="true"></span>
-            <ShieldCheck weight="bold" className="w-3.5 h-3.5" />
-            {t('rbac.eyebrow', 'ACCESS CONTROL')}
-          </div>
+          <HeroEyebrow icon={ShieldCheck} label={t('rbac.eyebrow', 'ACCESS CONTROL')} />
           <h1 className="admin-hero-headline">{t('rbac.title')}</h1>
           <p className="admin-hero-sub">{t('rbac.subtitle')}</p>
         </div>

--- a/parkhub-web/src/views/Vehicles.tsx
+++ b/parkhub-web/src/views/Vehicles.tsx
@@ -6,6 +6,7 @@ import { VehiclesSkeleton } from '../components/Skeleton';
 import { stagger, fadeUp } from '../constants/animations';
 import { useTranslation } from 'react-i18next';
 import toast from 'react-hot-toast';
+import { HeroEyebrow } from '../components/v11/HeroEyebrow';
 
 /**
  * Result contract between the add-vehicle action and the component:
@@ -115,11 +116,7 @@ export function VehiclesPage() {
       {/* v11 SOTA hero \u2014 primary tone, page-hero variant. */}
       <motion.section variants={item} className="admin-hero page-hero">
         <div className="admin-hero-left">
-          <div className="admin-hero-eyebrow">
-            <span className="admin-hero-dot" aria-hidden="true"></span>
-            <CarIcon weight="bold" className="w-3.5 h-3.5" />
-            {t('vehicles.eyebrow', 'MY FLEET')}
-          </div>
+          <HeroEyebrow icon={CarIcon} label={t('vehicles.eyebrow', 'MY FLEET')} />
           <h1 className="admin-hero-headline">{t('vehicles.title', 'Meine Fahrzeuge')}</h1>
           <p className="admin-hero-sub">{t('vehicles.subtitle', 'Fahrzeuge verwalten')}</p>
         </div>


### PR DESCRIPTION
## Summary
Second component-extraction PR after #524's `<V11Meter>`. Same architectural pattern: replace the 4-line inline `.admin-hero-eyebrow` block with a 1-line component call, keep the CSS contract intact.

## New: `parkhub-web/src/components/v11/HeroEyebrow.tsx` (~30 LOC)
Single source of truth for the dot + icon + UPPERCASE label group used at the top of every v11 hero across **45 admin + user-facing pages**.

```tsx
<HeroEyebrow icon={ShieldCheck} label={t('rbac.eyebrow', 'ACCESS CONTROL')} />
```

Props:
- `icon` — Phosphor `Icon` component (typed via `@phosphor-icons/react`)
- `label` — UPPERCASE eyebrow text (typically a `t()` call with fallback)

## 3-page PoC migration
- **AdminRoles.tsx** — ShieldCheck / `rbac.eyebrow` → ACCESS CONTROL
- **AdminPlugins.tsx** — PuzzlePiece / `plugins.eyebrow` → EXTENSIONS
- **Vehicles.tsx** — CarIcon / `vehicles.eyebrow` → MY FLEET

Each page lost a 4-line block + gained a 1-line component call.

## Type-safety bonus
My first attempt used a generic `ComponentType<{ weight?: string; className?: string }>` which TS rejected — Phosphor's `Icon` narrows weight to a string union (`thin | light | regular | bold | duotone | fill`). Switching to `import type { Icon as PhosphorIcon } from '@phosphor-icons/react'` restored the exact contract — call sites get full IntelliSense + can't pass a non-Phosphor component.

## Follow-on
42 remaining pages still use the inline 4-line block. Mechanical migration via the same pattern in a follow-up PR.

## Test plan
- [x] `npx astro check` — 0 errors / 0 warnings / 994 hints (unchanged)
- [ ] After merge: visual smoke of /admin/roles + /admin/plugins + /vehicles → eyebrow renders identically