### PR TITLE
chore(lefthook): wire workflow-drift + image-scan into pre-push (file-glob gated)

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -205,6 +205,34 @@ pre-push:
         OSV-Scanner found a vulnerability not in osv-scanner.toml.
         Triage upstream advisory or document the suppression with reason.
 
+    workflow-drift:
+      # Detects gitea ↔ github workflow drift (PR #519). Gating: missing
+      # files between sides fail; trigger/job-key drift is advisory.
+      # Only fires when workflow files touched, so doesn't slow down
+      # the typical Rust-only push.
+      glob: "{.github,.gitea}/workflows/**"
+      skip:
+        - run: 'test ! -x scripts/local-workflow-drift.sh'
+      run: ./scripts/local-workflow-drift.sh
+      fail_text: |
+        Workflow file missing on the other side (gitea ↔ github).
+        Add it, or document the exemption in scripts/local-workflow-drift.sh
+        EXEMPT lists.
+
+    image-scan:
+      # Local container image vulnerability scan (PR #513). Gating only on
+      # Dockerfile/Cargo.lock/package-lock changes — these are the inputs
+      # that determine image content. Stamp-cached so the script is fast
+      # if the inputs haven't changed since the last successful run.
+      glob: "{Dockerfile,Cargo.lock,parkhub-web/package-lock.json}"
+      skip:
+        - run: 'test ! -x scripts/local-image-scan.sh'
+        - run: 'test ! -x "$(command -v podman 2>/dev/null)"'
+      run: ./scripts/local-image-scan.sh
+      fail_text: |
+        Container image scan surfaced CRITICAL/HIGH vulnerabilities.
+        Triage with: trivy image parkhub-local:ci-* (see scripts/local-image-scan.sh)
+
     post-attestation:
       # Forks a deferred poll-and-post that waits until the SHA shows
       # up on GitHub (after `git push` transmits the commit) and then


### PR DESCRIPTION
## Summary
The local-* scripts shipped earlier this session (#513 image-scan, #519 workflow-drift) existed but only fired on manual invocation. This wires them into `pre-push` so they auto-run when their relevant inputs change — no surprise CI failures after push.

## Wired

### `workflow-drift`
- **Glob**: `.github/workflows/**`, `.gitea/workflows/**`
- **Gating**: missing files between sides fail; trigger/job-key drift is advisory (per the documented EXEMPT lists in `scripts/local-workflow-drift.sh`)

### `image-scan`
- **Glob**: `Dockerfile`, `Cargo.lock`, `parkhub-web/package-lock.json` (actual image content inputs)
- **Stamp-cached** — re-runs are fast when nothing changed since last success
- Skips silently if `podman` not on PATH (contributor-friendly)

## Pattern
Both follow the established lefthook patterns:
- `glob:` filters by changed files (no overhead when irrelevant)
- `skip:` graceful "skip if tool missing" via `test ! -x`
- `fail_text:` actionable error message with triage command

## Order
After `osv-scanner`, before `post-attestation`. So if either scan fails, the deferred status post doesn't fire — keeps the GitHub `local-ci-attestation` gate honest.

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(open('lefthook.yml'))"` — clean
- [ ] After merge: touch `.github/workflows/ci.yml` → push → workflow-drift fires
- [ ] After merge: touch `Dockerfile` → push → image-scan fires (stamp-cached if no real change)