### PR TITLE
refactor(web): HeroEyebrow icon prop now optional — sweep 3 iconless usages

### DIFF
--- a/parkhub-web/src/components/v11/HeroEyebrow.tsx
+++ b/parkhub-web/src/components/v11/HeroEyebrow.tsx
@@ -12,8 +12,9 @@
 import type { Icon as PhosphorIcon } from '@phosphor-icons/react';
 
 export interface HeroEyebrowProps {
-  /** Phosphor icon component (e.g. `ShieldCheck`, `MapPin`, `UserPlus`). */
-  icon: PhosphorIcon;
+  /** Optional Phosphor icon (e.g. `ShieldCheck`). Omit for an iconless
+      eyebrow (used by Admin shell + AdminUsers + AdminLots). */
+  icon?: PhosphorIcon;
   /** UPPERCASE eyebrow text — typically t('section.eyebrow', 'FALLBACK'). */
   label: string;
 }
@@ -22,7 +23,7 @@ export function HeroEyebrow({ icon: Icon, label }: HeroEyebrowProps) {
   return (
     <div className="admin-hero-eyebrow">
       <span className="admin-hero-dot" aria-hidden="true"></span>
-      <Icon weight="bold" className="w-3.5 h-3.5" />
+      {Icon && <Icon weight="bold" className="w-3.5 h-3.5" />}
       {label}
     </div>
   );

--- a/parkhub-web/src/views/Admin.tsx
+++ b/parkhub-web/src/views/Admin.tsx
@@ -7,6 +7,7 @@ import {
   Buildings, ClockCounterClockwiseIcon, Database, CarIcon, Wheelchair, Wrench, CurrencyDollar, UserPlusIcon, Lightning,
   PuzzlePiece, GraphicsCard, ShieldCheck, LockKey, MapTrifold, ArrowsClockwiseIcon, List, XIcon, ArrowSquareOut,
 } from '@phosphor-icons/react';
+import { HeroEyebrow } from '../components/v11/HeroEyebrow';
 
 /**
  * Admin shell — categorised sidebar on desktop, mobile drawer on small
@@ -210,10 +211,7 @@ export function AdminPage() {
       */}
       <section className="admin-hero hidden lg:block mb-6">
         <div className="admin-hero-left">
-          <div className="admin-hero-eyebrow">
-            <span className="admin-hero-dot" aria-hidden="true"></span>
-            {t('admin.studio_label', 'MARBLE GOVERNANCE STUDIO')}
-          </div>
+          <HeroEyebrow label={t('admin.studio_label', 'MARBLE GOVERNANCE STUDIO')} />
           <h1 className="admin-hero-headline">{t('admin.title')}</h1>
           <p className="admin-hero-sub">{t('admin.subtitle')}</p>
         </div>

--- a/parkhub-web/src/views/AdminLots.tsx
+++ b/parkhub-web/src/views/AdminLots.tsx
@@ -8,6 +8,7 @@ import { api, type ParkingLot, type CreateLotRequest, type UpdateLotRequest, typ
 import { useTranslation } from 'react-i18next';
 import toast from 'react-hot-toast';
 import { ConfirmDialog } from '../components/ui/ConfirmDialog';
+import { HeroEyebrow } from '../components/v11/HeroEyebrow';
 
 interface LotForm {
   name: string;
@@ -224,10 +225,7 @@ export function AdminLotsPage() {
       {/* v11 SOTA hero — emerald tone (parking inventory = healthy operational state). */}
       <section className="admin-hero admin-hero--emerald">
         <div className="admin-hero-left">
-          <div className="admin-hero-eyebrow">
-            <span className="admin-hero-dot" aria-hidden="true"></span>
-            {t('lots.eyebrow', 'OPERATIONS · PARKING NETWORK')}
-          </div>
+          <HeroEyebrow label={t('lots.eyebrow', 'OPERATIONS · PARKING NETWORK')} />
           <h1 className="admin-hero-headline">{t('admin.lots')}</h1>
           <p className="admin-hero-sub">{t('lots.count', '{{count}} lots online', { count: lots.length })}</p>
         </div>

--- a/parkhub-web/src/views/AdminUsers.tsx
+++ b/parkhub-web/src/views/AdminUsers.tsx
@@ -11,6 +11,7 @@ import { ConfirmDialog } from '../components/ui/ConfirmDialog';
 import { useTranslation } from 'react-i18next';
 import toast from 'react-hot-toast';
 import { DataTable } from '../components/ui/DataTable';
+import { HeroEyebrow } from '../components/v11/HeroEyebrow';
 
 const columnHelper = createColumnHelper<User>();
 
@@ -315,10 +316,7 @@ export function AdminUsersPage() {
       {/* v11 SOTA hero — primary tone (people & access). */}
       <section className="admin-hero">
         <div className="admin-hero-left">
-          <div className="admin-hero-eyebrow">
-            <span className="admin-hero-dot" aria-hidden="true"></span>
-            {t('users.eyebrow', 'PEOPLE & ACCESS')}
-          </div>
+          <HeroEyebrow label={t('users.eyebrow', 'PEOPLE & ACCESS')} />
           <h1 className="admin-hero-headline">{t('admin.users')}</h1>
           <p className="admin-hero-sub">
             {t('users.count', '{{count}} active', { count: users.length })}


### PR DESCRIPTION
## Summary
The eyebrow extraction (#525 + #526) only matched the icon-bearing pattern. **AdminUsers**, **AdminLots**, and **Admin** (the shell) use the eyebrow without an icon — those weren't migrated and still had the inline 4-line block.

## Changes

### 1. `<HeroEyebrow icon>` is now optional
```ts
icon?: PhosphorIcon  // was: icon: PhosphorIcon
```
The component renders the icon only when provided.

### 2. Migrate 3 iconless usages
- **AdminUsers**: `<HeroEyebrow label={t('users.eyebrow', 'PEOPLE & ACCESS')} />`
- **AdminLots**: `<HeroEyebrow label={t('lots.eyebrow', 'OPERATIONS · PARKING NETWORK')} />`
- **Admin** (shell): `<HeroEyebrow label={t('admin.studio_label', 'MARBLE GOVERNANCE STUDIO')} />`

## Result
After this PR, **all 48 eyebrow usages across parkhub-web/src/views/** go through the single `<HeroEyebrow>` component. **Zero inline copies left.**

## Test plan
- [x] `npx astro check` — 0 errors / 0 warnings / 994 hints (unchanged)
- [ ] After merge: visual smoke /admin (shell) → eyebrow renders without icon; /admin/users → "PEOPLE & ACCESS" eyebrow correct