### PR TITLE
chore(web): replace deprecated FormEvent with SyntheticEvent (React 19 path)

### DIFF
--- a/parkhub-web/src/components/ConfigEditor.tsx
+++ b/parkhub-web/src/components/ConfigEditor.tsx
@@ -23,7 +23,6 @@
  */
 
 import {
-  type FormEvent,
   type ReactNode,
   useCallback,
   useEffect,
@@ -207,7 +206,9 @@ export function ConfigEditor({
     if (node) firstFieldRef.current = node;
   }, []);
 
-  const onSubmit = async (e: FormEvent<HTMLFormElement>) => {
+  // React 19 deprecated FormEvent in favor of inline event types via JSX
+  // inference. Typing the form-submit handler explicitly avoids that path.
+  const onSubmit = async (e: React.SyntheticEvent<HTMLFormElement>) => {
     e.preventDefault();
     const errs = validateShape(schema, local);
     if (errs.length > 0) {

--- a/parkhub-web/src/components/PaymentModal.tsx
+++ b/parkhub-web/src/components/PaymentModal.tsx
@@ -48,7 +48,8 @@ export function PaymentModal({ open, onClose, onSuccess, amountCents, currency =
     && cvc.length >= 3
     && name.trim().length > 0;
 
-  const handleSubmit = async (e: React.FormEvent) => {
+  // React 19 deprecated React.FormEvent in favor of SyntheticEvent / inline JSX inference.
+  const handleSubmit = async (e: React.SyntheticEvent) => {
     e.preventDefault();
     if (!isFormValid) return;
 


### PR DESCRIPTION
## Summary
React 19 deprecated `FormEvent` in favor of inline event types via JSX inference. The 3 remaining `ts(6385) FormEvent` warnings (the only deprecation hints left after #535) are now gone.

## Changes
- `ConfigEditor.tsx`: drops `type FormEvent` import; types `onSubmit` parameter as `React.SyntheticEvent<HTMLFormElement>` (parent of FormEvent in React's type hierarchy, not deprecated).
- `PaymentModal.tsx`: `handleSubmit` parameter typed as `React.SyntheticEvent` (no specific element type needed since the handler doesn't access form-specific fields).

Both `e.preventDefault()` calls work unchanged — `preventDefault` is on the base `SyntheticEvent` interface.

## Test plan
- [x] `npx astro check` after fix: 0 errors / 0 warnings / **92 hints** (was 95)
- [ ] After merge: visual smoke /admin/plugins (ConfigEditor) + /book payment step (PaymentModal) → forms still submit correctly

The 92 remaining hints are 81 unused-variable warnings + ~10 framework API drift items not actionable from app code.