### PR TITLE
chore(web): exclude coverage/ from astro check + gitignore

### DIFF
--- a/parkhub-web/.gitignore
+++ b/parkhub-web/.gitignore
@@ -24,3 +24,6 @@ pnpm-debug.log*
 .idea/
 test-results/
 playwright-report/
+
+# vitest --coverage output
+coverage/

--- a/parkhub-web/tsconfig.json
+++ b/parkhub-web/tsconfig.json
@@ -6,6 +6,7 @@
   ],
   "exclude": [
     "dist",
+    "coverage",
     "**/*.stories.tsx",
     "**/*.stories.ts"
   ],


### PR DESCRIPTION
## Summary
`vitest --coverage` (introduced in #528 and run as part of `local-coverage.sh`) emits to `parkhub-web/coverage/lcov-report/` which includes `prettify.js` (a minified syntax highlighter for the HTML report). Astro check was scanning that file and surfacing 4 ts(6133) unused-variable warnings on minified single-letter names (`ae`, `ag`, `af`, `ae`).

## Two coordinated fixes
1. **`tsconfig.json`**: add `coverage` to exclude (alongside `dist` + stories). astro check + tsc now skip the directory entirely.
2. **`.gitignore`**: add `coverage/` so future `vitest run --coverage` outputs aren't accidentally committed.

## Results
| | Before | After |
|---|--------|-------|
| astro check hints | 92 | **88 (-4)** |

The remaining 88 hints are 81 unused-variable warnings in `*.test.tsx` files (mostly stale React imports + unused destructured types — would need a per-file sweep to clear) plus ~7 framework API drift items not actionable from app code.

## Test plan
- [x] `npx astro check` — 0 errors / 0 warnings / 88 hints
- [x] `git diff --check` clean