### PR TITLE
chore(web): remove 23 stale `import React` lines from test files (React 17+ JSX)

### DIFF
--- a/parkhub-web/src/components/AnimatedCounter.test.tsx
+++ b/parkhub-web/src/components/AnimatedCounter.test.tsx
@@ -1,5 +1,4 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import React from 'react';
 import { act, render, screen } from '@testing-library/react';
 
 import { AnimatedCounter } from './AnimatedCounter';

--- a/parkhub-web/src/components/ExportButton.test.tsx
+++ b/parkhub-web/src/components/ExportButton.test.tsx
@@ -1,5 +1,4 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { ExportButton, type ExportType } from './ExportButton';
 

--- a/parkhub-web/src/components/LoginHistory.test.tsx
+++ b/parkhub-web/src/components/LoginHistory.test.tsx
@@ -1,5 +1,4 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 

--- a/parkhub-web/src/components/NotificationPreferences.test.tsx
+++ b/parkhub-web/src/components/NotificationPreferences.test.tsx
@@ -1,5 +1,4 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import React from 'react';
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 

--- a/parkhub-web/src/components/OAuthButtons.test.tsx
+++ b/parkhub-web/src/components/OAuthButtons.test.tsx
@@ -1,5 +1,4 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 
 vi.mock('react-i18next', () => ({

--- a/parkhub-web/src/components/OccupancyHeatmap.test.tsx
+++ b/parkhub-web/src/components/OccupancyHeatmap.test.tsx
@@ -1,5 +1,4 @@
 import { describe, it, expect } from 'vitest';
-import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { OccupancyHeatmap, computeHeatmapData, heatmapColor } from './OccupancyHeatmap';
 import type { Booking } from '../api/client';

--- a/parkhub-web/src/components/PWAEnhanced.test.tsx
+++ b/parkhub-web/src/components/PWAEnhanced.test.tsx
@@ -1,5 +1,4 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import React from 'react';
 import { render, screen, waitFor, fireEvent, act } from '@testing-library/react';
 
 const { mockNavigate, mockLocation } = vi.hoisted(() => ({

--- a/parkhub-web/src/components/ParkingPass.test.tsx
+++ b/parkhub-web/src/components/ParkingPass.test.tsx
@@ -1,5 +1,4 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 
 // ── Mocks ──

--- a/parkhub-web/src/components/ProfileThemeSection.test.tsx
+++ b/parkhub-web/src/components/ProfileThemeSection.test.tsx
@@ -1,5 +1,4 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 

--- a/parkhub-web/src/components/SSOButtons.test.tsx
+++ b/parkhub-web/src/components/SSOButtons.test.tsx
@@ -1,5 +1,4 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import React from 'react';
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 
 vi.mock('react-i18next', () => ({

--- a/parkhub-web/src/components/SimpleChart.test.tsx
+++ b/parkhub-web/src/components/SimpleChart.test.tsx
@@ -1,5 +1,4 @@
 import { describe, it, expect } from 'vitest';
-import React from 'react';
 import { render } from '@testing-library/react';
 import { BarChart, DonutChart, type DonutSlice } from './SimpleChart';
 

--- a/parkhub-web/src/components/Skeleton.test.tsx
+++ b/parkhub-web/src/components/Skeleton.test.tsx
@@ -1,5 +1,4 @@
 import { describe, it, expect } from 'vitest';
-import React from 'react';
 import { render } from '@testing-library/react';
 import {
   SkeletonText,

--- a/parkhub-web/src/components/TwoFactorSetup.test.tsx
+++ b/parkhub-web/src/components/TwoFactorSetup.test.tsx
@@ -1,5 +1,4 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 

--- a/parkhub-web/src/components/ui/Breadcrumb.test.tsx
+++ b/parkhub-web/src/components/ui/Breadcrumb.test.tsx
@@ -1,5 +1,4 @@
 import { describe, it, expect, vi } from 'vitest';
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 

--- a/parkhub-web/src/context/FeaturesContext.test.tsx
+++ b/parkhub-web/src/context/FeaturesContext.test.tsx
@@ -1,5 +1,4 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 

--- a/parkhub-web/src/context/ThemeContext.test.tsx
+++ b/parkhub-web/src/context/ThemeContext.test.tsx
@@ -1,5 +1,4 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 

--- a/parkhub-web/src/context/UseCaseContext.test.tsx
+++ b/parkhub-web/src/context/UseCaseContext.test.tsx
@@ -1,5 +1,4 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 

--- a/parkhub-web/src/views/AdminAnalytics.test.tsx
+++ b/parkhub-web/src/views/AdminAnalytics.test.tsx
@@ -1,5 +1,4 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 
 vi.mock('react-i18next', () => ({

--- a/parkhub-web/src/views/ApiDocs.test.tsx
+++ b/parkhub-web/src/views/ApiDocs.test.tsx
@@ -1,5 +1,4 @@
 import { describe, it, expect, vi } from 'vitest';
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { useTranslation } from 'react-i18next';
 

--- a/parkhub-web/src/views/ApiVersion.test.tsx
+++ b/parkhub-web/src/views/ApiVersion.test.tsx
@@ -1,5 +1,4 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 
 vi.mock('react-i18next', () => ({

--- a/parkhub-web/src/views/LobbyDisplay.test.tsx
+++ b/parkhub-web/src/views/LobbyDisplay.test.tsx
@@ -1,5 +1,4 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 
 // ── Mocks ──

--- a/parkhub-web/src/views/NotFound.test.tsx
+++ b/parkhub-web/src/views/NotFound.test.tsx
@@ -1,5 +1,4 @@
 import { describe, it, expect, vi } from 'vitest';
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 
 // ── Mocks ──

--- a/parkhub-web/src/views/SetupWizard.test.tsx
+++ b/parkhub-web/src/views/SetupWizard.test.tsx
@@ -1,5 +1,4 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import React from 'react';
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 
 // ── Mocks ──


### PR DESCRIPTION
## Summary
React 17 enabled the new JSX transform that doesn't require an explicit React import in scope. Most test files were still carrying the legacy `import React from 'react';` line which TS now flags as ts(6133) "is declared but never read".

This sweep removes the line from every test file where ts(6133) specifically flagged React. Mechanical, idempotent — only touches files where astro check confirmed React was unused.

## Sweep stats
- **23 files** (.test.tsx)
- **-23 lines**

## Files
- **components**: AnimatedCounter, ExportButton, LoginHistory, NotificationPreferences, OAuthButtons, OccupancyHeatmap, PWAEnhanced, ParkingPass, ProfileThemeSection, SSOButtons, SimpleChart, Skeleton, TwoFactorSetup, ui/Breadcrumb
- **context**: FeaturesContext, ThemeContext, UseCaseContext
- **views**: AdminAnalytics, ApiDocs, ApiVersion, LobbyDisplay, NotFound, SetupWizard

## Net astro check result
| | Hints |
|---|---|
| Before (#538) | 88 |
| **After** | **65 (-23)** |

The remaining 65 hints are 58 unused-variable warnings (other names — not React; would need per-file review) + 7 framework API drift items.

## Cumulative session reduction
**994 → 65 hints (-929)** across the icon sweeps + FormEvent + coverage exclude + this React sweep.

## Test plan
- [x] `npx astro check` — 0 errors / 0 warnings / 65 hints