### PR TITLE
chore(web): prefix 11 unused mock-callback params with `_` (TS convention)

### DIFF
--- a/parkhub-web/src/views/AdminRoles.test.tsx
+++ b/parkhub-web/src/views/AdminRoles.test.tsx
@@ -26,7 +26,7 @@ const roles = [
 describe('AdminRolesPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    globalThis.fetch = vi.fn((url: string, opts?: any) => {
+    globalThis.fetch = vi.fn((_url: string, opts?: any) => {
       if (opts?.method === 'DELETE') return Promise.resolve({ json: () => Promise.resolve({ success: true }) } as Response);
       if (opts?.method === 'POST' || opts?.method === 'PUT') return Promise.resolve({ json: () => Promise.resolve({ success: true }) } as Response);
       return Promise.resolve({ json: () => Promise.resolve({ success: true, data: roles }) } as Response);
@@ -127,7 +127,7 @@ describe('AdminRolesPage', () => {
   });
 
   it('handles save error', async () => {
-    globalThis.fetch = vi.fn((url: string, opts?: any) => {
+    globalThis.fetch = vi.fn((_url: string, opts?: any) => {
       if (opts?.method === 'POST') return Promise.resolve({ json: () => Promise.resolve({ success: false, error: { message: 'Duplicate' } }) } as Response);
       return Promise.resolve({ json: () => Promise.resolve({ success: true, data: roles }) } as Response);
     }) as any;
@@ -140,7 +140,7 @@ describe('AdminRolesPage', () => {
   });
 
   it('handles save network error', async () => {
-    globalThis.fetch = vi.fn((url: string, opts?: any) => {
+    globalThis.fetch = vi.fn((_url: string, opts?: any) => {
       if (opts?.method === 'POST') return Promise.reject(new Error('net'));
       return Promise.resolve({ json: () => Promise.resolve({ success: true, data: roles }) } as Response);
     }) as any;
@@ -164,7 +164,7 @@ describe('AdminRolesPage', () => {
   });
 
   it('handles delete error response', async () => {
-    globalThis.fetch = vi.fn((url: string, opts?: any) => {
+    globalThis.fetch = vi.fn((_url: string, opts?: any) => {
       if (opts?.method === 'DELETE') return Promise.resolve({ json: () => Promise.resolve({ success: false, error: { message: 'In use' } }) } as Response);
       return Promise.resolve({ json: () => Promise.resolve({ success: true, data: roles }) } as Response);
     }) as any;
@@ -174,7 +174,7 @@ describe('AdminRolesPage', () => {
   });
 
   it('handles delete network error', async () => {
-    globalThis.fetch = vi.fn((url: string, opts?: any) => {
+    globalThis.fetch = vi.fn((_url: string, opts?: any) => {
       if (opts?.method === 'DELETE') return Promise.reject(new Error('net'));
       return Promise.resolve({ json: () => Promise.resolve({ success: true, data: roles }) } as Response);
     }) as any;

--- a/parkhub-web/src/views/AdminSSO.test.tsx
+++ b/parkhub-web/src/views/AdminSSO.test.tsx
@@ -208,7 +208,7 @@ describe('AdminSSOPage', () => {
   });
 
   it('deletes provider', async () => {
-    globalThis.fetch = vi.fn((url: string, opts?: any) => {
+    globalThis.fetch = vi.fn((_url: string, opts?: any) => {
       if (opts?.method === 'DELETE') return Promise.resolve({ json: () => Promise.resolve({ success: true }) } as any);
       return Promise.resolve({ json: () => Promise.resolve({ success: true, data: sampleProviders }) } as any);
     }) as any;
@@ -267,7 +267,7 @@ describe('AdminSSOPage', () => {
   });
 
   it('save error response', async () => {
-    globalThis.fetch = vi.fn((url: string, opts?: any) => {
+    globalThis.fetch = vi.fn((_url: string, opts?: any) => {
       if (opts?.method === 'PUT') return Promise.resolve({ json: () => Promise.resolve({ success: false, error: { message: 'Duplicate slug' } }) } as any);
       return Promise.resolve({ json: () => Promise.resolve({ success: true, data: { providers: [] } }) } as any);
     }) as any;
@@ -285,7 +285,7 @@ describe('AdminSSOPage', () => {
   });
 
   it('save network error', async () => {
-    globalThis.fetch = vi.fn((url: string, opts?: any) => {
+    globalThis.fetch = vi.fn((_url: string, opts?: any) => {
       if (opts?.method === 'PUT') return Promise.reject(new Error('net'));
       return Promise.resolve({ json: () => Promise.resolve({ success: true, data: { providers: [] } }) } as any);
     }) as any;

--- a/parkhub-web/src/views/AdminScheduledReports.test.tsx
+++ b/parkhub-web/src/views/AdminScheduledReports.test.tsx
@@ -128,7 +128,7 @@ describe('AdminScheduledReportsPage', () => {
 
   it('handles save error', async () => {
     const user = userEvent.setup();
-    globalThis.fetch = vi.fn((url: string, opts?: any) => {
+    globalThis.fetch = vi.fn((_url: string, opts?: any) => {
       if (opts?.method === 'POST') return Promise.reject(new Error('net'));
       return Promise.resolve({ json: () => Promise.resolve({ success: true, data: { schedules } }) } as Response);
     }) as any;
@@ -167,7 +167,7 @@ describe('AdminScheduledReportsPage', () => {
   });
 
   it('handles delete error', async () => {
-    globalThis.fetch = vi.fn((url: string, opts?: any) => {
+    globalThis.fetch = vi.fn((_url: string, opts?: any) => {
       if (opts?.method === 'DELETE') return Promise.reject(new Error('net'));
       return Promise.resolve({ json: () => Promise.resolve({ success: true, data: { schedules } }) } as Response);
     }) as any;

--- a/parkhub-web/src/views/Book.test.tsx
+++ b/parkhub-web/src/views/Book.test.tsx
@@ -563,7 +563,7 @@ describe('BookPage', () => {
     // Verify the badge mapping exists and has correct labels
     const badges = ['your_usual_spot', 'best_price', 'closest_entrance', 'available_now', 'preferred_lot', 'accessible'];
     const expectedLabels = ['Your usual spot', 'Best price', 'Closest', 'Available now', 'Preferred lot', 'Accessible'];
-    badges.forEach((badge, i) => {
+    badges.forEach((_badge, i) => {
       // The badgeLabels constant is embedded in the component; verify these strings exist in the source
       expect(expectedLabels[i]).toBeTruthy();
     });


### PR DESCRIPTION
## Summary
Mechanical, data-driven sweep — for each `ts(6133)` warning at a function-parameter position in a `*.test.tsx` file, prefix the unused name with `_`. TypeScript's `noUnusedParameters` check then accepts the param as "intentionally unused" without code change.

## Conservative
- **Test files only** (production code unused-vars may signal real bugs)
- **Position-precise**: only edits the exact (line, col) astro reports
- **Param-position only**: detects `(name…` or `,name…` followed by `:` or `)`
- **Idempotent**: skips names already starting with `_`

## Sweep stats
**11 params prefixed across 4 files.**

| File | Sites |
|------|-------|
| AdminRoles.test.tsx | 5 fetch mock callbacks |
| AdminSSO.test.tsx | 3 fetch mock callbacks |
| AdminScheduledReports.test.tsx | 2 fetch mock callbacks (url + opts) |
| Book.test.tsx | 1 fetch mock callback |

## Net astro check result
| | Hints |
|---|---|
| Before (#540) | 55 |
| **After** | **44 (-11)** |

**Cumulative session reduction**: 994 → 44 hints (**-950, -95.6%**)

## Test plan
- [x] `npx astro check` — 0 errors / 0 warnings / 44 hints
- [x] Spot-checked diff: only param renames, function bodies unchanged