### PR TITLE
chore(web): prefix 8 more unused mock-callback params (round 2 — handles `opts?:`)

### DIFF
--- a/parkhub-web/src/views/AdminScheduledReports.test.tsx
+++ b/parkhub-web/src/views/AdminScheduledReports.test.tsx
@@ -150,7 +150,7 @@ describe('AdminScheduledReportsPage', () => {
   });
 
   it('does not show success toast when send-now response is unsuccessful', async () => {
-    globalThis.fetch = vi.fn((url: string, opts?: any) => {
+    globalThis.fetch = vi.fn((url: string, _opts?: any) => {
       if (url.includes('send-now')) return Promise.resolve({ json: () => Promise.resolve({ success: false }) } as Response);
       return Promise.resolve({ json: () => Promise.resolve({ success: true, data: { schedules } }) } as Response);
     }) as any;
@@ -177,7 +177,7 @@ describe('AdminScheduledReportsPage', () => {
   });
 
   it('handles send-now error', async () => {
-    globalThis.fetch = vi.fn((url: string, opts?: any) => {
+    globalThis.fetch = vi.fn((url: string, _opts?: any) => {
       if (url.includes('send-now')) return Promise.reject(new Error('net'));
       return Promise.resolve({ json: () => Promise.resolve({ success: true, data: { schedules } }) } as Response);
     }) as any;

--- a/parkhub-web/src/views/AdminWebhooks.test.tsx
+++ b/parkhub-web/src/views/AdminWebhooks.test.tsx
@@ -108,7 +108,7 @@ describe('AdminWebhooksPage', () => {
   });
 
   it('test webhook failure response', async () => {
-    globalThis.fetch = vi.fn((url: string, opts?: any) => {
+    globalThis.fetch = vi.fn((url: string, _opts?: any) => {
       if (url.includes('/test')) return Promise.resolve({ json: () => Promise.resolve({ success: true, data: { success: false } }) } as Response);
       return Promise.resolve({ json: () => Promise.resolve({ success: true, data: webhooks }) } as Response);
     }) as any;

--- a/parkhub-web/src/views/SwapRequests.test.tsx
+++ b/parkhub-web/src/views/SwapRequests.test.tsx
@@ -135,7 +135,7 @@ describe('SwapRequestsPage', () => {
   });
 
   it('accept error', async () => {
-    globalThis.fetch = vi.fn((url: string, opts?: any) => {
+    globalThis.fetch = vi.fn((url: string, _opts?: any) => {
       if (url.includes('/accept')) return Promise.resolve({ json: () => Promise.resolve({ success: false, error: { message: 'Already handled' } }) } as Response);
       return Promise.resolve({ json: () => Promise.resolve({ success: true, data: requests }) } as Response);
     }) as any;
@@ -145,7 +145,7 @@ describe('SwapRequestsPage', () => {
   });
 
   it('decline error', async () => {
-    globalThis.fetch = vi.fn((url: string, opts?: any) => {
+    globalThis.fetch = vi.fn((url: string, _opts?: any) => {
       if (url.includes('/decline')) return Promise.reject(new Error('net'));
       return Promise.resolve({ json: () => Promise.resolve({ success: true, data: requests }) } as Response);
     }) as any;

--- a/parkhub-web/src/views/Translations.test.tsx
+++ b/parkhub-web/src/views/Translations.test.tsx
@@ -54,7 +54,7 @@ vi.mock('@phosphor-icons/react', () => ({
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
-    t: (key: string, opts?: any) => {
+    t: (key: string, _opts?: any) => {
       const map: Record<string, string> = {
         'translations.title': 'Translations',
         'translations.subtitle': 'Help improve translations',

--- a/parkhub-web/src/views/Visitors.test.tsx
+++ b/parkhub-web/src/views/Visitors.test.tsx
@@ -323,7 +323,7 @@ describe('VisitorsPage - extended', () => {
   it('shows error when registration server returns failure', async () => {
     const toast = await import('react-hot-toast');
     const errSpy = vi.spyOn(toast.default, 'error');
-    (global as any).fetch = vi.fn((url: string, opts?: any) => {
+    (global as any).fetch = vi.fn((url: string, _opts?: any) => {
       if (typeof url === 'string' && url.includes('/visitors/register')) {
         return Promise.resolve({ json: () => Promise.resolve({ success: false, error: { message: 'Server fail' } }) } as Response);
       }
@@ -352,7 +352,7 @@ describe('VisitorsPage - extended', () => {
   it('catches network errors during registration', async () => {
     const toast = await import('react-hot-toast');
     const errSpy = vi.spyOn(toast.default, 'error');
-    (global as any).fetch = vi.fn((url: string, opts?: any) => {
+    (global as any).fetch = vi.fn((url: string, _opts?: any) => {
       if (typeof url === 'string' && url.includes('/visitors/register')) {
         return Promise.reject(new Error('boom'));
       }


### PR DESCRIPTION
## Summary
Follow-up to #541 that catches the optional-param syntax (`?:`) my position-detector missed first time. Same data-driven approach: only prefixes the exact (line, col) astro reports.

## Sweep stats
**8 params prefixed across 5 files.**

| File | Sites |
|------|-------|
| AdminScheduledReports.test.tsx | 2 |
| AdminWebhooks.test.tsx | 1 |
| SwapRequests.test.tsx | 2 |
| Translations.test.tsx | 1 |
| Visitors.test.tsx | 2 |

## Script update
`/tmp/prefix_unused_params.py` param-position detector now allows `?:` (optional param syntax) after the identifier, alongside the existing `:` / `,` / `)` / `=` matches.

## Net astro check result
| | Hints |
|---|---|
| Before (#541) | 44 |
| **After** | **36 (-8)** |

**Cumulative session reduction**: 994 → 36 hints (**-958, -96.4%**)

## Test plan
- [x] `npx astro check` — 0 errors / 0 warnings / 36 hints