### PR TITLE
chore(web): remove 3 unused TS type-only named imports

### DIFF
--- a/parkhub-web/src/components/ExportButton.test.tsx
+++ b/parkhub-web/src/components/ExportButton.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import { ExportButton, type ExportType } from './ExportButton';
+import { ExportButton } from './ExportButton';
 
 vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (_: string, f: string) => f }) }));
 

--- a/parkhub-web/src/components/GenerativeBg.test.tsx
+++ b/parkhub-web/src/components/GenerativeBg.test.tsx
@@ -19,7 +19,7 @@ vi.mock('framer-motion', () => ({
   },
 }));
 
-import { GenerativeBg, useBgClass, type BgPattern } from './GenerativeBg';
+import { GenerativeBg, useBgClass } from './GenerativeBg';
 
 describe('GenerativeBg', () => {
   afterEach(() => {

--- a/parkhub-web/src/context/FeaturesContext.test.tsx
+++ b/parkhub-web/src/context/FeaturesContext.test.tsx
@@ -29,7 +29,6 @@ import {
   useFeatures,
   FEATURE_REGISTRY,
   USE_CASE_PRESETS,
-  type FeatureModule,
 } from './FeaturesContext';
 
 // Helper component to consume the context


### PR DESCRIPTION
## Summary
Round 3 of the test-file unused-import sweep. The previous rounds caught default + value imports; this catches the `type Name` named-import syntax (TypeScript's type-only imports introduced in TS 3.8).

## Sweep stats
**3 files, 3 unused type names removed.**

| File | Removed |
|------|---------|
| ExportButton.test.tsx | `type ExportType` |
| GenerativeBg.test.tsx | `type BgPattern` |
| FeaturesContext.test.tsx | `type FeatureModule` |

## Script update
`/tmp/remove_unused_named_imports.py` — when computing the "bare name" for matching against unused-name set, strip the `type ` prefix that distinguishes TS type-only named imports.

## Net astro check result
| | Hints |
|---|---|
| Before (#542) | 36 |
| **After** | **33 (-3)** |

**Cumulative session reduction**: 994 → 33 hints (**-961, -96.7%**)

## Test plan
- [x] `npx astro check` — 0 errors / 0 warnings / 33 hints