### PR TITLE
fix(admin-lots): render filtered lot count badge in table header

### DIFF
--- a/parkhub-web/src/views/AdminLots.tsx
+++ b/parkhub-web/src/views/AdminLots.tsx
@@ -533,7 +533,10 @@ export function AdminLotsPage() {
           <table className="w-full">
             <thead>
               <tr className="border-b border-surface-200 dark:border-surface-700">
-                <th className="text-left px-5 py-3.5 text-xs font-semibold text-surface-500 dark:text-surface-400 uppercase tracking-wider">{t('admin.lots')}</th>
+                <th className="text-left px-5 py-3.5 text-xs font-semibold text-surface-500 dark:text-surface-400 uppercase tracking-wider">
+                  {t('admin.lots')}{' '}
+                  <span className="font-normal normal-case text-surface-400">({filtered.length})</span>
+                </th>
                 <th className="text-left px-5 py-3.5 text-xs font-semibold text-surface-500 dark:text-surface-400 uppercase tracking-wider">{t('admin.totalSlots')}</th>
                 <th className="text-left px-5 py-3.5 text-xs font-semibold text-surface-500 dark:text-surface-400 uppercase tracking-wider">{t('admin.status')}</th>
                 <th className="text-left px-5 py-3.5 text-xs font-semibold text-surface-500 dark:text-surface-400 uppercase tracking-wider">{t('admin.pricing')}</th>


### PR DESCRIPTION
## Summary

Fixes the pre-existing **AdminLots "renders lot count"** test failure — the only red test on a per-file basis after PR #545 cleared the phosphor-icon mock cascade.

The test asserted that `screen.getByText('(1)')` was in the document for a single-lot fixture, but the production view rendered the table without any count badge. This was a UX gap exposed by the test, not a test bug.

## Pattern

Mirrors `AdminModules.tsx:360` (`<heading>{' '}<span className="...font-normal">({array.length})</span>`).

Placed on the **table column header** rather than the hero h1 because:
- the count is scoped to the live `filtered` array (stays in sync with the search input)
- the hero already shows `"{count} lots online"` as descriptive copy — adding the badge there would be redundant

## Verification

- 42/42 AdminLots tests pass (was 41/42)
- 84/84 across AdminLots + AdminModules + i18n (no regressions in adjacent surfaces)

## Diff

```diff
-                <th ...>{t('admin.lots')}</th>
+                <th ...>
+                  {t('admin.lots')}{' '}
+                  <span className="font-normal normal-case text-surface-400">({filtered.length})</span>
+                </th>
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)