### PR TITLE
chore(web): astro check sweep — 33 → 8 hints (-25, 76% reduction)

### DIFF
--- a/parkhub-web/src/components/ErrorBoundary.extended.test.tsx
+++ b/parkhub-web/src/components/ErrorBoundary.extended.test.tsx
@@ -23,12 +23,6 @@ function GoodComponent() {
   return <div data-testid="good-component">All good</div>;
 }
 
-function ThrowingWithStackComponent(): React.ReactElement {
-  const err = new Error('Stack trace error');
-  err.stack = 'Error: Stack trace error\n    at ThrowingWithStackComponent (file.tsx:1:1)';
-  throw err;
-}
-
 describe('ErrorBoundary (extended)', () => {
   const originalConsoleError = console.error;
   const mockReload = vi.fn();

--- a/parkhub-web/src/components/Layout.test.tsx
+++ b/parkhub-web/src/components/Layout.test.tsx
@@ -474,10 +474,7 @@ describe('Layout', () => {
 
     await user.click(screen.getByLabelText('Open navigation menu'));
 
-    // The mobile sidebar has its own logout button
-    const sidebar = screen.getByLabelText('Navigation menu');
-    const logoutBtn = sidebar.parentElement?.querySelector('button');
-    // There's a logout button in the mobile sidebar's bottom area
+    // The mobile sidebar has its own logout button in its bottom area.
     const allLogouts = screen.getAllByText('Log Out');
     expect(allLogouts.length).toBeGreaterThanOrEqual(2); // desktop + mobile
   });

--- a/parkhub-web/src/components/OnboardingHint.test.tsx
+++ b/parkhub-web/src/components/OnboardingHint.test.tsx
@@ -1,7 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import React from 'react';
 import { render, screen, act } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 
 // ── Mocks ──
 
@@ -168,7 +167,7 @@ describe('resetAllHints', () => {
       'parkhub_hint_b': '1',
       'other_key': 'keep',
     };
-    const removeSpy = vi.spyOn(Storage.prototype, 'removeItem').mockImplementation((key: string) => { delete store[key]; });
+    vi.spyOn(Storage.prototype, 'removeItem').mockImplementation((key: string) => { delete store[key]; });
     vi.spyOn(Object, 'keys').mockReturnValueOnce(Object.keys(store));
     // We need to mock localStorage properly
     Object.defineProperty(window, 'localStorage', {

--- a/parkhub-web/src/components/SWUpdatePrompt.test.tsx
+++ b/parkhub-web/src/components/SWUpdatePrompt.test.tsx
@@ -30,7 +30,6 @@ import { SWUpdatePrompt } from './SWUpdatePrompt';
 describe('SWUpdatePrompt', () => {
   let swReady: (reg: any) => void;
   let controllerChangeListeners: (() => void)[] = [];
-  const originalLocation = window.location;
 
   beforeEach(() => {
     controllerChangeListeners = [];
@@ -56,7 +55,7 @@ describe('SWUpdatePrompt', () => {
   });
 
   it('renders nothing when no service worker is waiting', () => {
-    const { container } = render(<SWUpdatePrompt />);
+    render(<SWUpdatePrompt />);
     // No update banner
     expect(screen.queryByText('A new version is available')).not.toBeInTheDocument();
   });

--- a/parkhub-web/src/components/SWUpdatePrompt.tsx
+++ b/parkhub-web/src/components/SWUpdatePrompt.tsx
@@ -11,8 +11,6 @@ export function SWUpdatePrompt() {
   useEffect(() => {
     if (!('serviceWorker' in navigator)) return;
 
-    let registration: ServiceWorkerRegistration | null = null;
-
     function onStateChange(this: ServiceWorker) {
       if (this.state === 'installed' && navigator.serviceWorker.controller) {
         setWaitingWorker(this);
@@ -21,8 +19,6 @@ export function SWUpdatePrompt() {
     }
 
     navigator.serviceWorker.ready.then((reg) => {
-      registration = reg;
-
       // Check if there's already a waiting worker
       if (reg.waiting) {
         setWaitingWorker(reg.waiting);

--- a/parkhub-web/src/views/AdminBilling.test.tsx
+++ b/parkhub-web/src/views/AdminBilling.test.tsx
@@ -134,7 +134,6 @@ describe('AdminBillingPage', () => {
   });
 
   it('handles CSV export click', async () => {
-    const mockBlob = new Blob(['csv data'], { type: 'text/csv' });
     const createObjectURL = vi.fn(() => 'blob:test');
     const revokeObjectURL = vi.fn();
     Object.defineProperty(URL, 'createObjectURL', { value: createObjectURL, writable: true });

--- a/parkhub-web/src/views/AdminFeatures.tsx
+++ b/parkhub-web/src/views/AdminFeatures.tsx
@@ -104,7 +104,7 @@ export function AdminFeaturesPage() {
       </motion.div>
 
       {/* Feature toggles by category */}
-      {grouped.map(({ category, modules }, gi) => (
+      {grouped.map(({ category, modules }) => (
         <motion.div
           key={category}
           variants={item}

--- a/parkhub-web/src/views/AdminMaintenance.test.tsx
+++ b/parkhub-web/src/views/AdminMaintenance.test.tsx
@@ -56,10 +56,7 @@ describe('AdminMaintenancePage', () => {
   it('shows help', async () => {
     render(<AdminMaintenancePage />);
     await waitFor(() => expect(screen.getByTestId('create-btn')).toBeInTheDocument());
-    // Find the help button (Question icon)
-    const buttons = screen.getAllByRole('button');
-    const helpBtn = buttons.find(b => b.textContent === '' && !b.hasAttribute('data-testid'));
-    // Click the help toggle - just verify the create button exists
+    // The help button (Question icon) is rendered alongside the create button — verify the create button exists as a smoke check.
   });
 
   it('opens create form', async () => {

--- a/parkhub-web/src/views/AdminRoles.tsx
+++ b/parkhub-web/src/views/AdminRoles.tsx
@@ -24,11 +24,6 @@ interface RbacRole {
   updated_at: string;
 }
 
-interface UserRoleAssignment {
-  user_id: string;
-  roles: { id: string; name: string; permissions: string[] }[];
-}
-
 export function AdminRolesPage() {
   const { t } = useTranslation();
   const [roles, setRoles] = useState<RbacRole[]>([]);

--- a/parkhub-web/src/views/AdminUsers.test.tsx
+++ b/parkhub-web/src/views/AdminUsers.test.tsx
@@ -504,7 +504,6 @@ describe('AdminUsersPage', () => {
   });
 
   it('bulk delete selected users', async () => {
-    const user = userEvent.setup();
     mockAdminBulkDelete.mockResolvedValue({ success: true, data: { succeeded: 1, total: 1 } });
 
     render(<AdminUsersPage />);
@@ -766,7 +765,6 @@ describe('AdminUsersPage', () => {
 
     it('bulk action returns early when no action selected', async () => {
       patchSelectedIds();
-      const user = userEvent.setup();
       render(<AdminUsersPage />);
       await waitFor(() => expect(screen.getByText('Alice')).toBeInTheDocument());
       // Apply button is disabled when bulkAction is empty

--- a/parkhub-web/src/views/BookingSharing.test.tsx
+++ b/parkhub-web/src/views/BookingSharing.test.tsx
@@ -292,7 +292,6 @@ describe('BookingSharingModal', () => {
   });
 
   it('validates empty email', async () => {
-    const toast = (await import('react-hot-toast')).default;
     render(<BookingSharingModal bookingId="booking-1" />);
     fireEvent.click(screen.getByTestId('tab-invite'));
     await waitFor(() => screen.getByTestId('send-invite-btn'));

--- a/parkhub-web/src/views/BookingSharing.tsx
+++ b/parkhub-web/src/views/BookingSharing.tsx
@@ -16,21 +16,12 @@ interface ShareLink {
   view_count: number;
 }
 
-interface InviteResponse {
-  invite_id: string;
-  booking_id: string;
-  email: string;
-  sent_at: string;
-  share_url: string;
-}
-
 interface BookingSharingProps {
   bookingId: string;
-  bookingLabel?: string;
   onClose?: () => void;
 }
 
-export function BookingSharingModal({ bookingId, bookingLabel, onClose }: BookingSharingProps) {
+export function BookingSharingModal({ bookingId, onClose }: BookingSharingProps) {
   const { t } = useTranslation();
   const [activeTab, setActiveTab] = useState<'link' | 'invite'>('link');
   const [shareLink, setShareLink] = useState<ShareLink | null>(null);

--- a/parkhub-web/src/views/Bookings.test.tsx
+++ b/parkhub-web/src/views/Bookings.test.tsx
@@ -86,6 +86,9 @@ vi.mock('framer-motion', () => ({
     div: React.forwardRef(({ children, initial, animate, exit, transition, whileHover, whileTap, variants, ...props }: any, ref: any) => (
       <div ref={ref} {...props}>{children}</div>
     )),
+    section: React.forwardRef(({ children, initial, animate, exit, transition, variants, ...props }: any, ref: any) => (
+      <section ref={ref} {...props}>{children}</section>
+    )),
     p: React.forwardRef(({ children, initial, animate, exit, transition, ...props }: any, ref: any) => (
       <p ref={ref} {...props}>{children}</p>
     )),
@@ -359,7 +362,6 @@ describe('BookingsPage', () => {
   it('handles booking_cancelled websocket event with toast', async () => {
     mockGetBookings.mockResolvedValue({ success: true, data: [] });
     mockGetVehicles.mockResolvedValue({ success: true, data: [] });
-    const toastModule = await import('react-hot-toast');
     render(<BookingsPage />);
     await waitFor(() => expect(mockGetBookings).toHaveBeenCalled());
     // The cancelled-event path uses toast(...) not success/error, so just assert no throw

--- a/parkhub-web/src/views/Bookings.tsx
+++ b/parkhub-web/src/views/Bookings.tsx
@@ -8,7 +8,7 @@ import {
   MagnifyingGlassIcon, FunnelIcon, QrCodeIcon, FilePdfIcon, CalendarPlusIcon,
 } from '@phosphor-icons/react';
 import type { TFunction } from 'i18next';
-import { api, type Booking, type Vehicle } from '../api/client';
+import { api, type Booking } from '../api/client';
 import { BookingsSkeleton } from '../components/Skeleton';
 import { ParkingPass } from '../components/ParkingPass';
 import { stagger, fadeUp } from '../constants/animations';
@@ -25,7 +25,6 @@ export function BookingsPage() {
   const { t, i18n } = useTranslation();
   const dateFnsLocale = i18n.language?.startsWith('de') ? de : enUS;
   const [bookings, setBookings] = useState<Booking[]>([]);
-  const [vehicles, setVehicles] = useState<Vehicle[]>([]);
   const [loading, setLoading] = useState(true);
   const [cancelling, setCancelling] = useState<string | null>(null);
   const [filterStatus, setFilterStatus] = useState('all');
@@ -63,9 +62,8 @@ export function BookingsPage() {
   }, []);
 
   async function loadData() {
-    const [bRes, vRes] = await Promise.all([api.getBookings(), api.getVehicles()]);
+    const bRes = await api.getBookings();
     if (bRes.success && bRes.data) setBookings(bRes.data);
-    if (vRes.success && vRes.data) setVehicles(vRes.data);
     setLoading(false);
   }
 
@@ -176,7 +174,7 @@ export function BookingsPage() {
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
             <AnimatePresence>
               {active.map(b => (
-                <BookingCard key={b.id} booking={b} now={now} vehicles={vehicles}
+                <BookingCard key={b.id} booking={b} now={now}
                   onCancel={handleCancel} cancelling={cancelling} onShowPass={setPassBooking} t={t} dateFnsLocale={dateFnsLocale} />
               ))}
             </AnimatePresence>
@@ -192,7 +190,7 @@ export function BookingsPage() {
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
             <AnimatePresence>
               {upcoming.map(b => (
-                <BookingCard key={b.id} booking={b} now={now} vehicles={vehicles}
+                <BookingCard key={b.id} booking={b} now={now}
                   onCancel={handleCancel} cancelling={cancelling} onShowPass={setPassBooking} t={t} dateFnsLocale={dateFnsLocale} />
               ))}
             </AnimatePresence>
@@ -207,7 +205,7 @@ export function BookingsPage() {
         ) : (
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
             {past.map(b => (
-              <BookingCard key={b.id} booking={b} now={now} vehicles={vehicles}
+              <BookingCard key={b.id} booking={b} now={now}
                 onCancel={handleCancel} cancelling={cancelling} t={t} dateFnsLocale={dateFnsLocale} />
             ))}
           </div>
@@ -298,7 +296,6 @@ function Empty({ text, showAction, t }: EmptyProps) {
 interface BookingCardProps {
   booking: Booking;
   now: number;
-  vehicles: Vehicle[];
   onCancel: (id: string) => void;
   cancelling: string | null;
   onShowPass?: (booking: Booking) => void;
@@ -306,7 +303,7 @@ interface BookingCardProps {
   dateFnsLocale: Locale;
 }
 
-function BookingCard({ booking, now, vehicles, onCancel, cancelling, onShowPass, t, dateFnsLocale }: BookingCardProps) {
+function BookingCard({ booking, now, onCancel, cancelling, onShowPass, t, dateFnsLocale }: BookingCardProps) {
   const isActiveOrConfirmed = booking.status === 'active' || booking.status === 'confirmed';
   const isPast = booking.status === 'completed' || booking.status === 'cancelled';
   const isExpiring = isActiveOrConfirmed && new Date(booking.end_time).getTime() - now < 30 * 60 * 1000;

--- a/parkhub-web/src/views/Calendar.test.tsx
+++ b/parkhub-web/src/views/Calendar.test.tsx
@@ -562,8 +562,6 @@ describe('CalendarPage', () => {
     const now = new Date();
     const testDate = new Date(now.getFullYear(), now.getMonth(), 10);
     const isoKey = testDate.toISOString().slice(0, 10);
-    const targetDate = new Date(now.getFullYear(), now.getMonth(), 20);
-    const targetIso = targetDate.toISOString().slice(0, 10);
     mockCalendarEvents.mockResolvedValue({
       success: true,
       data: [{

--- a/parkhub-web/src/views/OccupancyHeatmap.tsx
+++ b/parkhub-web/src/views/OccupancyHeatmap.tsx
@@ -33,13 +33,6 @@ function cellColor(pct: number): string {
   return 'bg-surface-100 dark:bg-surface-800';
 }
 
-function cellTextColor(pct: number): string {
-  if (pct >= 90) return 'text-white';
-  if (pct >= 75) return 'text-amber-900';
-  if (pct >= 50) return 'text-primary-900 dark:text-primary-100';
-  return 'text-surface-500';
-}
-
 function authHeaders(): Record<string, string> {
   const token = getInMemoryToken();
   return {

--- a/parkhub-web/src/views/SetupWizard.tsx
+++ b/parkhub-web/src/views/SetupWizard.tsx
@@ -2,12 +2,6 @@ import { useState, useEffect, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 
-interface WizardStep {
-  step: number;
-  name: string;
-  completed: boolean;
-}
-
 const THEMES = [
   { id: 'classic', label: 'Classic', color: 'bg-blue-600' },
   { id: 'glass', label: 'Glass', color: 'bg-sky-400/60' },

--- a/parkhub-web/src/views/TeamLeaderboard.tsx
+++ b/parkhub-web/src/views/TeamLeaderboard.tsx
@@ -245,11 +245,11 @@ export function TeamLeaderboardPage() {
         <motion.div variants={fadeUp} className="glass-card p-6" data-testid="podium">
           <div className="flex items-end justify-center gap-4 h-40">
             {/* 2nd place */}
-            <PodiumSlot entry={podiumEntries.second} rank={2} height="h-24" t={t} />
+            <PodiumSlot entry={podiumEntries.second} rank={2} height="h-24" />
             {/* 1st place */}
-            <PodiumSlot entry={podiumEntries.first} rank={1} height="h-32" t={t} />
+            <PodiumSlot entry={podiumEntries.first} rank={1} height="h-32" />
             {/* 3rd place */}
-            <PodiumSlot entry={podiumEntries.third} rank={3} height="h-20" t={t} />
+            <PodiumSlot entry={podiumEntries.third} rank={3} height="h-20" />
           </div>
         </motion.div>
       )}
@@ -314,11 +314,10 @@ export function TeamLeaderboardPage() {
   );
 }
 
-function PodiumSlot({ entry, rank, height, t }: {
+function PodiumSlot({ entry, rank, height }: {
   entry: LeaderboardEntry;
   rank: number;
   height: string;
-  t: TFunction;
 }) {
   return (
     <div className="flex flex-col items-center w-24" data-testid={`podium-${rank}`}>

--- a/parkhub-web/src/views/UseCaseSelector.test.tsx
+++ b/parkhub-web/src/views/UseCaseSelector.test.tsx
@@ -61,7 +61,7 @@ vi.mock('framer-motion', () => ({
       <button ref={ref} {...props}>{children}</button>
     )),
   },
-  AnimatePresence: ({ children, mode }: any) => <>{children}</>,
+  AnimatePresence: ({ children }: any) => <>{children}</>,
 }));
 
 vi.mock('@phosphor-icons/react', () => ({
@@ -182,7 +182,7 @@ describe('UseCaseSelectorPage', () => {
 
   it('finish button sets use case and features, navigates to welcome', async () => {
     vi.useFakeTimers();
-    const { container } = render(<UseCaseSelectorPage />);
+    render(<UseCaseSelectorPage />);
 
     // Use fireEvent for fake timers compatibility
     const businessBtn = screen.getByText('Business').closest('button')!;

--- a/parkhub-web/src/views/Vehicles.tsx
+++ b/parkhub-web/src/views/Vehicles.tsx
@@ -194,7 +194,7 @@ export function VehiclesPage() {
         </motion.div>
       ) : (
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-          {vehicles.map((v, i) => {
+          {vehicles.map((v) => {
             const colorClass = v.color ? (colorBgMap[v.color] || 'bg-surface-400') : 'bg-surface-400';
             return (
               <motion.div key={v.id} variants={item} className="bg-white dark:bg-surface-900 rounded-xl border border-surface-200 dark:border-surface-800 p-5">


### PR DESCRIPTION
## Summary

Cleans up **25 of 33** TypeScript hints flagged by `astro check`. Each fix removes dead code rather than papering over with `_` prefixes; the astro hint count drops from **33 → 8**. The remaining 8 are out of scope for a TS-hint sweep (zod v4 deprecation × 2, `sw.js` style suggestions × 5, `index.astro` inline-script notice × 1).

## Removals

### Dead code in production (cascading cleanup)
- `OccupancyHeatmap.tsx` — unused `cellTextColor()` function
- `AdminRoles.tsx`, `BookingSharing.tsx`, `SetupWizard.tsx` — unused interface declarations (`UserRoleAssignment`, `InviteResponse`, `WizardStep`)
- `SWUpdatePrompt.tsx` — unused `let registration` capture in serviceWorker.ready handler
- `Bookings.tsx` — unused `vehicles` state + `getVehicles()` fetch (cascading dead code; `Vehicle` type import dropped)
- `BookingSharing.tsx` — unused `bookingLabel` prop (no call site passes it)

### Unused locals / destructures (test files)
- Dead variables: `mockBlob`, `helpBtn`, `user`, `toast`, `toastModule`, `targetIso`, `originalLocation`, `removeSpy`, `logoutBtn`, `container` (×2), `ThrowingWithStackComponent`
- `userEvent` import removed from `OnboardingHint.test.tsx`

### Unused params
- `AdminFeatures.tsx` — `gi` index from `.map()`
- `Vehicles.tsx` — `i` index from `.map()`
- `TeamLeaderboard.tsx` — `t` param on `PodiumSlot` (unused in body); call sites updated to drop `t={t}`
- `UseCaseSelector.test.tsx` — `mode` from AnimatePresence destructure mock

## Bonus fix

`Bookings.test.tsx` — added missing `motion.section` to the framer-motion mock. Without it, all 20 tests in the file failed with `Element type is invalid` because `Bookings.tsx` now uses `<motion.section>` for the v11 hero. **Verified: 20/20 pass after the mock addition.**

## Verification

| Check | Before | After |
|-------|--------|-------|
| astro check hints | 33 | **8** |
| TypeScript | clean | clean |
| Bookings.test.tsx | 0/20 (Element-type error) | **20/20** |
| BookingSharing.test.tsx | 24/24 | 24/24 |
| Calendar.test.tsx | 48/48 | 48/48 |
| Layout.test.tsx | 36/36 | 36/36 |
| OnboardingHint.test.tsx | 9/9 | 9/9 |
| SWUpdatePrompt.test.tsx | 7/7 | 7/7 |
| UseCaseSelector.test.tsx | 13/13 | 13/13 |
| AdminUsers.test.tsx | 47/48 (1 pre-existing) | 47/48 |

The single AdminUsers failure (`shows user count`) is pre-existing and mirrors the AdminLots count pattern fixed in #547 — earmarked as the next slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)