### PR TITLE
fix(admin-users): render user count badge in table column header

### DIFF
--- a/parkhub-web/src/views/AdminUsers.tsx
+++ b/parkhub-web/src/views/AdminUsers.tsx
@@ -181,7 +181,12 @@ export function AdminUsersPage() {
 
   const columns = useMemo(() => [
     columnHelper.accessor('name', {
-      header: () => t('admin.users'),
+      header: () => (
+        <>
+          {t('admin.users')}{' '}
+          <span className="font-normal normal-case text-surface-400">({users.length})</span>
+        </>
+      ),
       cell: info => (
         <div className="min-w-0">
           <p className="text-sm font-medium text-surface-900 dark:text-white truncate">{info.getValue()}</p>
@@ -301,7 +306,7 @@ export function AdminUsersPage() {
         );
       },
     }),
-  ], [editingId, editRole, savingRole, editingQuotaId, editQuota, savingQuota, t]);
+  ], [editingId, editRole, savingRole, editingQuotaId, editQuota, savingQuota, t, users.length]);
 
   if (loading) {
     return (


### PR DESCRIPTION
## Summary

Resolves the pre-existing **AdminUsers \"shows user count\"** test failure — the same UX gap that AdminLots had (fixed in #547). The test asserts `screen.getByText('(2)')` for a 2-user fixture; production view rendered the table without any count badge.

## Pattern

Same pattern as #547 — mirrors `AdminModules.tsx:360`:
\`\`\`tsx
<heading>{' '}<span className=\"...font-normal\">({users.length})</span>
\`\`\`

Placed on the **DataTable column-header factory** rather than the hero h1 because:
- the hero already shows \`{count} active\` as descriptive copy
- the column header is the canonical scoped indicator for the table contents
- mirrors the parallel placement choice in #547

## Verification

- 48/48 AdminUsers tests pass (was 47/48)
- Added \`users.length\` to the columns useMemo deps to trigger header re-render

🤖 Generated with [Claude Code](https://claude.com/claude-code)