### PR TITLE
fix(web): inject missing motion.section mock — 96 tests resurrected across 8 files

### DIFF
--- a/parkhub-web/src/views/Credits.test.tsx
+++ b/parkhub-web/src/views/Credits.test.tsx
@@ -53,6 +53,9 @@ vi.mock('framer-motion', () => ({
     div: React.forwardRef(({ children, variants, initial, animate, exit, transition, ...props }: any, ref: any) => (
       <div ref={ref} {...props}>{children}</div>
     )),
+    section: React.forwardRef(({ children, variants, initial, animate, exit, transition, ...props }: any, ref: any) => (
+      <section ref={ref} {...props}>{children}</section>
+    )),
   },
 }));
 

--- a/parkhub-web/src/views/Favorites.test.tsx
+++ b/parkhub-web/src/views/Favorites.test.tsx
@@ -47,6 +47,9 @@ vi.mock('framer-motion', () => ({
     div: React.forwardRef(({ children, variants, initial, animate, exit, transition, whileHover, whileTap, layout, ...props }: any, ref: any) => (
       <div ref={ref} {...props}>{children}</div>
     )),
+    section: React.forwardRef(({ children, variants, initial, animate, exit, transition, whileHover, whileTap, layout, ...props }: any, ref: any) => (
+      <section ref={ref} {...props}>{children}</section>
+    )),
   },
   AnimatePresence: ({ children }: any) => <>{children}</>,
 }));

--- a/parkhub-web/src/views/MapView.test.tsx
+++ b/parkhub-web/src/views/MapView.test.tsx
@@ -33,6 +33,9 @@ vi.mock('framer-motion', () => ({
     div: React.forwardRef(({ children, variants, initial, animate, exit, transition, ...props }: any, ref: any) => (
       <div ref={ref} {...props}>{children}</div>
     )),
+    section: React.forwardRef(({ children, variants, initial, animate, exit, transition, ...props }: any, ref: any) => (
+      <section ref={ref} {...props}>{children}</section>
+    )),
   },
 }));
 

--- a/parkhub-web/src/views/ParkingHistory.test.tsx
+++ b/parkhub-web/src/views/ParkingHistory.test.tsx
@@ -55,6 +55,9 @@ vi.mock('framer-motion', () => ({
     div: React.forwardRef(({ children, initial, animate, exit, transition, variants, ...props }: any, ref: any) => (
       <div ref={ref} {...props}>{children}</div>
     )),
+    section: React.forwardRef(({ children, initial, animate, exit, transition, variants, ...props }: any, ref: any) => (
+      <section ref={ref} {...props}>{children}</section>
+    )),
   },
   AnimatePresence: ({ children }: any) => <>{children}</>,
 }));

--- a/parkhub-web/src/views/Profile.test.tsx
+++ b/parkhub-web/src/views/Profile.test.tsx
@@ -131,6 +131,9 @@ vi.mock('framer-motion', () => ({
     div: React.forwardRef(({ children, variants, initial, animate, exit, transition, whileHover, whileTap, ...props }: any, ref: any) => (
       <div ref={ref} {...props}>{children}</div>
     )),
+    section: React.forwardRef(({ children, variants, initial, animate, exit, transition, whileHover, whileTap, ...props }: any, ref: any) => (
+      <section ref={ref} {...props}>{children}</section>
+    )),
   },
   AnimatePresence: ({ children }: any) => <>{children}</>,
 }));

--- a/parkhub-web/src/views/QRCheckIn.test.tsx
+++ b/parkhub-web/src/views/QRCheckIn.test.tsx
@@ -66,6 +66,9 @@ vi.mock('framer-motion', () => ({
     div: React.forwardRef(({ children, initial, animate, exit, transition, whileHover, whileTap, variants, ...props }: any, ref: any) => (
       <div ref={ref} {...props}>{children}</div>
     )),
+    section: React.forwardRef(({ children, initial, animate, exit, transition, whileHover, whileTap, variants, ...props }: any, ref: any) => (
+      <section ref={ref} {...props}>{children}</section>
+    )),
   },
   AnimatePresence: ({ children }: any) => <>{children}</>,
 }));

--- a/parkhub-web/src/views/SwapRequests.test.tsx
+++ b/parkhub-web/src/views/SwapRequests.test.tsx
@@ -11,12 +11,15 @@ vi.mock('../api/client', () => ({
 
 vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (k: string) => k, i18n: { language: 'en' } }) }));
 vi.mock('framer-motion', () => ({
-  motion: { div: React.forwardRef(({ children, variants, ...p }: any, r: any) => <div ref={r} {...p}>{children}</div>) },
+  motion: {
+    div: React.forwardRef(({ children, variants, ...p }: any, r: any) => <div ref={r} {...p}>{children}</div>),
+    section: React.forwardRef(({ children, variants, ...p }: any, r: any) => <section ref={r} {...p}>{children}</section>),
+  },
   AnimatePresence: ({ children }: any) => <>{children}</>,
 }));
 vi.mock('@phosphor-icons/react', () => {
   const C = (p: any) => <span {...p} />;
-  return { Swap: C, Check: C, X: C, SpinnerGap: C, Plus: C, ArrowClockwise: C, CalendarBlank: C, Clock: C, ChatText: C };
+  return { SwapIcon: C, CheckIcon: C, XIcon: C, SpinnerGapIcon: C, PlusIcon: C, ArrowClockwiseIcon: C, CalendarBlankIcon: C, ClockIcon: C, ChatTextIcon: C };
 });
 vi.mock('react-hot-toast', () => ({ default: { success: vi.fn(), error: vi.fn() } }));
 vi.mock('date-fns', () => ({ format: (_d: any, fmt: string) => fmt === 'dd.MM HH:mm' ? '10.04 08:00' : fmt === 'HH:mm' ? '08:00' : '10. Apr 2026' }));

--- a/parkhub-web/src/views/Vehicles.test.tsx
+++ b/parkhub-web/src/views/Vehicles.test.tsx
@@ -48,6 +48,9 @@ vi.mock('framer-motion', () => ({
     div: React.forwardRef(({ children, variants, initial, animate, exit, transition, whileHover, whileTap, ...props }: any, ref: any) => (
       <div ref={ref} {...props}>{children}</div>
     )),
+    section: React.forwardRef(({ children, variants, initial, animate, exit, transition, whileHover, whileTap, ...props }: any, ref: any) => (
+      <section ref={ref} {...props}>{children}</section>
+    )),
     button: React.forwardRef(({ children, variants, initial, animate, exit, transition, whileHover, whileTap, ...props }: any, ref: any) => (
       <button ref={ref} {...props}>{children}</button>
     )),


### PR DESCRIPTION
## Summary

After the v11 SOTA chrome rollout switched many view heroes to `<motion.section>`, every test file that mocked framer-motion with only `motion.div` started silently rendering `undefined` → React threw \"Element type is invalid\" → entire describe blocks failed without indicating the real cause.

This PR sweeps 8 affected test files and adds the parallel `motion.section` mock (cloning each file's existing `motion.div` prop signature). Also fixes one phosphor mock cascade survivor in `SwapRequests.test.tsx` that the #545 sweep missed because of an inline-arrow-fn pattern (`Swap: C` instead of `Swap: (props) =>`).

## Impact

| File | Before | After |
|------|--------|-------|
| Credits.test.tsx | 1/6 pass | **6/6** |
| Favorites.test.tsx | 1/5 pass | **5/5** |
| MapView.test.tsx | 1/6 pass | **6/6** |
| ParkingHistory.test.tsx | 0/9 pass | **9/9** |
| Profile.test.tsx | 0/42 pass | **42/42** |
| QRCheckIn.test.tsx | 0/10 pass | **10/10** |
| SwapRequests.test.tsx | 1/18 pass | 17/18 |
| Vehicles.test.tsx | 1/7 pass | **7/7** |

**Total: 96 tests resurrected.**

The 1 remaining SwapRequests failure (`refresh button` asserting on literal text `common.refresh`) is unrelated pre-existing i18n-mock rot — out of scope for this sweep.

## Mechanical pattern

For each file, the existing `motion.div` prop signature is cloned for `section`:

```diff
 motion: {
   div: React.forwardRef(({ children, variants, ..., ...props }, ref) => (
     <div ref={ref} {...props}>{children}</div>
   )),
+  section: React.forwardRef(({ children, variants, ..., ...props }, ref) => (
+    <section ref={ref} {...props}>{children}</section>
+  )),
 }
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)