### PR TITLE
chore(web): zod v4 — z.string().email() → z.email() (-2 deprecation hints)

### DIFF
--- a/parkhub-web/src/utils/validation.test.ts
+++ b/parkhub-web/src/utils/validation.test.ts
@@ -12,7 +12,7 @@ const loginSchema = z.object({
 
 const registerSchema = z.object({
   name: z.string().min(1, 'Required'),
-  email: z.string().email('Invalid email'),
+  email: z.email('Invalid email'),
   password: z
     .string()
     .min(8, '8+ characters')

--- a/parkhub-web/src/views/Register.tsx
+++ b/parkhub-web/src/views/Register.tsx
@@ -12,7 +12,7 @@ import { OAuthButtons } from '../components/OAuthButtons';
 
 const registerSchema = z.object({
   name: z.string().min(1, 'Required'),
-  email: z.string().email('Invalid email'),
+  email: z.email('Invalid email'),
   password: z
     .string()
     .min(8, '8+ characters')


### PR DESCRIPTION
## Summary

Migrates the two remaining `ts(6385)` deprecation hints in `src/`. Zod v4 deprecated the chained `z.string().email(msg)` form in favour of the top-level shortcut `z.email(msg)`, which returns the same ZodEmail validator without the redundant `.string()` prefix.

## Files

- `src/views/Register.tsx` — `registerSchema.email`
- `src/utils/validation.test.ts` — mirror of the same schema

## Verification

| Check | Before | After |
|-------|--------|-------|
| ts(6385) hints | 2 | **0** |
| validation.test.ts + Register.test.tsx | 57/57 | 57/57 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)