### PR TITLE
chore(web): clean Icon-suffix leakage from 9 source comments

### DIFF
--- a/parkhub-web/src/components/DemoOverlay.tsx
+++ b/parkhub-web/src/components/DemoOverlay.tsx
@@ -134,7 +134,7 @@ export function DemoOverlay({ reloadPage = defaultReloadPage }: { reloadPage?: (
             {t('demo.badge')}
           </span>
 
-          {/* TimerIcon */}
+          {/* Timer */}
           <span className={`font-mono text-sm font-bold transition-colors duration-300 ${isLow ? 'text-red-700 dark:text-red-300' : 'text-surface-800 dark:text-surface-200'}`}>
             <TimerIcon weight="bold" className="w-3.5 h-3.5 inline mr-1" />
             {String(minutes).padStart(2, '0')}:{String(seconds).padStart(2, '0')}

--- a/parkhub-web/src/components/NotificationCenter.tsx
+++ b/parkhub-web/src/components/NotificationCenter.tsx
@@ -132,7 +132,7 @@ export function NotificationCenter() {
 
   return (
     <div ref={panelRef} className="relative">
-      {/* BellIcon icon button */}
+      {/* Bell icon button */}
       <button
         onClick={() => setOpen(o => !o)}
         className="relative p-2 rounded-lg text-surface-600 dark:text-surface-400 hover:bg-surface-100 dark:hover:bg-surface-800 transition-colors"

--- a/parkhub-web/src/components/NotificationPreferences.tsx
+++ b/parkhub-web/src/components/NotificationPreferences.tsx
@@ -119,7 +119,7 @@ export function NotificationPreferencesComponent() {
         </div>
       </div>
 
-      {/* PhoneIcon number for SMS/WhatsApp */}
+      {/* Phone number for SMS/WhatsApp */}
       <div className="space-y-2">
         <div className="flex items-center gap-2 text-sm font-medium text-gray-500 mb-1">
           <PhoneIcon size={16} />

--- a/parkhub-web/src/views/Absences.tsx
+++ b/parkhub-web/src/views/Absences.tsx
@@ -46,7 +46,7 @@ export function AbsencesPage() {
 
   const hoPattern = useMemo(() => patterns.find(p => p.absence_type === 'homeoffice'), [patterns]);
 
-  // CalendarIcon days
+  // Calendar days
   const calendarDays = useMemo(() => {
     const firstDay = new Date(calYear, calMonth, 1);
     const lastDay = new Date(calYear, calMonth + 1, 0);
@@ -140,7 +140,7 @@ export function AbsencesPage() {
       </section>
 
       <div className="grid grid-cols-1 lg:grid-cols-5 gap-6">
-        {/* CalendarIcon */}
+        {/* Calendar */}
         <div className="lg:col-span-3 bg-white dark:bg-surface-900 rounded-2xl border border-surface-200 dark:border-surface-800 p-6">
           <div className="flex items-center justify-between mb-4">
             <h2 className="text-lg font-semibold text-surface-900 dark:text-white">{calMonthLabel}</h2>

--- a/parkhub-web/src/views/AdminCompliance.tsx
+++ b/parkhub-web/src/views/AdminCompliance.tsx
@@ -189,7 +189,7 @@ export function AdminCompliancePage() {
         </div>
       </div>
 
-      {/* DownloadIcon Actions */}
+      {/* Download Actions */}
       <div className="flex flex-wrap gap-3" data-testid="compliance-downloads">
         <button
           onClick={downloadPdf}

--- a/parkhub-web/src/views/Book.tsx
+++ b/parkhub-web/src/views/Book.tsx
@@ -251,7 +251,7 @@ export function BookPage() {
   );
 }
 
-/** CheckIcon if a lot is currently open based on operating_hours. */
+/** Check if a lot is currently open based on operating_hours. */
 function isLotOpenNow(hours?: OperatingHoursData): boolean {
   if (!hours || hours.is_24h) return true;
   const days = ['sunday', 'monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday'] as const;

--- a/parkhub-web/src/views/Settings.tsx
+++ b/parkhub-web/src/views/Settings.tsx
@@ -83,7 +83,7 @@ export function SettingsPage() {
 
   return (
     <div className="max-w-4xl mx-auto p-4 sm:p-6 pb-20">
-      {/* v11 SOTA hero — primary tone, page-hero variant. UserIcon-level settings
+      {/* v11 SOTA hero — primary tone, page-hero variant. User-level settings
           (workspace + appearance), distinct from amber AdminSettings. */}
       <section className="admin-hero page-hero mb-5">
         <div className="admin-hero-left">

--- a/parkhub-web/src/views/SwapRequests.tsx
+++ b/parkhub-web/src/views/SwapRequests.tsx
@@ -262,7 +262,7 @@ export function SwapRequestsPage() {
         )}
       </motion.div>
 
-      {/* Create SwapIcon Modal */}
+      {/* Create Swap Modal */}
       <AnimatePresence>
         {showModal && (
           <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm p-4">


### PR DESCRIPTION
## Summary

Follow-up to #554 (which fixed user-visible string-literal damage from the over-aggressive icon-rename sweep in #535/#545). The same regex also hit **comment text** — these don't affect runtime but read awkwardly.

## Files

| File | Before | After |
|------|--------|-------|
| NotificationCenter.tsx | `BellIcon icon button` | `Bell icon button` |
| DemoOverlay.tsx | `TimerIcon` | `Timer` |
| NotificationPreferences.tsx | `PhoneIcon number` | `Phone number` |
| Absences.tsx (×2) | `CalendarIcon` | `Calendar` |
| Book.tsx | `CheckIcon if a lot is currently open` | `Check if a lot is currently open` |
| AdminCompliance.tsx | `DownloadIcon Actions` | `Download Actions` |
| SwapRequests.tsx | `Create SwapIcon Modal` | `Create Swap Modal` |
| Settings.tsx | `UserIcon-level settings` | `User-level settings` |

A repo-wide grep for `(//|/\*).*[A-Z]\w+Icon\b` (excluding legitimate JSX icon refs) confirms no other comment damage remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)