### PR TITLE
fix(admin-translations): add aria-label to bulk buttons (a11y + 4 tests)

### DIFF
--- a/parkhub-web/src/views/AdminTranslations.test.tsx
+++ b/parkhub-web/src/views/AdminTranslations.test.tsx
@@ -271,8 +271,8 @@ describe('AdminTranslationsPage', () => {
   it('renders approve all and reject all buttons when pending exist', async () => {
     render(<AdminTranslationsPage />);
     await waitFor(() => {
-      expect(screen.getByText('Approve All')).toBeInTheDocument();
-      expect(screen.getByText('Reject All')).toBeInTheDocument();
+      expect(screen.getByLabelText('Approve All')).toBeInTheDocument();
+      expect(screen.getByLabelText('Reject All')).toBeInTheDocument();
     });
   });
 
@@ -284,7 +284,7 @@ describe('AdminTranslationsPage', () => {
 
     render(<AdminTranslationsPage />);
     await waitFor(() => {
-      expect(screen.queryByText('Approve All')).not.toBeInTheDocument();
+      expect(screen.queryByLabelText('Approve All')).not.toBeInTheDocument();
     });
   });
 
@@ -314,10 +314,10 @@ describe('AdminTranslationsPage', () => {
   it('bulk approve opens confirm dialog and processes pending proposals', async () => {
     const user = userEvent.setup();
     render(<AdminTranslationsPage />);
-    await waitFor(() => expect(screen.getByText('Approve All')).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByLabelText('Approve All')).toBeInTheDocument());
 
     // Click Approve All to trigger handleBulkAction
-    await user.click(screen.getByText('Approve All'));
+    await user.click(screen.getByLabelText('Approve All'));
 
     // ConfirmDialog should appear
     await waitFor(() => {
@@ -337,9 +337,9 @@ describe('AdminTranslationsPage', () => {
   it('bulk reject opens confirm dialog and processes pending proposals', async () => {
     const user = userEvent.setup();
     render(<AdminTranslationsPage />);
-    await waitFor(() => expect(screen.getByText('Reject All')).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByLabelText('Reject All')).toBeInTheDocument());
 
-    await user.click(screen.getByText('Reject All'));
+    await user.click(screen.getByLabelText('Reject All'));
     await waitFor(() => expect(screen.getByTestId('confirm-dialog')).toBeInTheDocument());
 
     mockReviewProposal.mockResolvedValue({ success: true, data: { ...MOCK_PROPOSALS[0], status: 'rejected' } });
@@ -353,9 +353,9 @@ describe('AdminTranslationsPage', () => {
   it('cancel on confirm dialog closes it without action', async () => {
     const user = userEvent.setup();
     render(<AdminTranslationsPage />);
-    await waitFor(() => expect(screen.getByText('Approve All')).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByLabelText('Approve All')).toBeInTheDocument());
 
-    await user.click(screen.getByText('Approve All'));
+    await user.click(screen.getByLabelText('Approve All'));
     await waitFor(() => expect(screen.getByTestId('confirm-dialog')).toBeInTheDocument());
 
     await user.click(screen.getByText('Cancel'));
@@ -443,7 +443,7 @@ describe('AdminTranslationsPage', () => {
     });
     render(<AdminTranslationsPage />);
     await waitFor(() => {
-      expect(screen.queryByText('Approve All')).not.toBeInTheDocument();
+      expect(screen.queryByLabelText('Approve All')).not.toBeInTheDocument();
     });
   });
 

--- a/parkhub-web/src/views/AdminTranslations.tsx
+++ b/parkhub-web/src/views/AdminTranslations.tsx
@@ -225,10 +225,10 @@ export function AdminTranslationsPage() {
           )}
           {pendingCount > 0 && (
             <>
-              <button onClick={() => handleBulkAction('approved')} className="admin-hero-iconbtn text-emerald-600 dark:text-emerald-400" title={t('translations.admin.approveAll')}>
+              <button onClick={() => handleBulkAction('approved')} className="admin-hero-iconbtn text-emerald-600 dark:text-emerald-400" aria-label={t('translations.admin.approveAll')} title={t('translations.admin.approveAll')}>
                 <CheckCircleIcon weight="bold" className="w-4 h-4" />
               </button>
-              <button onClick={() => handleBulkAction('rejected')} className="admin-hero-iconbtn text-red-500 dark:text-red-400" title={t('translations.admin.rejectAll')}>
+              <button onClick={() => handleBulkAction('rejected')} className="admin-hero-iconbtn text-red-500 dark:text-red-400" aria-label={t('translations.admin.rejectAll')} title={t('translations.admin.rejectAll')}>
                 <XCircleIcon weight="bold" className="w-4 h-4" />
               </button>
             </>


### PR DESCRIPTION
## Summary

Resolves the 4 pre-existing `AdminTranslations` test failures by fixing an underlying a11y gap.

## Failing tests
- renders approve all and reject all buttons when pending exist
- bulk approve opens confirm dialog and processes pending proposals
- bulk reject opens confirm dialog and processes pending proposals
- cancel on confirm dialog closes it without action

## Root cause

The bulk-action buttons in the v11 hero render **only an icon** (`CheckCircleIcon` / `XCircleIcon`) with `title=` set as a tooltip. The tests asserted on `getByText('Approve All')`, but `title` is **not visible text** — it's only an accessible name when read by assistive tech. The buttons had no `aria-label`, so screen readers also could not identify them.

## Fix (two-fer)

1. **Production** — add `aria-label` to both buttons (mirrors the existing `title` translation key). Improves a11y AND makes the buttons identifiable to RTL queries.
2. **Tests** — switch from `getByText` to `getByLabelText` (and matching `queryByLabelText`) for the 7 call sites that look for "Approve All" / "Reject All".

## Verification

- 40/40 AdminTranslations tests pass (was 36/40)
- Production change is purely additive (adds `aria-label`, no behavior change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)