### PR TITLE
test(i18n): relax locales.test.ts to allow DE-superset (mirrors #546)

### DIFF
--- a/parkhub-web/src/i18n/locales.test.ts
+++ b/parkhub-web/src/i18n/locales.test.ts
@@ -100,10 +100,13 @@ describe('i18n locales', () => {
     it('has the same top-level keys as en.ts', () => {
       const localeKeys = getTopLevelKeys(locale);
       const missing = enKeys.filter(k => !localeKeys.includes(k));
-      const extra = localeKeys.filter(k => !enKeys.includes(k));
-
+      // Asymmetric: a non-EN locale may add top-level sections (e.g. eyebrow
+      // labels added to DE during the v11 chrome rollout — the English
+      // fallbacks live inline in the source as `t('section.eyebrow', 'X')`
+      // rather than in en.ts). Strict superset check: every EN key must
+      // exist, but extras are allowed. Mirrors the relaxation in
+      // i18n.test.ts (PR #546).
       expect(missing, `${code} is missing keys: ${missing.join(', ')}`).toEqual([]);
-      expect(extra, `${code} has extra keys: ${extra.join(', ')}`).toEqual([]);
     });
 
     it('has no empty string values', () => {


### PR DESCRIPTION
## Summary

PR #546 relaxed `src/i18n/i18n.test.ts` to allow DE to have extra eyebrow keys not in EN (English fallbacks live inline in source as `t('section.eyebrow', 'FALLBACK')`). The **parallel test in `src/i18n/locales.test.ts`** was missed and continued asserting strict equality of top-level keys, breaking the build whenever a new section is added to DE.

## Fix

Same relaxation pattern as #546: every EN key must still exist in every locale (strict superset check on `missing`), but extras are allowed.

## Concretely fixes

The `de` locale's 7 extras flagged by the v11 chrome rollout:
`leaderboard`, `analytics`, `users`, `lots`, `updates`, `announcements`, `checkin`

## Verification

- 52/52 locales tests pass (was 51/52)
- The relaxation is symmetric with i18n.test.ts so both files now agree on the contract

🤖 Generated with [Claude Code](https://claude.com/claude-code)