### PR TITLE
fix(web): 3 v11-rollout aftershocks (label leak + act type + refresh aria)

### DIFF
--- a/parkhub-web/src/components/PWAEnhanced.test.tsx
+++ b/parkhub-web/src/components/PWAEnhanced.test.tsx
@@ -208,10 +208,10 @@ describe('OfflineIndicator - events', () => {
     Object.defineProperty(navigator, 'onLine', { value: true, writable: true });
     render(<OfflineIndicator />);
     // Go offline
-    await act(() => { window.dispatchEvent(new Event('offline')); });
+    await act(async () => { window.dispatchEvent(new Event('offline')); });
     expect(screen.getByText('You are offline. Some features may be unavailable.')).toBeDefined();
     // Go back online
-    await act(() => { window.dispatchEvent(new Event('online')); });
+    await act(async () => { window.dispatchEvent(new Event('online')); });
     expect(screen.queryByText('You are offline. Some features may be unavailable.')).toBeNull();
   });
 });

--- a/parkhub-web/src/views/AdminAnalytics.tsx
+++ b/parkhub-web/src/views/AdminAnalytics.tsx
@@ -186,7 +186,7 @@ export function AdminAnalyticsPage() {
             <StatCard icon={CalendarBlankIcon} label="Total Bookings" value={String(data.total_bookings)} sub={`Last ${range} days`} />
             <StatCard icon={CurrencyDollarIcon} label="Total Revenue" value={`${data.total_revenue.toFixed(2)}`} sub={`Last ${range} days`} />
             <StatCard icon={ClockIcon} label="Avg Duration" value={`${Math.round(data.avg_booking_duration_minutes)} min`} />
-            <StatCard icon={UsersIcon} label="Active UsersIcon" value={String(data.active_users)} sub="With bookings in period" />
+            <StatCard icon={UsersIcon} label="Active Users" value={String(data.active_users)} sub="With bookings in period" />
           </div>
 
           {/* Charts row */}

--- a/parkhub-web/src/views/SwapRequests.test.tsx
+++ b/parkhub-web/src/views/SwapRequests.test.tsx
@@ -133,7 +133,8 @@ describe('SwapRequestsPage', () => {
 
   it('refresh button', async () => {
     render(<SwapRequestsPage />);
-    await waitFor(() => fireEvent.click(screen.getByText('common.refresh')));
+    // The refresh button is icon-only; assert via aria-label, not visible text.
+    await waitFor(() => fireEvent.click(screen.getByLabelText('common.refresh')));
     await waitFor(() => expect(globalThis.fetch).toHaveBeenCalled());
   });
 


### PR DESCRIPTION
## Summary

Three small post-merge fixes surfaced after #547-#557 cleared the broader cascade rot. All three are aftershocks of the v11 SOTA chrome rollout.

## Fixes

### 1. AdminAnalytics — label string leak
`AdminAnalytics.tsx:189` — `label=\"Active UsersIcon\"` → `label=\"Active Users\"`

The icon-rename sweep in #535/#545 leaked into **JSX attribute string literals** (regex matched `Users → UsersIcon` even inside `label=` props). The previous string-leak sweep (#554) only caught `'...'` and `\"...\"` standalone strings, missing JSX attr-value damage. A repo-wide grep for `label=\"...Icon...\"` confirms this is the only remaining case.

Fixes the `AdminAnalytics 'renders stat cards after data loads'` test.

### 2. PWAEnhanced — `act()` await type
`PWAEnhanced.test.tsx:211,214` — `await act(() => syncFn())` → `await act(async () => syncFn())`

React 18+ `act()` only returns a Thenable when the callback is async; awaiting a sync-callback `act()` is a no-op that `ts(80007)` flags. Switching the callback to async makes the `await` meaningful.

Clears the 2 remaining `ts(80007)` hints (**6 → 4 total**).

### 3. SwapRequests — refresh button uses aria-label
`SwapRequests.test.tsx:136` — `getByText('common.refresh')` → `getByLabelText('common.refresh')`

Same pattern as #556 (AdminTranslations a11y fix). The refresh button in SwapRequests' v11 hero renders only an icon with `title=` and `aria-label=`, no visible text. Switching to `getByLabelText` matches what the production HTML actually exposes.

Fixes the `SwapRequests 'refresh button'` test.

## Verification

| Surface | Before | After |
|---------|--------|-------|
| AdminAnalytics | 10/11 | **11/11** |
| SwapRequests | 17/18 | **18/18** |
| PWAEnhanced | 17/17 | 17/17 (hint cleared) |
| astro check hints | 6 | **4** |

Post-merge survey of all view + component test files now shows **0 silent failures** across the entire suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)