### PR TITLE
chore(web): add aria-label to 7 icon-only buttons (a11y)

### DIFF
--- a/parkhub-web/src/components/NotificationCenter.tsx
+++ b/parkhub-web/src/components/NotificationCenter.tsx
@@ -161,7 +161,7 @@ export function NotificationCenter() {
             <div className="flex items-center justify-between px-4 py-3 border-b border-surface-200 dark:border-surface-700">
               <div className="flex items-center gap-2">
                 <h3 className="font-semibold text-surface-900 dark:text-white">{t('notificationCenter.title')}</h3>
-                <button onClick={() => setShowHelp(h => !h)} className="text-surface-400 hover:text-surface-600 dark:hover:text-surface-300" title={t('notificationCenter.helpLabel')}>
+                <button onClick={() => setShowHelp(h => !h)} className="text-surface-400 hover:text-surface-600 dark:hover:text-surface-300" aria-label={t('notificationCenter.helpLabel')} title={t('notificationCenter.helpLabel')}>
                   <QuestionIcon weight="bold" className="w-4 h-4" />
                 </button>
               </div>

--- a/parkhub-web/src/views/AbsenceApproval.tsx
+++ b/parkhub-web/src/views/AbsenceApproval.tsx
@@ -237,7 +237,7 @@ export function AbsenceApprovalPage() {
           <h1 className="text-2xl font-bold text-surface-900 dark:text-surface-100">{t('absenceApproval.title')}</h1>
           <p className="text-surface-500 dark:text-surface-400 text-sm">{t('absenceApproval.subtitle')}</p>
         </div>
-        <button onClick={() => setShowHelp(!showHelp)} className="p-2 rounded-lg hover:bg-surface-100 dark:hover:bg-surface-800 text-surface-500" title={t('absenceApproval.helpLabel')}>
+        <button onClick={() => setShowHelp(!showHelp)} className="p-2 rounded-lg hover:bg-surface-100 dark:hover:bg-surface-800 text-surface-500" aria-label={t('absenceApproval.helpLabel')} title={t('absenceApproval.helpLabel')}>
           <QuestionIcon size={20} />
         </button>
       </div>

--- a/parkhub-web/src/views/AdminDashboard.tsx
+++ b/parkhub-web/src/views/AdminDashboard.tsx
@@ -116,7 +116,7 @@ export function AdminDashboardPage() {
           <p className="admin-hero-sub">{t('widgets.subtitle')}</p>
         </div>
         <div className="admin-hero-actions">
-          <button onClick={() => setShowHelp(!showHelp)} className="admin-hero-iconbtn" title={t('widgets.helpLabel')}>
+          <button onClick={() => setShowHelp(!showHelp)} className="admin-hero-iconbtn" aria-label={t('widgets.helpLabel')} title={t('widgets.helpLabel')}>
             <QuestionIcon size={16} />
           </button>
           <button onClick={() => setShowCatalog(!showCatalog)} className="admin-hero-action">

--- a/parkhub-web/src/views/AdminRoles.tsx
+++ b/parkhub-web/src/views/AdminRoles.tsx
@@ -139,6 +139,7 @@ export function AdminRolesPage() {
           <button
             onClick={() => setShowHelp(h => !h)}
             className="admin-hero-iconbtn"
+            aria-label={t('rbac.helpLabel')}
             title={t('rbac.helpLabel')}
           >
             <QuestionIcon className="w-4 h-4" />

--- a/parkhub-web/src/views/AdminZones.tsx
+++ b/parkhub-web/src/views/AdminZones.tsx
@@ -110,6 +110,7 @@ export function AdminZonesPage() {
           <button
             onClick={() => setShowHelp(h => !h)}
             className="admin-hero-iconbtn"
+            aria-label={t('parkingZones.helpLabel')}
             title={t('parkingZones.helpLabel')}
           >
             <QuestionIcon className="w-4 h-4" />

--- a/parkhub-web/src/views/BookingSharing.tsx
+++ b/parkhub-web/src/views/BookingSharing.tsx
@@ -140,6 +140,7 @@ export function BookingSharingModal({ bookingId, onClose }: BookingSharingProps)
             <button
               onClick={onClose}
               className="p-1.5 rounded-lg hover:bg-surface-100 dark:hover:bg-surface-700"
+              aria-label={t('common.close', 'Close')}
               data-testid="sharing-close-btn"
             >
               <XIcon size={16} />

--- a/parkhub-web/src/views/Calendar.tsx
+++ b/parkhub-web/src/views/Calendar.tsx
@@ -245,7 +245,7 @@ export function CalendarPage() {
           <p className="admin-hero-sub">{t('calendar.subtitle', 'See and manage your reservations across the month')}</p>
         </div>
         <div className="admin-hero-actions">
-          <button onClick={() => setShowHelp(!showHelp)} className="admin-hero-iconbtn" title={t('calendarDrag.helpLabel')}>
+          <button onClick={() => setShowHelp(!showHelp)} className="admin-hero-iconbtn" aria-label={t('calendarDrag.helpLabel')} title={t('calendarDrag.helpLabel')}>
             <QuestionIcon className="w-4 h-4" />
           </button>
           <button


### PR DESCRIPTION
## Summary

Six help-toggle buttons (`setShowHelp` pattern) and one modal close button rendered only an icon with `title=` set as a tooltip but no `aria-label`. The HTML `title` attribute is a tooltip — **NOT an accessible name**. Screen readers can't reliably identify these buttons.

Mirrors the fix pattern from #556 (AdminTranslations bulk buttons): add `aria-label=` alongside the existing `title=` so both pointer users and assistive tech get a label.

## Files & buttons

| File | Button |
|------|--------|
| components/NotificationCenter.tsx:164 | help toggle |
| views/AdminDashboard.tsx:119 | widgets help toggle |
| views/AbsenceApproval.tsx:240 | absence approval help toggle |
| views/AdminZones.tsx:110 | parking zones help toggle |
| views/AdminRoles.tsx:139 | RBAC help toggle |
| views/Calendar.tsx:248 | calendar drag help toggle |
| views/BookingSharing.tsx:140 | modal close button (no `title=` either — used `t('common.close', 'Close')`) |

## Verification

- **127/127** tests pass across NotificationCenter, Calendar, BookingSharing, AdminDashboard
- `tsc --noEmit` clean
- All edits purely additive (add an attribute, no behavior change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)