### PR TITLE
chore(web): add aria-label to 13 row-action icon buttons (a11y)

### DIFF
--- a/parkhub-web/src/components/NotificationCenter.tsx
+++ b/parkhub-web/src/components/NotificationCenter.tsx
@@ -252,11 +252,11 @@ export function NotificationCenter() {
                             </div>
                             <div className="flex flex-col gap-1 flex-shrink-0">
                               {!n.read && (
-                                <button onClick={e => { e.stopPropagation(); markRead(n.id); }} className="p-1 rounded text-surface-400 hover:text-emerald-500 hover:bg-emerald-50 dark:hover:bg-emerald-900/20" title={t('notificationCenter.markRead')}>
+                                <button onClick={e => { e.stopPropagation(); markRead(n.id); }} className="p-1 rounded text-surface-400 hover:text-emerald-500 hover:bg-emerald-50 dark:hover:bg-emerald-900/20" aria-label={t('notificationCenter.markRead')} title={t('notificationCenter.markRead')}>
                                   <CheckIcon weight="bold" className="w-3.5 h-3.5" />
                                 </button>
                               )}
-                              <button onClick={e => { e.stopPropagation(); deleteNotification(n.id); }} className="p-1 rounded text-surface-400 hover:text-red-500 hover:bg-red-50 dark:hover:bg-red-900/20" title={t('notificationCenter.deleteOne')}>
+                              <button onClick={e => { e.stopPropagation(); deleteNotification(n.id); }} className="p-1 rounded text-surface-400 hover:text-red-500 hover:bg-red-50 dark:hover:bg-red-900/20" aria-label={t('notificationCenter.deleteOne')} title={t('notificationCenter.deleteOne')}>
                                 <TrashIcon weight="bold" className="w-3.5 h-3.5" />
                               </button>
                             </div>

--- a/parkhub-web/src/components/ParkingPass.tsx
+++ b/parkhub-web/src/components/ParkingPass.tsx
@@ -119,6 +119,7 @@ export function ParkingPass({ booking, onClose }: ParkingPassProps) {
           <button
             onClick={() => window.print()}
             className="btn btn-secondary flex items-center justify-center gap-2 px-4"
+            aria-label="Print booking confirmation"
             title="Print booking confirmation"
           >
             <PrinterIcon weight="bold" className="w-4 h-4" />

--- a/parkhub-web/src/views/AdminDashboard.tsx
+++ b/parkhub-web/src/views/AdminDashboard.tsx
@@ -187,7 +187,7 @@ export function AdminDashboardPage() {
                     </div>
                     <h3 className="font-semibold text-surface-900 dark:text-white text-sm">{t(`widgets.types.${w.widget_type}`)}</h3>
                   </div>
-                  <button onClick={() => toggleWidget(w.widget_type)} className="p-1 rounded hover:bg-surface-100 dark:hover:bg-surface-800 text-surface-400" title={t('widgets.remove')}>
+                  <button onClick={() => toggleWidget(w.widget_type)} className="p-1 rounded hover:bg-surface-100 dark:hover:bg-surface-800 text-surface-400" aria-label={`${t('widgets.remove')} ${t(`widgets.types.${w.widget_type}`)}`} title={t('widgets.remove')}>
                     <MinusIcon size={14} />
                   </button>
                 </div>

--- a/parkhub-web/src/views/AdminMaintenance.tsx
+++ b/parkhub-web/src/views/AdminMaintenance.tsx
@@ -269,10 +269,10 @@ export function AdminMaintenancePage() {
                   </div>
                 </div>
                 <div className="flex items-center gap-1 flex-shrink-0">
-                  <button onClick={() => openEdit(w)} className="p-2 rounded-lg hover:bg-surface-100 dark:hover:bg-surface-800 text-surface-400 hover:text-primary-600">
+                  <button onClick={() => openEdit(w)} className="p-2 rounded-lg hover:bg-surface-100 dark:hover:bg-surface-800 text-surface-400 hover:text-primary-600" aria-label={`${t('common.edit', 'Edit')} ${w.reason}`} title={t('common.edit', 'Edit')}>
                     <PencilSimpleIcon weight="bold" className="w-4 h-4" />
                   </button>
-                  <button onClick={() => handleDelete(w.id)} className="p-2 rounded-lg hover:bg-red-50 dark:hover:bg-red-900/20 text-surface-400 hover:text-red-600">
+                  <button onClick={() => handleDelete(w.id)} className="p-2 rounded-lg hover:bg-red-50 dark:hover:bg-red-900/20 text-surface-400 hover:text-red-600" aria-label={`${t('common.delete', 'Delete')} ${w.reason}`} title={t('common.delete', 'Delete')}>
                     <TrashIcon weight="bold" className="w-4 h-4" />
                   </button>
                 </div>

--- a/parkhub-web/src/views/AdminRoles.tsx
+++ b/parkhub-web/src/views/AdminRoles.tsx
@@ -285,6 +285,7 @@ export function AdminRolesPage() {
                   <button
                     onClick={() => startEdit(role)}
                     className="p-2 rounded-lg text-surface-400 hover:bg-surface-100 dark:hover:bg-surface-700"
+                    aria-label={`${t('rbac.edit')} ${role.name}`}
                     title={t('rbac.edit')}
                   >
                     <PencilIcon className="w-4 h-4" />
@@ -293,6 +294,7 @@ export function AdminRolesPage() {
                     <button
                       onClick={() => handleDelete(role)}
                       className="p-2 rounded-lg text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20"
+                      aria-label={`${t('rbac.delete')} ${role.name}`}
                       title={t('rbac.delete')}
                     >
                       <TrashIcon className="w-4 h-4" />

--- a/parkhub-web/src/views/AdminScheduledReports.tsx
+++ b/parkhub-web/src/views/AdminScheduledReports.tsx
@@ -331,6 +331,7 @@ export function AdminScheduledReportsPage() {
                   <button
                     onClick={() => handleSendNow(schedule.id)}
                     className="p-1.5 rounded-lg hover:bg-surface-100 dark:hover:bg-surface-700 text-primary-500"
+                    aria-label={`${t('scheduledReports.sendNow')} ${schedule.name}`}
                     title={t('scheduledReports.sendNow')}
                     data-testid="send-now-btn"
                   >
@@ -339,6 +340,7 @@ export function AdminScheduledReportsPage() {
                   <button
                     onClick={() => startEdit(schedule)}
                     className="p-1.5 rounded-lg hover:bg-surface-100 dark:hover:bg-surface-700"
+                    aria-label={`${t('scheduledReports.edit')} ${schedule.name}`}
                     title={t('scheduledReports.edit')}
                     data-testid="edit-btn"
                   >
@@ -347,6 +349,7 @@ export function AdminScheduledReportsPage() {
                   <button
                     onClick={() => handleDelete(schedule.id)}
                     className="p-1.5 rounded-lg hover:bg-red-50 dark:hover:bg-red-900/20 text-red-500"
+                    aria-label={`${t('scheduledReports.delete')} ${schedule.name}`}
                     title={t('scheduledReports.delete')}
                     data-testid="delete-btn"
                   >

--- a/parkhub-web/src/views/AdminZones.tsx
+++ b/parkhub-web/src/views/AdminZones.tsx
@@ -157,6 +157,7 @@ export function AdminZonesPage() {
                   <button
                     onClick={() => startEdit(zone)}
                     className="p-2 rounded-lg text-surface-400 hover:bg-surface-100 dark:hover:bg-surface-700"
+                    aria-label={`${t('parkingZones.editPricing')} ${zone.name}`}
                     title={t('parkingZones.editPricing')}
                   >
                     <PencilIcon className="w-4 h-4" />

--- a/parkhub-web/src/views/GuestPass.tsx
+++ b/parkhub-web/src/views/GuestPass.tsx
@@ -415,11 +415,11 @@ export function GuestPassPage() {
                   </div>
                 </div>
                 <div className="flex items-center gap-2 ml-4">
-                  <button onClick={() => sharePass(b)} className="p-2 rounded-lg hover:bg-surface-100 dark:hover:bg-surface-700 text-surface-500" title={t('guestBooking.share')}>
+                  <button onClick={() => sharePass(b)} className="p-2 rounded-lg hover:bg-surface-100 dark:hover:bg-surface-700 text-surface-500" aria-label={`${t('guestBooking.share')} ${b.guest_name || b.id}`} title={t('guestBooking.share')}>
                     <ShareNetworkIcon className="w-5 h-5" />
                   </button>
                   {isAdmin && b.status === 'active' && (
-                    <button onClick={() => handleCancel(b.id)} className="p-2 rounded-lg hover:bg-red-50 dark:hover:bg-red-900/20 text-red-500" title={t('guestBooking.cancel')} data-testid={`cancel-${b.id}`}>
+                    <button onClick={() => handleCancel(b.id)} className="p-2 rounded-lg hover:bg-red-50 dark:hover:bg-red-900/20 text-red-500" aria-label={`${t('guestBooking.cancel')} ${b.guest_name || b.id}`} title={t('guestBooking.cancel')} data-testid={`cancel-${b.id}`}>
                       <TrashIcon className="w-5 h-5" />
                     </button>
                   )}

--- a/parkhub-web/src/views/Visitors.tsx
+++ b/parkhub-web/src/views/Visitors.tsx
@@ -264,16 +264,16 @@ export function VisitorsPage() {
               </div>
               <div className="flex items-center gap-2 ml-4">
                 {v.qr_code && (
-                  <button onClick={() => setShowQr(v.qr_code)} className="p-2 rounded-lg hover:bg-surface-100 dark:hover:bg-surface-700 text-surface-500" title={t('visitors.showQr')}>
+                  <button onClick={() => setShowQr(v.qr_code)} className="p-2 rounded-lg hover:bg-surface-100 dark:hover:bg-surface-700 text-surface-500" aria-label={`${t('visitors.showQr')} ${v.name}`} title={t('visitors.showQr')}>
                     <QrCodeIcon className="w-5 h-5" />
                   </button>
                 )}
                 {v.status === 'pending' && (
                   <>
-                    <button onClick={() => handleCheckIn(v.id)} className="p-2 rounded-lg hover:bg-green-50 dark:hover:bg-green-900/20 text-green-600" title={t('visitors.checkIn')}>
+                    <button onClick={() => handleCheckIn(v.id)} className="p-2 rounded-lg hover:bg-green-50 dark:hover:bg-green-900/20 text-green-600" aria-label={`${t('visitors.checkIn')} ${v.name}`} title={t('visitors.checkIn')}>
                       <CheckCircleIcon className="w-5 h-5" />
                     </button>
-                    <button onClick={() => handleCancel(v.id)} className="p-2 rounded-lg hover:bg-red-50 dark:hover:bg-red-900/20 text-red-500" title={t('visitors.cancelVisitor')}>
+                    <button onClick={() => handleCancel(v.id)} className="p-2 rounded-lg hover:bg-red-50 dark:hover:bg-red-900/20 text-red-500" aria-label={`${t('visitors.cancelVisitor')} ${v.name}`} title={t('visitors.cancelVisitor')}>
                       <TrashIcon className="w-5 h-5" />
                     </button>
                   </>


### PR DESCRIPTION
## Summary

Continues the a11y sweep from #560 (which fixed 7 hero/help buttons). This wave covers **per-row action buttons in admin tables** — edit, delete, sendNow, share, etc. — that rendered only an icon with `title=` set as a tooltip but no `aria-label`.

## Buttons fixed (13 across 9 files)

| File | Buttons |
|------|---------|
| components/NotificationCenter.tsx | markRead, deleteNotification |
| components/ParkingPass.tsx | print |
| views/AdminDashboard.tsx | toggleWidget |
| views/AdminMaintenance.tsx | edit, delete (also added `title=` — was missing) |
| views/AdminRoles.tsx | edit, delete |
| views/AdminScheduledReports.tsx | sendNow, edit, delete |
| views/AdminZones.tsx | edit |
| views/GuestPass.tsx | share, cancel |
| views/Visitors.tsx | showQr, checkIn, cancel |

For per-row buttons, the `aria-label` is **row-specific**:
```tsx
aria-label={`${t('rbac.delete')} ${role.name}`}
```
So screen readers announce e.g. "Delete Manager role" instead of just "Delete". The existing `title=` tooltip stays unchanged for pointer users.

## Verification

- **171/171** tests pass across the 8 affected test files
- `tsc --noEmit` clean (one fix during edit: `AdminMaintenance.tsx` used `w.reason` as the row name, not `w.title` which doesn't exist on `MaintenanceWindow`)
- All edits purely additive (add an attribute, no behavior change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)