### PR TITLE
chore(web): add aria-label to 3 SidebarV3 buttons (a11y)

### DIFF
--- a/parkhub-web/src/components/nav/SidebarV3.tsx
+++ b/parkhub-web/src/components/nav/SidebarV3.tsx
@@ -353,6 +353,7 @@ export function SidebarV3() {
               // Dispatches the same event pages use to open the notification centre.
               window.dispatchEvent(new CustomEvent('parkhub:open-notifications'));
             }}
+            aria-label="Notifications"
             title="Notifications"
             className="sv3-hover relative flex items-center justify-center"
             style={{ width: 28, height: 28, borderRadius: 7, color: 'oklch(0.75 0.01 260)' }}
@@ -374,6 +375,7 @@ export function SidebarV3() {
           <button
             type="button"
             onClick={() => setUserMenuOpen(o => !o)}
+            aria-label={`Account menu — ${user?.name || user?.username || 'You'}`}
             title={user?.name || 'Account'}
             aria-haspopup="menu"
             aria-expanded={userMenuOpen}
@@ -549,6 +551,7 @@ export function SidebarV3() {
                   opacity: 0.6,
                   cursor: 'not-allowed',
                 }}
+                aria-label="Extend parking by 1 hour (coming soon)"
                 title="Extend parking — coming soon"
               >
                 +1h


### PR DESCRIPTION
## Summary

Continues the a11y sweep from #560 / #561. SidebarV3 had 3 buttons with `title=` (tooltip) but no `aria-label` (accessible name).

## Buttons

| Button | Issue | Fix |
|--------|-------|-----|
| Notifications bell (line 350) | icon-only with title only | added `aria-label=\"Notifications\"` |
| User account menu (line 374) | visible content is just user initial (e.g. \"F\") — meaningless to screen readers | `aria-label=\`Account menu — \${user.name}\`` for proper context |
| Disabled \"+1h\" extend-parking button (line 539) | visible \"+1h\" is cryptic | matches existing `title=` for clarity |

## Verification

- **2/2** SidebarV3 tests pass
- `tsc --noEmit` clean
- All edits purely additive

🤖 Generated with [Claude Code](https://claude.com/claude-code)