### PR TITLE
chore(web): remove obsolete @ts-ignore on JSON import

### DIFF
--- a/parkhub-web/src/lib/appVersion.ts
+++ b/parkhub-web/src/lib/appVersion.ts
@@ -6,7 +6,7 @@
 // Previously this lived hardcoded in Layout.tsx ("v4.9.0") and drifted —
 // v4.13.0 and later shipped with a stale footer. One-line source so it
 // stays accurate forever.
-// @ts-ignore — Vite resolves JSON imports at build time
+// resolveJsonModule is enabled in astro/tsconfigs/base.json so this is type-safe.
 import { version as pkgVersion } from '../../package.json';
 
 export const APP_VERSION: string =


### PR DESCRIPTION
## Summary

The `@ts-ignore` on `appVersion.ts:9` was claiming Vite-only resolution of JSON imports, but `astro/tsconfigs/base.json` (which the project extends through `strict`) sets `resolveJsonModule: true`. **TypeScript itself understands the import** — no suppression needed.

Replaced the comment with a positive note documenting the `resolveJsonModule` dependency, so a future config audit knows what breaks if it's removed.

## Verification

`npx tsc --noEmit` clean — the import resolves type-safely without any suppression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)