### PR TITLE
chore(web): wrap AdminAnalytics hardcoded strings in t() (i18n + test mock)

### DIFF
--- a/parkhub-web/src/views/AdminAnalytics.test.tsx
+++ b/parkhub-web/src/views/AdminAnalytics.test.tsx
@@ -2,7 +2,22 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 
 vi.mock('react-i18next', () => ({
-  useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en', changeLanguage: vi.fn() } }),
+  useTranslation: () => ({
+    // Mirror i18next's real behavior: the second arg is the English fallback,
+    // and an opts object's interpolation values replace `{{name}}` placeholders.
+    t: (key: string, defaultOrOpts?: string | Record<string, unknown>, opts?: Record<string, unknown>) => {
+      const isFallback = typeof defaultOrOpts === 'string';
+      let text = isFallback ? defaultOrOpts : key;
+      const interp = isFallback ? opts : (defaultOrOpts as Record<string, unknown> | undefined);
+      if (interp) {
+        for (const [k, v] of Object.entries(interp)) {
+          text = text.replace(new RegExp(`{{\\s*${k}\\s*}}`, 'g'), String(v));
+        }
+      }
+      return text;
+    },
+    i18n: { language: 'en', changeLanguage: vi.fn() },
+  }),
 }));
 
 vi.mock('../api/client', () => ({

--- a/parkhub-web/src/views/AdminAnalytics.tsx
+++ b/parkhub-web/src/views/AdminAnalytics.tsx
@@ -149,8 +149,8 @@ export function AdminAnalyticsPage() {
       <section className="admin-hero admin-hero--emerald">
         <div className="admin-hero-left">
           <HeroEyebrow icon={ChartBarIcon} label={t('analytics.eyebrow', 'USAGE & TRENDS')} />
-          <h1 className="admin-hero-headline">Analytics</h1>
-          <p className="admin-hero-sub">Comprehensive parking analytics and trends</p>
+          <h1 className="admin-hero-headline">{t('analytics.headline', 'Analytics')}</h1>
+          <p className="admin-hero-sub">{t('analytics.subtitle', 'Comprehensive parking analytics and trends')}</p>
         </div>
         <div className="admin-hero-actions">
           {(['7', '30', '90', '365'] as DateRange[]).map(r => (
@@ -183,10 +183,10 @@ export function AdminAnalyticsPage() {
         <>
           {/* Stats cards */}
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
-            <StatCard icon={CalendarBlankIcon} label="Total Bookings" value={String(data.total_bookings)} sub={`Last ${range} days`} />
-            <StatCard icon={CurrencyDollarIcon} label="Total Revenue" value={`${data.total_revenue.toFixed(2)}`} sub={`Last ${range} days`} />
-            <StatCard icon={ClockIcon} label="Avg Duration" value={`${Math.round(data.avg_booking_duration_minutes)} min`} />
-            <StatCard icon={UsersIcon} label="Active Users" value={String(data.active_users)} sub="With bookings in period" />
+            <StatCard icon={CalendarBlankIcon} label={t('analytics.totalBookings', 'Total Bookings')} value={String(data.total_bookings)} sub={t('analytics.lastNDays', 'Last {{n}} days', { n: range })} />
+            <StatCard icon={CurrencyDollarIcon} label={t('analytics.totalRevenue', 'Total Revenue')} value={`${data.total_revenue.toFixed(2)}`} sub={t('analytics.lastNDays', 'Last {{n}} days', { n: range })} />
+            <StatCard icon={ClockIcon} label={t('analytics.avgDuration', 'Avg Duration')} value={t('analytics.nMinutes', '{{n}} min', { n: Math.round(data.avg_booking_duration_minutes) })} />
+            <StatCard icon={UsersIcon} label={t('analytics.activeUsers', 'Active Users')} value={String(data.active_users)} sub={t('analytics.activeUsersSub', 'With bookings in period')} />
           </div>
 
           {/* Charts row */}
@@ -194,14 +194,14 @@ export function AdminAnalyticsPage() {
             <div className="bg-white dark:bg-surface-900 rounded-xl p-5 border border-surface-200 dark:border-surface-800">
               <h3 className="text-sm font-medium text-surface-600 dark:text-surface-400 mb-4 flex items-center gap-2">
                 <TrendUpIcon weight="bold" className="w-4 h-4" />
-                Daily Bookings
+                {t('analytics.dailyBookings', 'Daily Bookings')}
               </h3>
               <MiniBarChart data={bookingsChartData} height={160} color="var(--color-primary-500, #6366f1)" />
             </div>
             <div className="bg-white dark:bg-surface-900 rounded-xl p-5 border border-surface-200 dark:border-surface-800">
               <h3 className="text-sm font-medium text-surface-600 dark:text-surface-400 mb-4 flex items-center gap-2">
                 <CurrencyDollarIcon weight="bold" className="w-4 h-4" />
-                Daily Revenue
+                {t('analytics.dailyRevenue', 'Daily Revenue')}
               </h3>
               <MiniBarChart data={revenueChartData} height={160} color="var(--color-emerald-500, #10b981)" />
             </div>
@@ -210,13 +210,13 @@ export function AdminAnalyticsPage() {
           {/* Heatmap + Top Lots */}
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
             <div className="bg-white dark:bg-surface-900 rounded-xl p-5 border border-surface-200 dark:border-surface-800">
-              <h3 className="text-sm font-medium text-surface-600 dark:text-surface-400 mb-4">Bookings by Hour (Heatmap)</h3>
+              <h3 className="text-sm font-medium text-surface-600 dark:text-surface-400 mb-4">{t('analytics.bookingsByHour', 'Bookings by Hour (Heatmap)')}</h3>
               <HeatmapChart peak_hours={data.peak_hours} />
             </div>
             <div className="bg-white dark:bg-surface-900 rounded-xl p-5 border border-surface-200 dark:border-surface-800">
-              <h3 className="text-sm font-medium text-surface-600 dark:text-surface-400 mb-4">Top Lots by Utilization</h3>
+              <h3 className="text-sm font-medium text-surface-600 dark:text-surface-400 mb-4">{t('analytics.topLots', 'Top Lots by Utilization')}</h3>
               <div className="space-y-3">
-                {data.top_lots.length === 0 && <p className="text-sm text-surface-400">No lot data</p>}
+                {data.top_lots.length === 0 && <p className="text-sm text-surface-400">{t('analytics.noLotData', 'No lot data')}</p>}
                 {data.top_lots.map(lot => (
                   <div key={lot.lot_id} className="flex items-center gap-3">
                     <div className="flex-1 min-w-0">


### PR DESCRIPTION
## Summary

10 hardcoded English strings in `AdminAnalytics.tsx` now route through react-i18next's `t('key', 'fallback')` pattern (same as the rest of the codebase post-#546). German users currently see English; this PR makes them eligible for translation when DE locale gets the new keys.

## Wrapped strings

- `admin-hero` headline + subtitle
- 4 StatCard labels + 2 sub captions (\`Total Bookings\`, \`Total Revenue\`, \`Avg Duration\`, \`Active Users\`, \`Last X days\`, \`With bookings in period\`, \`X min\`)
- 4 chart h3 headings (Daily Bookings, Daily Revenue, Bookings by Hour Heatmap, Top Lots by Utilization)
- \`No lot data\` empty state

## Bundled test-mock fix

The existing `useTranslation` mock returned `key` for every `t()` call, which is fine when the production code uses bare keys but breaks assertions like `getByText('Analytics')` once `t()` gains an inline fallback. Updated the mock to **mirror real i18next behavior**: return the second arg if it's a string fallback, with `{{name}}` interpolation from the opts object.

This is a reusable improvement — any future test file that needs the same treatment can copy this 12-line mock.

## Verification

- **11/11** AdminAnalytics tests pass (was 7/11 mid-edit, would've broken without the mock fix)
- `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)