### PR TITLE
chore(web): wrap final 3 hardcoded strings in t() (LoginHistory + AdminAnalytics)

### DIFF
--- a/parkhub-web/src/components/LoginHistory.test.tsx
+++ b/parkhub-web/src/components/LoginHistory.test.tsx
@@ -18,7 +18,10 @@ vi.mock('../api/client', () => ({
 }));
 
 vi.mock('react-i18next', () => ({
-  useTranslation: () => ({ t: (key: string) => key }),
+  useTranslation: () => ({
+    // Mirror i18next: return the inline fallback (2nd arg) if provided.
+    t: (key: string, fallback?: string) => fallback ?? key,
+  }),
 }));
 
 vi.mock('react-hot-toast', () => ({

--- a/parkhub-web/src/components/LoginHistory.tsx
+++ b/parkhub-web/src/components/LoginHistory.tsx
@@ -15,7 +15,7 @@ function parseUserAgent(ua: string): string {
 }
 
 export function LoginHistoryComponent() {
-  useTranslation(); // initialized for future i18n
+  const { t } = useTranslation();
   const [history, setHistory] = useState<LoginHistoryEntry[]>([]);
   const [sessions, setSessions] = useState<SessionInfo[]>([]);
   const [loading, setLoading] = useState(true);
@@ -80,7 +80,7 @@ export function LoginHistoryComponent() {
       {tab === 'history' && (
         <div className="space-y-2">
           {history.length === 0 ? (
-            <p className="text-sm text-gray-500 text-center py-4">No login history</p>
+            <p className="text-sm text-gray-500 text-center py-4">{t('loginHistory.empty', 'No login history')}</p>
           ) : (
             history.map((entry, i) => (
               <div key={i} className="flex items-center justify-between p-3 rounded-lg bg-gray-50 dark:bg-gray-800/50 border border-gray-100 dark:border-gray-700">
@@ -118,7 +118,7 @@ export function LoginHistoryComponent() {
       {tab === 'sessions' && (
         <div className="space-y-2">
           {sessions.length === 0 ? (
-            <p className="text-sm text-gray-500 text-center py-4">No active sessions</p>
+            <p className="text-sm text-gray-500 text-center py-4">{t('loginHistory.noSessions', 'No active sessions')}</p>
           ) : (
             sessions.map(session => (
               <div key={session.id} className="flex items-center justify-between p-3 rounded-lg bg-gray-50 dark:bg-gray-800/50 border border-gray-100 dark:border-gray-700">

--- a/parkhub-web/src/views/AdminAnalytics.tsx
+++ b/parkhub-web/src/views/AdminAnalytics.tsx
@@ -254,7 +254,7 @@ export function AdminAnalyticsPage() {
           </div>
         </>
       ) : (
-        <div className="text-center py-12 text-surface-500">Failed to load analytics data</div>
+        <div className="text-center py-12 text-surface-500">{t('analytics.loadFailed', 'Failed to load analytics data')}</div>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary

Mops up the remaining hardcoded English in `LoginHistory.tsx` + the lone \"Failed to load analytics data\" survivor in `AdminAnalytics`. After this PR, the only intentionally-hardcoded English text in the surveyed production tree is in design-system playgrounds (`design-v5/`).

## Wrapped strings

- `LoginHistory.tsx` — \"No login history\" + \"No active sessions\"
- `AdminAnalytics.tsx` — \"Failed to load analytics data\"

`LoginHistory` previously had `useTranslation()` initialized but never destructured (with a `// initialized for future i18n` comment) — the \"future\" arrived. Replaced with `const { t } = useTranslation()`.

## Test mock fix (matches #564 pattern)

`LoginHistory.test.tsx` had the same `t: (key) => key` mock that breaks on `t('key', 'fallback')`. Updated to mirror i18next: return the fallback (2nd arg) when provided.

## Verification

- **24/24** tests pass across LoginHistory + AdminAnalytics
- `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)