### PR TITLE
chore(common): fix 5 clippy::doc_markdown warnings

### DIFF
--- a/parkhub-common/src/models.rs
+++ b/parkhub-common/src/models.rs
@@ -36,7 +36,7 @@ pub struct User {
     /// Multi-tenant isolation: tenant ID (None = super-admin / global scope)
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tenant_id: Option<String>,
-    /// Accessibility needs: wheelchair, reduced_mobility, visual, hearing, none
+    /// Accessibility needs: `wheelchair`, `reduced_mobility`, `visual`, `hearing`, `none`
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub accessibility_needs: Option<String>,
     /// Cost center for billing allocation
@@ -689,7 +689,7 @@ pub struct WaitlistEntry {
     pub notified_at: Option<DateTime<Utc>>,
     #[serde(default = "default_waitlist_status")]
     pub status: WaitlistStatus,
-    /// When the offer expires (notified_at + 15 min)
+    /// When the offer expires (`notified_at` + 15 min)
     #[serde(default)]
     pub offer_expires_at: Option<DateTime<Utc>>,
     /// Booking ID created when the offer is accepted
@@ -944,7 +944,7 @@ pub struct ChargingSession {
 // ═══════════════════════════════════════════════════════════════════════════════
 
 /// Discriminant for `FleetEvent` — matches the wire contract for the
-/// `/api/v1/events/fleet` SSE stream (snake_case variant → dotted wire type).
+/// `/api/v1/events/fleet` SSE stream (`snake_case` variant → dotted wire type).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "gen-types", derive(ts_rs::TS), ts(export))]
 pub enum FleetEventType {

--- a/parkhub-common/src/validation.rs
+++ b/parkhub-common/src/validation.rs
@@ -1,8 +1,8 @@
-//! Pure input-validation helpers shared across the ParkHub workspace.
+//! Pure input-validation helpers shared across the `ParkHub` workspace.
 //!
 //! These functions are intentionally dependency-free (no `regex`, no
 //! `validator`, no runtime state). They encode the "structural" half of
-//! the ParkHub input contract — shape and range checks that every layer
+//! the `ParkHub` input contract — shape and range checks that every layer
 //! (server handlers, client SDKs, future CLI tools) should agree on.
 //!
 //! The heavier, policy-laden validators (password strength rules,

--- a/parkhub-web/src/generated/types/FleetEventType.ts
+++ b/parkhub-web/src/generated/types/FleetEventType.ts
@@ -8,6 +8,6 @@
 
 /**
  * Discriminant for `FleetEvent` — matches the wire contract for the
- * `/api/v1/events/fleet` SSE stream (snake_case variant → dotted wire type).
+ * `/api/v1/events/fleet` SSE stream (`snake_case` variant → dotted wire type).
  */
 export type FleetEventType = "checkin.started" | "checkin.completed" | "swap.requested" | "swap.accepted" | "swap.declined" | "ev.session.started" | "ev.session.stopped" | "guest.created" | "guest.cancelled";

--- a/parkhub-web/src/generated/types/User.ts
+++ b/parkhub-web/src/generated/types/User.ts
@@ -17,7 +17,7 @@ export type User = { id: string, username: string, email: string, password_hash:
  */
 tenant_id: string | null, 
 /**
- * Accessibility needs: wheelchair, reduced_mobility, visual, hearing, none
+ * Accessibility needs: `wheelchair`, `reduced_mobility`, `visual`, `hearing`, `none`
  */
 accessibility_needs: string | null, 
 /**


### PR DESCRIPTION
## Summary

`clippy::pedantic` flagged 5 doc-comment items in `parkhub-common` missing backticks. Quick fix — wrapped the bare identifiers so they render as code in `cargo doc` output and satisfy the lint.

## Files

| File | Item |
|------|------|
| `models.rs:39` | accessibility-needs enum values now backticked |
| `models.rs:692` | `notified_at` field reference now backticked |
| `models.rs:947` | `snake_case` term now backticked |
| `validation.rs` (5 sites in module docs) | `ParkHub` brand backticked |

## Bundled (auto-regen)

Doc-comment changes flow through `ts-rs` into `parkhub-web/src/generated/types/`. The lefthook `types-drift` gate caught the drift on first push attempt; regenerated and amended:
- `FleetEventType.ts` — `snake_case` now backticked in TSDoc
- `User.ts` — accessibility-needs values now backticked in TSDoc

## Verification

- `cargo clippy -p parkhub-common -- -W clippy::doc_markdown` → 0 warnings (was 5)
- `cargo fmt -p parkhub-common --check` clean
- `scripts/check-types-drift.sh` clean

## Note

Workspace-wide there are still ~80 `clippy::doc_markdown` warnings in `parkhub-server` / `parkhub-client` / `parkhub-desktop`. Tackling those is out of scope for this focused PR — could be a follow-up sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)