### PR TITLE
chore(server): fix 17 clippy::doc_markdown warnings (co2 + api_docs + admin_ext)

### DIFF
--- a/docs/openapi/rust.json
+++ b/docs/openapi/rust.json
@@ -425,11 +425,11 @@
         "description": "Request body for bulk user update.",
         "properties": {
           "action": {
-            "description": "Action: \"activate\", \"deactivate\", \"set_role\"",
+            "description": "Action: \"activate\", \"deactivate\", `\"set_role\"`",
             "type": "string"
           },
           "role": {
-            "description": "Role to set (only used with \"set_role\" action)",
+            "description": "Role to set (only used with `\"set_role\"` action)",
             "type": [
               "string",
               "null"
@@ -1710,15 +1710,15 @@
             "type": "boolean"
           },
           "whatsapp_booking_cancelled": {
-            "description": "WhatsApp channel: booking cancelled",
+            "description": "`WhatsApp` channel: booking cancelled",
             "type": "boolean"
           },
           "whatsapp_booking_confirm": {
-            "description": "WhatsApp channel: booking confirmations",
+            "description": "`WhatsApp` channel: booking confirmations",
             "type": "boolean"
           },
           "whatsapp_booking_reminder": {
-            "description": "WhatsApp channel: booking reminders",
+            "description": "`WhatsApp` channel: booking reminders",
             "type": "boolean"
           }
         },

--- a/parkhub-server/src/api/admin_ext.rs
+++ b/parkhub-server/src/api/admin_ext.rs
@@ -24,9 +24,9 @@ use super::{AuthUser, SharedState, check_admin};
 pub struct BulkUserUpdateRequest {
     /// User IDs to update
     pub user_ids: Vec<String>,
-    /// Action: "activate", "deactivate", "set_role"
+    /// Action: "activate", "deactivate", `"set_role"`
     pub action: String,
-    /// Role to set (only used with "set_role" action)
+    /// Role to set (only used with `"set_role"` action)
     pub role: Option<String>,
 }
 
@@ -552,13 +552,13 @@ pub struct NotificationPreferences {
     /// SMS channel: booking cancelled
     #[serde(default)]
     pub sms_booking_cancelled: bool,
-    /// WhatsApp channel: booking confirmations
+    /// `WhatsApp` channel: booking confirmations
     #[serde(default)]
     pub whatsapp_booking_confirm: bool,
-    /// WhatsApp channel: booking reminders
+    /// `WhatsApp` channel: booking reminders
     #[serde(default)]
     pub whatsapp_booking_reminder: bool,
-    /// WhatsApp channel: booking cancelled
+    /// `WhatsApp` channel: booking cancelled
     #[serde(default)]
     pub whatsapp_booking_cancelled: bool,
     /// Phone number for SMS/WhatsApp (E.164 format, e.g. "+491234567890")

--- a/parkhub-server/src/api/api_docs.rs
+++ b/parkhub-server/src/api/api_docs.rs
@@ -3,8 +3,8 @@
 //! Provides convenient endpoints for accessing the API documentation.
 //!
 //! - `GET /api/v1/docs` — serve embedded Swagger UI HTML page
-//! - `GET /api/v1/docs/openapi.json` — raw OpenAPI 3.0 specification
-//! - `GET /api/v1/docs/postman.json` — auto-generated Postman collection
+//! - `GET /api/v1/docs/openapi.json` — raw `OpenAPI` 3.0 specification
+//! - `GET /api/v1/docs/postman.json` — auto-generated `Postman` collection
 
 use axum::{
     http::{StatusCode, header},
@@ -23,7 +23,7 @@ pub async fn api_docs_ui() -> impl IntoResponse {
     Html(SWAGGER_HTML)
 }
 
-/// `GET /api/v1/docs/openapi.json` — raw OpenAPI spec
+/// `GET /api/v1/docs/openapi.json` — raw `OpenAPI` spec
 #[utoipa::path(get, path = "/api/v1/docs/openapi.json", tag = "Documentation",
     summary = "OpenAPI specification",
     description = "Returns the raw OpenAPI 3.0 JSON specification for the ParkHub API.",
@@ -41,7 +41,7 @@ pub async fn api_docs_openapi_json() -> impl IntoResponse {
     )
 }
 
-/// Generate the OpenAPI spec JSON string
+/// Generate the `OpenAPI` spec JSON string
 fn generate_openapi_spec() -> String {
     serde_json::json!({
         "openapi": "3.0.3",
@@ -94,7 +94,7 @@ fn generate_openapi_spec() -> String {
     .to_string()
 }
 
-/// `GET /api/v1/docs/postman.json` — auto-generated Postman collection from OpenAPI spec
+/// `GET /api/v1/docs/postman.json` — auto-generated `Postman` collection from `OpenAPI` spec
 #[utoipa::path(get, path = "/api/v1/docs/postman.json", tag = "Documentation",
     summary = "Postman collection",
     description = "Returns an auto-generated Postman v2.1 collection derived from the OpenAPI specification. Import directly into Postman.",
@@ -111,7 +111,7 @@ pub async fn api_docs_postman_json() -> impl IntoResponse {
     )
 }
 
-/// Convert OpenAPI spec into a Postman v2.1 collection.
+/// Convert `OpenAPI` spec into a `Postman` v2.1 collection.
 fn generate_postman_collection() -> String {
     let spec_str = generate_openapi_spec();
     let spec: serde_json::Value = serde_json::from_str(&spec_str).unwrap_or_default();

--- a/parkhub-server/src/api/co2.rs
+++ b/parkhub-server/src/api/co2.rs
@@ -1,7 +1,7 @@
 //! CO2 accounting — converts bookings into emissions saved.
 //!
 //! Methodology: each booking represents a car trip to the lot.
-//! Without ParkHub, the user would still drive there (booking doesn't
+//! Without `ParkHub`, the user would still drive there (booking doesn't
 //! eliminate the trip), so the "saved" metric comes from two sources:
 //!   1. **Powertrain**: EVs, hybrids, and hydrogen vehicles emit less
 //!      per km than a gasoline baseline. The delta vs the fleet baseline
@@ -10,7 +10,7 @@
 //!      time-window, the extra riders would otherwise have made their own
 //!      trips — each additional rider saves their entire trip emissions.
 //!
-//! Emission factors (g CO2e per vehicle-km) are DEFRA 2024 + UBA 2024.
+//! Emission factors (g `CO2e` per vehicle-km) are `DEFRA` 2024 + `UBA` 2024.
 //! Baseline = gasoline car. Values are conservative; tune via
 //! `co2_*_g_per_km` admin settings when deploying.
 //!
@@ -30,7 +30,7 @@ use serde::{Deserialize, Serialize};
 
 use super::{AuthUser, SharedState};
 
-/// Default per-km emission factors (g CO2e / km). Aligned with DEFRA 2024
+/// Default per-km emission factors (g `CO2e` / km). Aligned with `DEFRA` 2024
 /// "Company reporting" dataset and UBA 2024 road transport breakdown.
 /// `Unknown` falls back to `Gasoline` so under-reported vehicles at least
 /// surface a real cost rather than masquerading as zero.
@@ -80,7 +80,7 @@ pub struct Co2Summary {
     pub counterfactual_g: f64,
     pub saved_g: f64,
     pub carpool_saved_g: f64,
-    /// Convenience: saved_g + carpool_saved_g / 1000, rounded to 2 decimals.
+    /// Convenience: `saved_g` + `carpool_saved_g` / 1000, rounded to 2 decimals.
     pub saved_kg: f64,
 }
 
@@ -88,7 +88,7 @@ pub struct Co2Summary {
 ///
 /// Returns the CO2 accounting across the requested window. Scoped to the
 /// authenticated user's own bookings. For carpool detection we count any
-/// N≥2 bookings that share the same lot_id and overlap on start_time
+/// N≥2 bookings that share the same `lot_id` and overlap on `start_time`
 /// within a 30-minute grace window as a shared trip; each additional
 /// rider is credited with saving one full trip's baseline emissions.
 pub async fn co2_summary(


### PR DESCRIPTION
## Summary

Continues the #568 sweep across `parkhub-server`, focusing on the 3 files with the highest `doc_markdown` count:

| File | Warnings | Items |
|------|----------|-------|
| `api/co2.rs` | 7 | DEFRA, UBA, ParkHub, CO2e, saved_g, carpool_saved_g, lot_id, start_time |
| `api/api_docs.rs` | 5 | OpenAPI, Postman (×2 each) |
| `api/admin_ext.rs` | 5 | set_role (×2), WhatsApp (×3) |

All edits are pure prose (doc-comment backtick wrapping) — **no runtime behavior change**.

## Bundled

`api_docs.rs` + `admin_ext.rs` doc comments are scanned by `utoipa::path` and end up in the OpenAPI spec, so this also regenerates `docs/openapi/rust.json` with the same backtick changes propagated. The lefthook `openapi-drift` gate caught this on the first push attempt.

## Verification

- `cargo clippy -p parkhub-server -- -W clippy::doc_markdown` → 0 warnings in these 3 files (was 17)
- `scripts/check-openapi-drift.sh` → matches live spec
- `cargo fmt -p parkhub-server --check` clean

## Note

Workspace-wide ~63 `doc_markdown` warnings remain in other server modules + parkhub-client + parkhub-desktop. Follow-up sweep candidates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)