### PR TITLE
chore(client): fix 5 clippy::doc_markdown warnings (ParkHub backticks)

### DIFF
--- a/parkhub-client/build.rs
+++ b/parkhub-client/build.rs
@@ -1,4 +1,4 @@
-//! Build script for ParkHub Client
+//! Build script for `ParkHub` Client
 //!
 //! Compiles Slint UI files and embeds Windows resources.
 

--- a/parkhub-client/src/discovery.rs
+++ b/parkhub-client/src/discovery.rs
@@ -1,6 +1,6 @@
 //! Server Discovery
 //!
-//! Discovers ParkHub servers on the local network using mDNS/DNS-SD
+//! Discovers `ParkHub` servers on the local network using mDNS/DNS-SD
 //! with fallback to localhost probing.
 
 use anyhow::Result;

--- a/parkhub-client/src/main.rs
+++ b/parkhub-client/src/main.rs
@@ -1,7 +1,7 @@
-//! ParkHub Client
+//! `ParkHub` Client
 //!
 //! Desktop application for parking lot management.
-//! Connects to ParkHub Server via HTTP API with autodiscovery.
+//! Connects to `ParkHub` Server via HTTP API with autodiscovery.
 
 #![windows_subsystem = "windows"]
 #![allow(unsafe_code)] // Slint uses unsafe FFI for native window management

--- a/parkhub-client/src/server_connection.rs
+++ b/parkhub-client/src/server_connection.rs
@@ -1,6 +1,6 @@
 //! Server Connection
 //!
-//! Handles HTTP API communication with the ParkHub server.
+//! Handles HTTP API communication with the `ParkHub` server.
 
 use anyhow::{Context, Result};
 use reqwest::Client;


### PR DESCRIPTION
## Summary

Continues the #568/#569 sweep. `parkhub-client` had 5 doc-comment references to `ParkHub` not wrapped in backticks. Mechanical fix — no runtime behavior change.

## Files

- `build.rs`
- `src/main.rs` (×2 — header + Connects-to-ParkHub-Server line)
- `src/discovery.rs`
- `src/server_connection.rs`

## Verification

`cargo clippy -p parkhub-client -- -W clippy::doc_markdown` → 0 warnings (was 5)

These files have no `ts-rs` / `utoipa` derives, so **no generated-bindings drift expected** (per the pattern documented in `feedback_parkhub_doc_comments_drift_two_gates_2026_05_03.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)