### PR TITLE
chore(web): tighten 7 any types — SOTA-2026 type safety

### DIFF
--- a/parkhub-web/src/components/MicroAnimated.tsx
+++ b/parkhub-web/src/components/MicroAnimated.tsx
@@ -23,7 +23,12 @@ export function MicroAnimated({ children, noHover, noPress, ...rest }: Props) {
     && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 
   if (!isEnabled('micro_animations') || prefersReducedMotion) {
-    return <div {...(rest as any)}>{children}</div>;
+    // Framer-only props (whileHover/whileTap) are already Omit'd from
+    // Props above. The remaining `initial/animate/transition/etc.` get
+    // string-coerced and silently ignored on a real div, which is
+    // acceptable. We assert HTMLAttributes<HTMLDivElement> rather than
+    // `any` to keep the tooling honest about the contract.
+    return <div {...(rest as React.HTMLAttributes<HTMLDivElement>)}>{children}</div>;
   }
 
   return (

--- a/parkhub-web/src/views/AdminAnalytics.tsx
+++ b/parkhub-web/src/views/AdminAnalytics.tsx
@@ -22,7 +22,7 @@ interface AnalyticsData {
 
 type DateRange = '7' | '30' | '90' | '365';
 
-function StatCard({ icon: Icon, label, value, sub }: { icon: any; label: string; value: string; sub?: string }) {
+function StatCard({ icon: Icon, label, value, sub }: { icon: React.ComponentType<{ weight?: 'fill' | 'regular' | 'bold' | 'duotone' | 'thin' | 'light'; className?: string }>; label: string; value: string; sub?: string }) {
   return (
     <div className="bg-white dark:bg-surface-900 rounded-xl p-5 border border-surface-200 dark:border-surface-800 shadow-sm">
       <div className="flex items-center gap-3 mb-2">
@@ -101,7 +101,7 @@ export function AdminAnalyticsPage() {
 
   useEffect(() => {
     setLoading(true);
-    const base = (import.meta as any).env?.VITE_API_URL || '';
+    const base = (import.meta as { env?: { VITE_API_URL?: string } }).env?.VITE_API_URL || '';
     const token = getInMemoryToken();
     const headers: Record<string, string> = {
       Accept: 'application/json',

--- a/parkhub-web/src/views/AdminCompliance.tsx
+++ b/parkhub-web/src/views/AdminCompliance.tsx
@@ -32,10 +32,10 @@ interface ComplianceReport {
   generated_at: string;
   overall_status: 'compliant' | 'warning' | 'non_compliant';
   checks: ComplianceCheck[];
-  data_categories: any[];
-  legal_basis: any[];
-  retention_periods: any[];
-  sub_processors: any[];
+  data_categories: unknown[];
+  legal_basis: unknown[];
+  retention_periods: unknown[];
+  sub_processors: unknown[];
   tom_summary: TomSummary;
 }
 


### PR DESCRIPTION
## Summary

Continues the type-safety pass. Replaces 7 `: any` / `as any` with honest, narrow types:

| File | Before | After |
|------|--------|-------|
| `MicroAnimated.tsx:26` | `as any` | `as React.HTMLAttributes<HTMLDivElement>` |
| `AdminAnalytics.tsx:25` | `icon: any` | proper phosphor-icon `ComponentType<{ weight?...; className?... }>` |
| `AdminAnalytics.tsx:104` | `(import.meta as any).env?...` | `(import.meta as { env?: { VITE_API_URL?: string } }).env?...` |
| `AdminCompliance.tsx:35-38` | 4× `any[]` | `unknown[]` (serde-compat fields, never read) |

## Verification

- **35/35** tests pass (MicroAnimated + AdminAnalytics + AdminCompliance)
- `tsc --noEmit` clean
- Pure type-level changes, no runtime impact

After this PR: 12 of 19 production `any` references remain — most are load-bearing (e.g. `api/client.ts`'s `ApiResponse<any>` heterogeneous cache, `CommandPalette` icon prop) where narrow typing would require more invasive refactors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)