### PR TITLE
chore(server): fix 10 clippy::doc_markdown warnings (jobs + db/bookings + circuit_breaker)

### DIFF
--- a/parkhub-server/src/circuit_breaker.rs
+++ b/parkhub-server/src/circuit_breaker.rs
@@ -17,7 +17,7 @@
 //! host (lower-cased); unknown/invalid URLs fall back to the literal URL.
 //!
 //! Metrics (reusing the existing `metrics` crate helpers):
-//!   * `parkhub_circuit_breaker_state{name}` gauge — 0 = Closed, 1 = HalfOpen,
+//!   * `parkhub_circuit_breaker_state{name}` gauge — 0 = Closed, 1 = `HalfOpen`,
 //!     2 = Open.
 //!   * `parkhub_circuit_breaker_events_total{name, event}` counter — event is
 //!     one of `success`, `failure`, `opened`, `half_opened`, `closed`,
@@ -46,13 +46,13 @@ pub struct Config {
     pub failure_threshold: u32,
     /// How long the breaker stays Open before allowing a probe.
     pub reset_after: Duration,
-    /// Max probe calls allowed concurrently in HalfOpen.
+    /// Max probe calls allowed concurrently in `HalfOpen`.
     pub half_open_max_calls: u32,
 }
 
 impl Config {
     /// Defaults tuned for webhook delivery: 5 consecutive failures, 30-second
-    /// cooldown, one probe at a time in HalfOpen.
+    /// cooldown, one probe at a time in `HalfOpen`.
     #[must_use]
     pub const fn webhook_defaults() -> Self {
         Self {

--- a/parkhub-server/src/db/bookings.rs
+++ b/parkhub-server/src/db/bookings.rs
@@ -69,7 +69,7 @@ impl Database {
         Ok(bookings)
     }
 
-    /// List bookings with pagination. Returns (page_items, total_count).
+    /// List bookings with pagination. Returns (`page_items`, `total_count`).
     pub async fn list_bookings_paginated(
         &self,
         page: i32,
@@ -91,7 +91,7 @@ impl Database {
         Ok((bookings, total))
     }
 
-    /// Get bookings for a user using the BOOKINGS_BY_USER secondary index.
+    /// Get bookings for a user using the `BOOKINGS_BY_USER` secondary index.
     ///
     /// O(k) where k = number of bookings for this user, instead of O(n) over
     /// all bookings.

--- a/parkhub-server/src/jobs.rs
+++ b/parkhub-server/src/jobs.rs
@@ -1,10 +1,10 @@
 //! Background job scheduler.
 //!
 //! Uses tokio interval tasks (no external cron dependency beyond what's already in the tree):
-//! - **AutoRelease** (every 5 min): cancel no-show bookings after the configured threshold
-//! - **ExpandRecurring** (every 1 h): create future booking instances for recurring series
-//! - **PurgeExpired** (every 24 h): remove old cancelled/expired bookings beyond retention period
-//! - **AggregateOccupancy** (every 15 min): persist aggregated occupancy stats to settings
+//! - **`AutoRelease`** (every 5 min): cancel no-show bookings after the configured threshold
+//! - **`ExpandRecurring`** (every 1 h): create future booking instances for recurring series
+//! - **`PurgeExpired`** (every 24 h): remove old cancelled/expired bookings beyond retention period
+//! - **`AggregateOccupancy`** (every 15 min): persist aggregated occupancy stats to settings
 
 // Background jobs hold read/write guards within tight scoped blocks by design.
 // Clippy flags the contained scope as "not tight enough" but the block is the


### PR DESCRIPTION
## Summary

Continues the #569 sweep. 3 more parkhub-server files cleared.

| File | Warnings | Items |
|------|----------|-------|
| `jobs.rs` | 4 | AutoRelease, ExpandRecurring, PurgeExpired, AggregateOccupancy |
| `db/bookings.rs` | 3 | page_items, total_count, BOOKINGS_BY_USER |
| `circuit_breaker.rs` | 3 | HalfOpen (×3) |

None of these files have `utoipa::path` or `ts-rs` derives → no openapi-drift / types-drift expected.

## Verification

- `cargo clippy -p parkhub-server -- -W clippy::doc_markdown` → 0 warnings in these 3 files
- doc-comment-only, no runtime impact

After this PR: ~53 `clippy::doc_markdown` warnings remain across other parkhub-server modules. Follow-up sweeps welcome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)