### PR TITLE
chore(server): fix 3 clippy::doc_markdown warnings in api/mod.rs

### DIFF
--- a/parkhub-server/src/api/mod.rs
+++ b/parkhub-server/src/api/mod.rs
@@ -408,17 +408,17 @@ pub async fn check_admin(
     }
 }
 
-/// T-1731: resolve the caller's tenant_id by looking up the authenticated user.
+/// T-1731: resolve the caller's `tenant_id` by looking up the authenticated user.
 ///
 /// Returns the user's `tenant_id` field (which is `None` for platform admins
 /// or unbound accounts — the same semantic the PHP side uses via
 /// `TenantScope::currentId()`).  Returns `None` when the user cannot be
 /// loaded at all (caller should treat that as "no tenant bound" rather than
-/// failing the request — the auth layer already guaranteed a valid user_id).
+/// failing the request — the auth layer already guaranteed a valid `user_id`).
 ///
 /// This is the first half of the Rust-side multi-tenancy hardening: every
 /// domain object created on behalf of `auth_user` carries the caller's
-/// tenant_id instead of a hard-coded `None`, so when `MODULE_MULTI_TENANT`
+/// `tenant_id` instead of a hard-coded `None`, so when `MODULE_MULTI_TENANT`
 /// flips on (today it is OFF) the records are already partitioned correctly.
 pub async fn resolve_tenant_id(state: &crate::AppState, user_id: Uuid) -> Option<String> {
     state


### PR DESCRIPTION
## Summary

Continues the doc_markdown sweep. `api/mod.rs` had 3 missing-backtick references to identifiers in the `resolve_tenant_id` docstring: `tenant_id` (×2) and `user_id`.

`api/mod.rs` has no `utoipa::path` / `utoipa::ToSchema`, so **no openapi-drift expected**.

## Verification

- `cargo clippy -p parkhub-server -- -W clippy::doc_markdown` → 0 warnings in this file (was 3)
- doc-comment-only, no runtime impact

## Note

After this PR: ~50 clippy::doc_markdown warnings remain in parkhub-server. Remaining files mostly contain `utoipa::path` which would trigger openapi-drift on doc-comment edits — those sweeps need the predictive regen recipe from `feedback_parkhub_doc_comments_drift_two_gates_2026_05_03.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)