### PR TITLE
chore(server): backtick OpenAPI/WhatsApp in doc comments

### DIFF
--- a/parkhub-server/src/api/notification_channels.rs
+++ b/parkhub-server/src/api/notification_channels.rs
@@ -1,4 +1,4 @@
-//! Notification channel stubs: SMS and WhatsApp.
+//! Notification channel stubs: SMS and `WhatsApp`.
 //!
 //! These are stub implementations that log the notification instead of
 //! actually sending it. They validate and store preferences, and when
@@ -70,7 +70,7 @@ fn send_sms_stub(phone: &str, user_id: &str, booking_id: &str, event: Notificati
     );
 }
 
-/// Stub: logs "would send WhatsApp" with the phone number and event details.
+/// Stub: logs "would send `WhatsApp`" with the phone number and event details.
 fn send_whatsapp_stub(phone: &str, user_id: &str, booking_id: &str, event: NotificationEvent) {
     info!(
         channel = "whatsapp",

--- a/parkhub-server/src/api/snapshots.rs
+++ b/parkhub-server/src/api/snapshots.rs
@@ -10,7 +10,7 @@
 //!   no wall-clock reads. Use redactions (`{".field" => "[redacted]"}`)
 //!   for fields that are stable-shaped but non-stable-valued.
 //! - **Use the smallest stable surface.** Snapshot envelope/metadata,
-//!   not full payloads — a 4000-line OpenAPI spec would churn constantly.
+//!   not full payloads — a 4000-line `OpenAPI` spec would churn constantly.
 //! - **Review snapshot diffs with `cargo insta review` locally** before
 //!   committing. `.snap` files are committed; `.snap.new` is gitignored.
 //!
@@ -44,7 +44,7 @@ async fn snap_system_version_shape() {
     });
 }
 
-/// OpenAPI document metadata shape — title, openapi version, info.license.
+/// `OpenAPI` document metadata shape — title, openapi version, info.license.
 /// We only snapshot the envelope so the snapshot doesn't churn every time
 /// a handler is added. The raw spec is tested separately by openapi-drift.
 #[tokio::test]


### PR DESCRIPTION
Two more clippy::doc_markdown nits in pre-existing comments:
- `snapshots.rs`: ``OpenAPI`` (×2) in module header + test docstring
- `notification_channels.rs`: ``WhatsApp`` (×2) in module header + stub fn docstring

Both files have no `#[utoipa::path]` / `ts-rs` derives → no openapi-drift / types-drift gate trip.

Continuation of the doc_markdown sweep (#570/#571/#575/#576).

🤖 Autonomous parkhub loop tick 2026-05-03.