### PR TITLE
chore(server): backtick X-API-Key/bucket_label/X-RateLimit-Bucket

### DIFF
--- a/parkhub-server/src/rate_limit.rs
+++ b/parkhub-server/src/rate_limit.rs
@@ -10,7 +10,7 @@
 //!    server from unauthenticated flooding and from attackers who don't yet
 //!    have credentials.
 //! 2. **Per-identity** — a second limiter keyed off the caller's `user_id`
-//!    (session / bearer / cookie auth) or `api_key_id` (X-API-Key auth).
+//!    (session / bearer / cookie auth) or `api_key_id` (`X-API-Key` auth).
 //!    Protects against credential-reuse attacks where a compromised key or
 //!    session rotates across IPs behind CGNAT/mobile carrier NAT.
 //!
@@ -864,7 +864,7 @@ mod tests {
         assert!(bucket.check(key_b).is_err());
     }
 
-    /// The bucket_label emitted in the X-RateLimit-Bucket header must
+    /// The `bucket_label` emitted in the `X-RateLimit-Bucket` header must
     /// never leak internal limiter names — only a small enum-of-strings.
     #[test]
     fn test_bucket_label_enum_of_strings() {


### PR DESCRIPTION
Three more clippy::doc_markdown nits in rate_limit.rs:
- Module header: ``X-API-Key``
- Per-IP bucket test docstring: ``bucket_label`` and ``X-RateLimit-Bucket``

No utoipa::path / ts-rs derives → no openapi-drift / types-drift gate trip.

Continuation of doc_markdown sweep (#570/#571/#575/#576/#577).

🤖 Autonomous parkhub loop tick 2026-05-03.