### PR TITLE
chore(server): backtick config/discovery/demo doc identifiers

### DIFF
--- a/parkhub-server/src/config.rs
+++ b/parkhub-server/src/config.rs
@@ -42,7 +42,7 @@ pub struct ServerConfig {
     #[serde(skip)]
     pub generate_dummy_users: bool,
 
-    /// Username style for dummy users (0=FirstLastLetter, 1=FirstDotLast, 2=InitialLast, 3=FirstInitial)
+    /// Username style for dummy users (0=`FirstLastLetter`, 1=`FirstDotLast`, 2=`InitialLast`, 3=`FirstInitial`)
     #[serde(skip)]
     pub username_style: u8,
 

--- a/parkhub-server/src/demo.rs
+++ b/parkhub-server/src/demo.rs
@@ -370,7 +370,7 @@ pub async fn demo_config(
 mod tests {
     use super::*;
 
-    /// Build a DemoState with `enabled = true` without touching the environment.
+    /// Build a `DemoState` with `enabled = true` without touching the environment.
     fn enabled_demo_state() -> DemoState {
         let now = Utc::now();
         DemoState {

--- a/parkhub-server/src/discovery.rs
+++ b/parkhub-server/src/discovery.rs
@@ -73,7 +73,7 @@ impl Drop for MdnsService {
 mod tests {
     use super::*;
 
-    /// Build a minimal ServerConfig for discovery tests.
+    /// Build a minimal `ServerConfig` for discovery tests.
     fn test_config() -> ServerConfig {
         ServerConfig {
             server_name: "TestServer".into(),


### PR DESCRIPTION
Six more clippy::doc_markdown nits across 3 files (cosmetic only — workspace policy already `allow`s this lint, but improves IDE/rustdoc rendering):
- `config.rs`:45 — backtick ``FirstLastLetter``, ``FirstDotLast``, ``InitialLast``, ``FirstInitial`` (4 enum variants)
- `discovery.rs`:76 — backtick ``ServerConfig``
- `demo.rs`:373 — backtick ``DemoState``

No `#[utoipa::path]` / ts-rs in these files.

🤖 Autonomous parkhub loop tick 2026-05-03.