### PR TITLE
chore(web): replace 3 `any` request bodies with explicit interface types

### DIFF
--- a/parkhub-web/src/views/AdminMaintenance.tsx
+++ b/parkhub-web/src/views/AdminMaintenance.tsx
@@ -94,7 +94,13 @@ export function AdminMaintenancePage() {
     }
     setSubmitting(true);
     try {
-      const body: any = {
+      const body: {
+        lot_id: string;
+        start_time: string;
+        end_time: string;
+        reason: string;
+        affected_slots?: string[];
+      } = {
         lot_id: form.lot_id,
         start_time: new Date(form.start_time).toISOString(),
         end_time: new Date(form.end_time).toISOString(),
@@ -264,7 +270,7 @@ export function AdminMaintenancePage() {
                     </p>
                     <p className="text-xs text-surface-500 dark:text-surface-400">
                       {new Date(w.start_time).toLocaleString()} — {new Date(w.end_time).toLocaleString()}
-                      {w.affected_slots.type === 'all' ? ` (${t('maintenance.allSlots', 'all slots')})` : ` (${(w.affected_slots as any).slot_ids?.length || 0} slots)`}
+                      {w.affected_slots.type === 'all' ? ` (${t('maintenance.allSlots', 'all slots')})` : ` (${w.affected_slots.slot_ids.length} slots)`}
                     </p>
                   </div>
                 </div>

--- a/parkhub-web/src/views/AdminZones.tsx
+++ b/parkhub-web/src/views/AdminZones.tsx
@@ -72,7 +72,9 @@ export function AdminZonesPage() {
   async function handleSavePricing() {
     if (!editZoneId) return;
     try {
-      const body: any = { tier: editTier };
+      const body: { tier: string; pricing_multiplier?: number; max_capacity?: number } = {
+        tier: editTier,
+      };
       const mult = parseFloat(editMultiplier);
       if (!isNaN(mult) && mult > 0) body.pricing_multiplier = mult;
       const cap = parseInt(editCapacity, 10);

--- a/parkhub-web/src/views/AdminZones.tsx
+++ b/parkhub-web/src/views/AdminZones.tsx
@@ -72,7 +72,7 @@ export function AdminZonesPage() {
   async function handleSavePricing() {
     if (!editZoneId) return;
     try {
-      const body: { tier: string; pricing_multiplier?: number; max_capacity?: number } = {
+      const body: { tier: PricingTier; pricing_multiplier?: number; max_capacity?: number } = {
         tier: editTier,
       };
       const mult = parseFloat(editMultiplier);


### PR DESCRIPTION
Type-safety improvement: 3 production `any` types eliminated.

`AdminZones.tsx`:75 — request body for PUT /api/v1/admin/zones/:id/pricing now typed as `{ tier: string; pricing_multiplier?: number; max_capacity?: number }`

`AdminMaintenance.tsx`:97 — request body for POST/PUT /api/v1/admin/maintenance now typed with explicit shape

`AdminMaintenance.tsx`:267 — drop redundant `(w.affected_slots as any)` cast — the discriminated-union narrowing on `type === 'all'` already proves the 'specific' branch has `slot_ids: string[]` at the type level

After this PR, the only remaining production `any` types are 6 browser-API workarounds (View Transitions API on document, requestIdleCallback on globalThis, and a Leaflet icon-prototype hack) — all justified.

Re-creates #580 (which conflicted due to the gitea/github main divergence).

🤖 Autonomous parkhub loop tick 2026-05-03.