### PR TITLE
chore(attestation): add `--sha` flag + state validation to post-attestation-deferred.sh

### DIFF
--- a/scripts/post-attestation-deferred.sh
+++ b/scripts/post-attestation-deferred.sh
@@ -9,20 +9,49 @@
 # every 5s (up to 2.5min) until the SHA shows up, then posts the status.
 # The parent process returns immediately so lefthook isn't blocked.
 #
-# Usage: bash scripts/post-attestation-deferred.sh [success|failure] [description]
+# Usage:
+#   bash scripts/post-attestation-deferred.sh [state] [description]
+#   bash scripts/post-attestation-deferred.sh --sha <sha> [state] [description]
+#
+# By default the SHA comes from `git rev-parse HEAD` (the lefthook
+# pre-push case). Use `--sha <sha>` to manually re-post against a
+# different commit (e.g. when an earlier post failed and the PR is
+# stuck on `fop/local-ci/pr` PENDING — see
+# `feedback_parkhub_attestation_script_args_2026_05_03.md`).
 #
 # Skips cleanly if `gh` isn't on PATH or no GitHub remote is configured.
 
 set -euo pipefail
 
+sha=""
+if [ "${1:-}" = "--sha" ]; then
+  sha="${2:-}"
+  if [ -z "$sha" ]; then
+    echo "ERROR: --sha requires a SHA argument" >&2
+    exit 2
+  fi
+  shift 2
+fi
+
 state="${1:-success}"
 description="${2:-Local-first attestation: lefthook pre-push gates clean}"
+
+# Validate state — GitHub statuses API rejects anything outside this set.
+case "$state" in
+  success|failure|pending|error) ;;
+  *)
+    echo "ERROR: state must be one of: success failure pending error (got: $state)" >&2
+    exit 2
+    ;;
+esac
 
 if ! command -v gh >/dev/null 2>&1; then
   exit 0
 fi
 
-sha="$(git rev-parse HEAD)"
+if [ -z "$sha" ]; then
+  sha="$(git rev-parse HEAD)"
+fi
 repo=""
 for remote in github upstream origin; do
   url="$(git remote get-url "$remote" 2>/dev/null || true)"


### PR DESCRIPTION
Two QoL improvements to prevent silent attestation-poster failures:

**1. `--sha <sha>` flag** — manual re-post against a specific commit without detaching HEAD.
Previously, calling `post-attestation-deferred.sh <SHA>` (as suggested in cron-loop docs) silently:
- Set `state=<SHA>` → GitHub statuses API rejects (`422`)
- Used `git rev-parse HEAD` for the actual SHA → posted against the WRONG commit
- Logged only `post failed on <sha>` to `~/.cache/parkhub-attestation/post-XXX.log` (caller sees no error)

After this PR:
```bash
bash scripts/post-attestation-deferred.sh --sha 7fb080c66a... success
```

**2. State validation** — reject anything outside `success|failure|pending|error` with a clear ERROR message and `exit 2`. Catches the typo class above before it hits GitHub.

Lefthook callsite (`bash scripts/post-attestation-deferred.sh success "…"`) is unchanged — backwards-compatible, no migration needed.

Discovered during cron tick 2026-05-03 19:00Z when PRs #579 + #581 were stuck BLOCKED for 12+ min on the `fop/local-ci/pr` poll. Documented in `feedback_parkhub_attestation_script_args_2026_05_03.md`.

🤖 Autonomous parkhub loop tick 2026-05-03.