### PR TITLE
chore(attestation): expand short SHAs in `--sha` to full 40-char form

### DIFF
--- a/scripts/post-attestation-deferred.sh
+++ b/scripts/post-attestation-deferred.sh
@@ -51,6 +51,18 @@ fi
 
 if [ -z "$sha" ]; then
   sha="$(git rev-parse HEAD)"
+else
+  # Expand short / abbreviated SHAs to the full 40-char form.
+  # GitHub's POST /repos/.../statuses/{sha} endpoint rejects anything
+  # shorter with HTTP 422 "Sha must be a valid hex object ID", even
+  # though GET /commits/{sha} accepts the prefix. Fail loudly if the
+  # SHA isn't resolvable locally.
+  expanded="$(git rev-parse --verify "${sha}^{commit}" 2>/dev/null || true)"
+  if [ -z "$expanded" ]; then
+    echo "ERROR: --sha '$sha' is not a valid commit in this repo" >&2
+    exit 2
+  fi
+  sha="$expanded"
 fi
 repo=""
 for remote in github upstream origin; do


### PR DESCRIPTION
Follow-up to #582 (`--sha` flag).

GitHub's `POST /repos/.../statuses/{sha}` endpoint requires a full 40-char SHA — abbreviated forms (8-12 chars, the kind `git log --oneline` shows) get HTTP 422 "Sha must be a valid hex object ID". Worse, the script's detached `nohup` subshell wrote only `post failed on <sha>` to the log file with no body — hiding the 422 from the caller.

Fix: `git rev-parse --verify '<sha>^{commit}'` expands the input before the API call. Invalid SHAs now exit 2 with a clear local error instead of silently fanning out to a doomed background poll.

Tested locally:
- `--sha 51ebccef success` → expands and posts
- `--sha deadbeef success` → `ERROR: --sha 'deadbeef' is not a valid commit in this repo`, exit 2

Burned 6+ min on PR #581 attestation poll today (T-2653) before discovering this.

🤖 Autonomous parkhub loop tick 2026-05-03.