### PR TITLE
test: update absence config icon mock

### DIFF
--- a/parkhub-web/src/constants/absenceConfig.test.ts
+++ b/parkhub-web/src/constants/absenceConfig.test.ts
@@ -1,11 +1,11 @@
 import { describe, it, expect, vi } from 'vitest';
 
 vi.mock('@phosphor-icons/react', () => ({
-  House: 'House',
-  Airplane: 'Airplane',
-  FirstAidKit: 'FirstAidKit',
-  Briefcase: 'Briefcase',
-  NoteBlank: 'NoteBlank',
+  HouseIcon: 'HouseIcon',
+  AirplaneIcon: 'AirplaneIcon',
+  FirstAidKitIcon: 'FirstAidKitIcon',
+  BriefcaseIcon: 'BriefcaseIcon',
+  NoteBlankIcon: 'NoteBlankIcon',
 }));
 
 import { ABSENCE_CONFIG, type AbsenceType } from './absenceConfig';
@@ -58,11 +58,11 @@ describe('ABSENCE_CONFIG', () => {
   });
 
   it('icons map to phosphor icon components', () => {
-    expect(ABSENCE_CONFIG.homeoffice.icon).toBe('House');
-    expect(ABSENCE_CONFIG.vacation.icon).toBe('Airplane');
-    expect(ABSENCE_CONFIG.sick.icon).toBe('FirstAidKit');
-    expect(ABSENCE_CONFIG.business_trip.icon).toBe('Briefcase');
-    expect(ABSENCE_CONFIG.other.icon).toBe('NoteBlank');
+    expect(ABSENCE_CONFIG.homeoffice.icon).toBe('HouseIcon');
+    expect(ABSENCE_CONFIG.vacation.icon).toBe('AirplaneIcon');
+    expect(ABSENCE_CONFIG.sick.icon).toBe('FirstAidKitIcon');
+    expect(ABSENCE_CONFIG.business_trip.icon).toBe('BriefcaseIcon');
+    expect(ABSENCE_CONFIG.other.icon).toBe('NoteBlankIcon');
   });
 
   it('all colors include dark mode variants', () => {


### PR DESCRIPTION
## Summary
- update the absence config Vitest Phosphor mock to export the current *Icon component names
- keep the icon mapping assertions aligned with src/constants/absenceConfig.ts

## Verification
- fop build --backend local --resource-profile interactive-small . --preset custom -- npm test -- --run src/constants/absenceConfig.test.ts
- git push pre-push hooks passed: cargo check, clippy, fast tests, openapi drift, osv, trivy, types drift, zizmor