### PR TITLE
ci: Nix/Garnix baseline + flake.lock for release-grade reproducibility

### DIFF
--- a/.gitea/workflows/ci.yaml
+++ b/.gitea/workflows/ci.yaml
@@ -70,6 +70,9 @@ jobs:
       - name: Validate Fly config
         run: python3 -c "import pathlib, tomllib; tomllib.loads(pathlib.Path('fly.toml').read_text())"
 
+      - name: Validate Nix/Garnix contract
+        run: make nix-contract
+
   helm-validate:
     name: Helm validate
     runs-on: ubuntu-latest

--- a/.gitea/workflows/ci.yml
+++ b/.gitea/workflows/ci.yml
@@ -13,6 +13,23 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  nix-garnix-contract:
+    name: Nix/Garnix contract
+    runs-on: ubuntu-latest
+    container:
+      image: rust:1.94.1-bookworm
+      # Resolve gitea.test (the in-cluster Gitea HTTP API at 192.168.178.233)
+      # so action ref rewrites work from inside the runner container.
+      options: --add-host=gitea.test:192.168.178.233
+    steps:
+      - name: Checkout code
+        uses: https://192.168.178.233/actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Validate Nix/Garnix contract
+        run: bash scripts/check-nix-garnix-contract.sh
+
   fmt:
     name: Cargo Format
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,9 @@ jobs:
       - name: Validate Fly config
         run: python3 -c "import pathlib, tomllib; tomllib.loads(pathlib.Path('fly.toml').read_text())"
 
+      - name: Validate Nix/Garnix contract
+        run: make nix-contract
+
   helm-validate:
     name: Helm validate
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ MAKEFLAGS += --no-print-directory
 EMBED_PLACEHOLDER := parkhub-web/dist/index.html
 SERVER_FEATURES   := --no-default-features --features headless
 
-.PHONY: help ci ci-post ci-security fmt clippy check client-check test lint drift frontend integration embed act pre-push clean
+.PHONY: help ci ci-post ci-security fmt clippy check client-check test lint drift frontend nix-contract integration embed act pre-push clean
 
 help:
 	@echo "parkhub-rust local CI mirror (see .github/workflows/*.yml)"
@@ -37,6 +37,7 @@ help:
 	@echo "  make test        — cargo test headless"
 	@echo "  make integration — integration tests (-- integration --test-threads=1)"
 	@echo "  make frontend    — parkhub-web vitest + build"
+	@echo "  make nix-contract — static Nix/Garnix CI contract"
 	@echo "  make drift       — openapi snapshot drift check"
 	@echo "  make act         — run workflows via nektos/act (if installed)"
 	@echo "  make pre-push    — alias for ci; run before git push"
@@ -80,6 +81,12 @@ integration: embed
 ## Mirrors: frontend job
 frontend:
 	cd parkhub-web && npm ci && npm test && npm run build
+
+## Static Nix/Garnix baseline contract. Real `nix flake check` requires nix
+## on PATH and a generated flake.lock; this gate keeps CI/Gitea/fop honest
+## until the host has Nix/Garnix tooling available.
+nix-contract:
+	bash scripts/check-nix-garnix-contract.sh
 
 ## Mirrors: openapi-drift.yml (starts headless server on :18181, dumps, diffs)
 drift: embed

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ MAKEFLAGS += --no-print-directory
 EMBED_PLACEHOLDER := parkhub-web/dist/index.html
 SERVER_FEATURES   := --no-default-features --features headless
 
-.PHONY: help ci ci-post ci-security fmt clippy check client-check test lint drift frontend nix-contract integration embed act pre-push clean
+.PHONY: help ci ci-post ci-security fmt clippy check client-check test lint drift frontend nix-contract nix-contract-strict integration embed act pre-push clean
 
 help:
 	@echo "parkhub-rust local CI mirror (see .github/workflows/*.yml)"
@@ -38,6 +38,7 @@ help:
 	@echo "  make integration — integration tests (-- integration --test-threads=1)"
 	@echo "  make frontend    — parkhub-web vitest + build"
 	@echo "  make nix-contract — static Nix/Garnix CI contract"
+	@echo "  make nix-contract-strict — require committed flake.lock for release-grade Nix/Garnix"
 	@echo "  make drift       — openapi snapshot drift check"
 	@echo "  make act         — run workflows via nektos/act (if installed)"
 	@echo "  make pre-push    — alias for ci; run before git push"
@@ -87,6 +88,9 @@ frontend:
 ## until the host has Nix/Garnix tooling available.
 nix-contract:
 	bash scripts/check-nix-garnix-contract.sh
+
+nix-contract-strict:
+	bash scripts/check-nix-garnix-contract.sh --require-lock
 
 ## Mirrors: openapi-drift.yml (starts headless server on :18181, dumps, diffs)
 drift: embed

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,82 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1777954456,
+        "narHash": "sha256-hGdgeU2Nk87RAuZyYjyDjFL6LK7dAZN5RE9+hrDTkDU=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "549bd84d6279f9852cae6225e372cc67fb91a4c1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1777950921,
+        "narHash": "sha256-NpOgt8ISaHTDNJZjNUfwFfbieKfRXzab4WKM31gZCGA=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "366ea19e0e55b768f74b7a0b2a20f847e7ae828d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,96 @@
+{
+  description = "ParkHub Rust - Tauri/headless server plus React 19 toolchain";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs = { nixpkgs, flake-utils, rust-overlay, ... }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        overlays = [ (import rust-overlay) ];
+        pkgs = import nixpkgs { inherit system overlays; };
+        rustToolchain = pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
+        nodejs = pkgs.nodejs_22;
+      in
+      {
+        devShells.default = pkgs.mkShell {
+          packages = with pkgs; [
+            rustToolchain
+            rust-analyzer
+            nodejs
+            pkg-config
+            cmake
+            clang
+            mold
+            sccache
+            openssl
+            sqlite
+            postgresql
+            curl
+            jq
+            git
+            zlib
+            fontconfig
+            freetype
+            wayland
+            wayland-protocols
+            libxkbcommon
+            libGL
+            xorg.libX11
+            xorg.libXcursor
+            xorg.libXrandr
+            xorg.libXi
+          ];
+
+          env = {
+            CI = "true";
+            RUSTC_WRAPPER = "sccache";
+            RUSTFLAGS = "-C link-arg=-fuse-ld=mold";
+          };
+
+          shellHook = ''
+            echo "ParkHub Rust dev shell: $(rustc --version), Node $(node --version)"
+          '';
+        };
+
+        checks = {
+          toolchain-contract = pkgs.runCommand "parkhub-rust-toolchain-contract"
+            {
+              nativeBuildInputs = [
+                rustToolchain
+                nodejs
+                pkgs.jq
+                pkgs.gnugrep
+              ];
+            }
+            ''
+              rustc --version | grep -q '1.94.1'
+              cargo --version >/dev/null
+              node --version | grep -Eq '^v22\.'
+              npm --version >/dev/null
+              grep -q 'channel = "1.94.1"' ${./rust-toolchain.toml}
+              jq -e '.engines.node == ">=22.12.0"' ${./parkhub-web/package.json} >/dev/null
+              touch "$out"
+            '';
+
+          garnix-contract = pkgs.runCommand "parkhub-rust-garnix-contract"
+            {
+              nativeBuildInputs = [ pkgs.gnugrep ];
+            }
+            ''
+              test -f ${./garnix.yaml}
+              grep -q 'checks.x86_64-linux.*' ${./garnix.yaml}
+              grep -q 'devShells.x86_64-linux.default' ${./garnix.yaml}
+              touch "$out"
+            '';
+        };
+
+        formatter = pkgs.nixpkgs-fmt;
+      });
+}

--- a/garnix.yaml
+++ b/garnix.yaml
@@ -1,0 +1,9 @@
+# Garnix reads this file after the GitHub app is enabled for the repo.
+# Keep the first ParkHub Rust slice Linux-only: fop remains the full heavy
+# cargo/E2E gate, while Garnix proves flake evaluation, checks, and
+# dev-shell cacheability.
+builds:
+  include:
+    - 'checks.x86_64-linux.*'
+    - 'devShells.x86_64-linux.default'
+  exclude: []

--- a/scripts/check-nix-garnix-contract.sh
+++ b/scripts/check-nix-garnix-contract.sh
@@ -6,6 +6,18 @@ fail() {
   exit 1
 }
 
+require_lock=0
+case "${1:-}" in
+  "")
+    ;;
+  --require-lock|--strict)
+    require_lock=1
+    ;;
+  *)
+    fail "unknown argument: $1"
+    ;;
+esac
+
 require_file() {
   [[ -f "$1" ]] || fail "missing $1"
 }
@@ -39,7 +51,9 @@ require_grep '"node"[[:space:]]*:[[:space:]]*">=22\.12\.0"' parkhub-web/package.
 require_grep 'checks\.x86_64-linux\.\*' garnix.yaml 'Garnix must build Linux checks'
 require_grep 'devShells\.x86_64-linux\.default' garnix.yaml 'Garnix must build the Linux dev shell'
 
-if [[ ! -f flake.lock ]]; then
+if [[ ! -f flake.lock && "$require_lock" -eq 1 ]]; then
+  fail "flake.lock is not committed yet; run nix flake lock and commit it before release-grade Garnix use"
+elif [[ ! -f flake.lock ]]; then
   printf 'WARN: flake.lock is not committed yet; run nix flake lock once nix is available.\n' >&2
 fi
 

--- a/scripts/check-nix-garnix-contract.sh
+++ b/scripts/check-nix-garnix-contract.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+fail() {
+  printf 'ERROR: %s\n' "$*" >&2
+  exit 1
+}
+
+require_file() {
+  [[ -f "$1" ]] || fail "missing $1"
+}
+
+require_grep() {
+  local pattern="$1"
+  local file="$2"
+  local note="$3"
+  grep -Eq "$pattern" "$file" || fail "$note ($file)"
+}
+
+require_file flake.nix
+require_file garnix.yaml
+require_file rust-toolchain.toml
+
+require_grep 'nixos-unstable' flake.nix 'flake must use nixos-unstable'
+require_grep 'flake-utils' flake.nix 'flake must use flake-utils'
+require_grep 'rust-overlay' flake.nix 'flake must use rust-overlay'
+require_grep 'fromRustupToolchainFile \./rust-toolchain\.toml' flake.nix 'flake must read rust-toolchain.toml'
+require_grep 'nodejs_22' flake.nix 'flake must pin Node 22'
+require_grep 'mold' flake.nix 'flake must include mold linker'
+require_grep 'sccache' flake.nix 'flake must include sccache'
+require_grep 'devShells\.default' flake.nix 'flake must expose devShells.default'
+require_grep 'toolchain-contract' flake.nix 'flake must expose toolchain-contract check'
+require_grep 'garnix-contract' flake.nix 'flake must expose garnix-contract check'
+require_grep 'formatter = pkgs\.nixpkgs-fmt' flake.nix 'flake must expose nixpkgs-fmt formatter'
+
+require_grep 'channel[[:space:]]*=[[:space:]]*"1\.94\.1"' rust-toolchain.toml 'rust-toolchain.toml must pin Rust 1.94.1'
+require_grep '"node"[[:space:]]*:[[:space:]]*">=22\.12\.0"' parkhub-web/package.json 'parkhub-web package must require Node >=22.12.0'
+
+require_grep 'checks\.x86_64-linux\.\*' garnix.yaml 'Garnix must build Linux checks'
+require_grep 'devShells\.x86_64-linux\.default' garnix.yaml 'Garnix must build the Linux dev shell'
+
+if [[ ! -f flake.lock ]]; then
+  printf 'WARN: flake.lock is not committed yet; run nix flake lock once nix is available.\n' >&2
+fi
+
+printf 'ParkHub Rust Nix/Garnix contract OK.\n'


### PR DESCRIPTION
## Summary

T-2775. Adds the Nix/Garnix baseline to parkhub-rust with a committed `flake.lock` so `make nix-contract --strict` and Garnix flake-check can run reproducibly.

- New `flake.nix` (already on branch) with nixpkgs/nixos-unstable + flake-utils + rust-overlay inputs
- New `flake.lock` pinned to:
  - nixpkgs: `549bd84d` (2026-05-05)
  - flake-utils: `11707dc2` (2024-11-13)
  - rust-overlay: `366ea19e` (2026-05-05)
- New `scripts/check-nix-garnix-contract.sh` (60 lines): static checks for flake.nix structure, garnix.yaml schema, devShells.default, formatter pin, toolchain-contract output
- New `make nix-contract` (warns on missing lock) + `make nix-contract-strict` (`--require-lock`, hard fail) targets
- `flake.lock` was generated via mirrored `192.168.178.250:5000/nixos-nix:2.24.10` in a clean podman context (CLAUDE.md: never pull from Docker Hub during builds)

## Follow-ups

- After this merges: switch CI to call `make nix-contract-strict` instead of `make nix-contract` to lock in the strict gate
- Pair PR for parkhub-php nix-garnix is queued behind a separate `make ci` run

## Test plan

- [x] All 10 lefthook pre-push gates green (cargo-check, clippy, test-fast, openapi-drift, osv-scanner, post-attestation, trivy-fs, types-drift, workflow-drift, zizmor)
- [x] `make nix-contract` passes locally  
- [ ] Garnix flake-check on first push (post-merge)
- [ ] Required CI gates on this PR