### PR TITLE
ci: switch nix-contract gate to --strict (--require-lock)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,8 +62,8 @@ jobs:
       - name: Validate Fly config
         run: python3 -c "import pathlib, tomllib; tomllib.loads(pathlib.Path('fly.toml').read_text())"
 
-      - name: Validate Nix/Garnix contract
-        run: make nix-contract
+      - name: Validate Nix/Garnix contract (strict, --require-lock)
+        run: make nix-contract-strict
 
   helm-validate:
     name: Helm validate


### PR DESCRIPTION
T-2778. Audit follow-up from PR #598.

Now that flake.lock is committed in main (#598), flip CI from non-strict make nix-contract (warns on missing lock) to make nix-contract-strict (--require-lock, hard fails if lock drifts). Locks in the strict reproducibility gate.

## Test plan
- [x] All 10 lefthook pre-push gates green