### PR TITLE
fix(ci): parameterize WOLFI_BASE for cloud builds + tauri 2.11.1 (CVE)

### DIFF
--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -28,6 +28,11 @@ jobs:
           git clone --depth 1 https://github.com/nash87/parkhub-rust.git /tmp/smoke
       - name: Follow INSTALLATION.md Docker Compose steps
         working-directory: /tmp/smoke
+        env:
+          # Cloud runners can't reach the homelab LAN mirror; pull the same
+          # Wolfi base from Chainguard's public registry. Dockerfile defaults
+          # to the LAN mirror for local + gitea-runner builds.
+          WOLFI_BASE: cgr.dev/chainguard/wolfi-base:latest
         run: |
           # Step 2 — set admin password
           echo "PARKHUB_ADMIN_PASSWORD=$(openssl rand -base64 24)" > .env

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2165,7 +2165,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2586,7 +2586,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3205,7 +3205,7 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.1.3",
+ "windows-link 0.2.1",
  "windows-result 0.4.1",
 ]
 
@@ -3997,12 +3997,12 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
- "windows-registry 0.6.1",
+ "windows-registry",
 ]
 
 [[package]]
@@ -5651,7 +5651,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5808,7 +5808,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6540,7 +6540,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.45.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7015,7 +7015,6 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
- "phf_macros 0.11.3",
  "phf_shared 0.11.3",
 ]
 
@@ -7121,19 +7120,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "phf_macros"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
-dependencies = [
- "phf_generator 0.11.3",
- "phf_shared 0.11.3",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -7681,7 +7667,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.2",
  "rustls",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -7719,9 +7705,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8485,7 +8471,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8543,7 +8529,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9404,7 +9390,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9866,9 +9852,9 @@ checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "tauri"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d059f2527558d9dba6f186dec4772610e1aecfd3f94002397613e7e648752b66"
+checksum = "b93bd86d231f0a8138f11a02a584769fe4b703dc36ae133d783228dbc4801405"
 dependencies = [
  "anyhow",
  "bytes",
@@ -9917,9 +9903,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-build"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be9aa8c59a894f76c29a002501c589de5eb4987a5913d62a6e0a47f320901988"
+checksum = "3a318b234cc2dea65f575467bafcfb76286bce228ebc3778e337d61d03213007"
 dependencies = [
  "anyhow",
  "cargo_toml",
@@ -9938,9 +9924,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-codegen"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3e4e8230d565106aa19dfbaa01a7ed01abf78047fe0577a83377224bd1bf20e"
+checksum = "6bd11644962add2549a60b7e7c6800f17d7020156e02f516021d8103e80cc528"
 dependencies = [
  "base64 0.22.1",
  "brotli",
@@ -9965,9 +9951,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-macros"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc8de2cddbbc33dbdf4c84f170121886595efdbcc9cb4b3d76342b79d082cedc"
+checksum = "fed9d3742a37a355d2e47c9af924e9fbc112abb76f9835d35d4780e318419502"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -10011,7 +9997,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tracing",
  "url",
- "windows-registry 0.5.3",
+ "windows-registry",
  "windows-result 0.3.4",
 ]
 
@@ -10222,9 +10208,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-runtime"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e42bbcb76237351fbaa02f08d808c537dc12eb5a6eabbf3e517b50056334d95"
+checksum = "8fef478ba1d2ac21c2d528740b24d0cb315e1e8b1111aae53fafac34804371fc"
 dependencies = [
  "cookie",
  "dpi",
@@ -10247,9 +10233,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-runtime-wry"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cadb13dad0c681e1e0a2c49ae488f0e2906ded3d57e7a0017f4aaf46e387117"
+checksum = "a3989df2ae1c476404fe0a2e8ffc4cfbde97e51efd613c2bb5355fbc9ab52cf0"
 dependencies = [
  "gtk",
  "http 1.4.0",
@@ -10273,9 +10259,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-utils"
-version = "2.9.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55f61d2bf7188fbcf2b0ed095b67a6bc498f713c939314bb19eb700118a573b7"
+checksum = "d57200389a2f82b4b0a40ae29ca19b6978116e8f4d4e974c3234ce40c0ffbdec"
 dependencies = [
  "anyhow",
  "brotli",
@@ -10291,7 +10277,7 @@ dependencies = [
  "kuchikiki",
  "log",
  "memchr",
- "phf 0.11.3",
+ "phf 0.13.1",
  "plist",
  "proc-macro2",
  "quote",
@@ -10344,7 +10330,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -11015,7 +11001,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -11123,7 +11109,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -12052,7 +12038,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -12230,17 +12216,6 @@ dependencies = [
  "windows-link 0.1.3",
  "windows-result 0.3.4",
  "windows-strings 0.4.2",
-]
-
-[[package]]
-name = "windows-registry"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
-dependencies = [
- "windows-link 0.2.1",
- "windows-result 0.4.1",
- "windows-strings 0.5.1",
 ]
 
 [[package]]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,14 @@
 # and a distroless runtime for minimal attack surface (~20 MB image).
 # =============================================================================
 
+# Global build-args (declared before the first FROM so every stage can
+# reference them). WOLFI_BASE defaults to the homelab LAN mirror to preserve
+# the "never pull from Docker Hub" convention for local + gitea-runner
+# builds. GitHub Actions cloud runners pass
+#   --build-arg WOLFI_BASE=cgr.dev/chainguard/wolfi-base:latest
+# to source the same Wolfi base from Chainguard's public registry.
+ARG WOLFI_BASE=192.168.178.250:5000/wolfi-base:latest
+
 # ---------------------------------------------------------------------------
 # Stage 1: Frontend build (Astro/Vite)
 # ---------------------------------------------------------------------------
@@ -94,8 +102,12 @@ RUN mkdir -p /data && chown 65532:65532 /data
 #   - openssl: lettre's tokio1-native-tls dynamically links libssl/libcrypto at runtime
 #     (openssl-sys is `vendored` at BUILD time, but native-tls still dlopens the system libs)
 #   - libgcc: Rust panic unwinding (_Unwind_* symbols)
+#
+# WOLFI_BASE is a global build-arg declared at the top of the file (see
+# header comment). Cloud CI overrides it; local + gitea-runner builds use
+# the LAN mirror default.
 # ---------------------------------------------------------------------------
-FROM 192.168.178.250:5000/wolfi-base:latest AS runtime
+FROM ${WOLFI_BASE} AS runtime
 
 # `apk update && apk upgrade --no-cache --available` is mandatory to bump glibc
 # past CVE-2026-5450 — without `--available`, glibc 2.43-r6 sticks and grype

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,9 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+      args:
+        # Default to LAN mirror; cloud CI sets WOLFI_BASE in env to override.
+        WOLFI_BASE: ${WOLFI_BASE:-192.168.178.250:5000/wolfi-base:latest}
     container_name: parkhub
     restart: unless-stopped
     # Pass CLI flags so the server runs headless on port 8080.

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -89,11 +89,6 @@ reason = "unic-* family unmaintained; Slint 1.16 plans replacement"
 id = "RUSTSEC-2025-0141"
 reason = "bincode unmaintained (transitive via hyphenation -> printpdf 0.9)"
 
-# npm transitive (parkhub-web)
-[[IgnoredVulns]]
-id = "GHSA-48c2-rrv3-qjmp"
-reason = "yaml dev-dep CVE; non-prod; bumping in next dependabot wave"
-
 [[IgnoredVulns]]
 id = "GHSA-wrw7-89jp-8q8g"
 reason = "glib gtk-rs unchecked-callback PSK leak; not used by parkhub-server (Tauri-side only)"


### PR DESCRIPTION
## Summary

- **CI fix**: Add `ARG WOLFI_BASE` (global, declared before first FROM) to make the runtime image build-target configurable. Default = LAN mirror (`192.168.178.250:5000/wolfi-base:latest`); cloud CI passes `--build-arg WOLFI_BASE=cgr.dev/chainguard/wolfi-base:latest` to source the same Wolfi base from Chainguard's public registry. Closes the Install Smoke nightly failures (`dial tcp 192.168.178.250:5000: i/o timeout`).
- **Security**: Bump `tauri` 2.11.0 → 2.11.1 ([GHSA-7gmj-67g7-phm9](https://github.com/advisories/GHSA-7gmj-67g7-phm9), CVSS 6.1) plus the related `tauri-build/codegen/macros/runtime/runtime-wry/utils` family.
- **Cleanup**: Drop unused `GHSA-48c2-rrv3-qjmp` suppression from `osv-scanner.toml` (yaml dev-dep CVE was already addressed upstream).

## Why
Wolfi runtime rebase (#601) pinned the LAN registry which cloud runners can't reach. Same root cause as the failing nightly Install Smoke runs since 2026-05-06. Local + gitea-runner builds keep the LAN convention; only cloud CI uses cgr.dev.

## Test plan
- [x] Local lefthook full pre-push pass (cargo-check / clippy / test-fast / image-scan / osv-scanner / openapi-drift / types-drift / workflow-drift / trivy-fs / zizmor / post-attestation)
- [x] Trivy: 0 vulns, Grype: 0 vulns on the rebuilt image
- [x] osv-scanner: clean (no findings)
- [ ] CI: Install Smoke nightly should now succeed (verifies `cgr.dev` ingress works on GitHub-hosted runners)