### PR TITLE
chore(release): bump to v5.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6647,7 +6647,7 @@ dependencies = [
 
 [[package]]
 name = "parkhub-client"
-version = "5.0.9"
+version = "5.1.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6674,7 +6674,7 @@ dependencies = [
 
 [[package]]
 name = "parkhub-common"
-version = "5.0.9"
+version = "5.1.0"
 dependencies = [
  "chrono",
  "proptest",
@@ -6688,7 +6688,7 @@ dependencies = [
 
 [[package]]
 name = "parkhub-desktop"
-version = "5.0.9"
+version = "5.1.0"
 dependencies = [
  "directories",
  "serde",
@@ -6712,7 +6712,7 @@ dependencies = [
 
 [[package]]
 name = "parkhub-server"
-version = "5.0.9"
+version = "5.1.0"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "5.0.9"
+version = "5.1.0"
 edition = "2024"
 rust-version = "1.94"
 authors = ["nash87"]

--- a/helm/parkhub/Chart.yaml
+++ b/helm/parkhub/Chart.yaml
@@ -3,7 +3,7 @@ name: parkhub
 description: Self-hosted parking management platform — single binary, zero dependencies
 type: application
 version: 1.0.0
-appVersion: "4.13.0"
+appVersion: "5.1.0"
 home: https://github.com/nash87/parkhub-rust
 sources:
   - https://github.com/nash87/parkhub-rust

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parkhub",
-  "version": "5.0.9",
+  "version": "5.1.0",
   "description": "Open source parking lot management system with client-server architecture.",
   "scripts": {
     "test:e2e": "npx playwright test",

--- a/parkhub-web/package.json
+++ b/parkhub-web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "parkhub-web",
   "type": "module",
-  "version": "5.0.9",
+  "version": "5.1.0",
   "engines": {
     "node": ">=22.12.0"
   },


### PR DESCRIPTION
## Summary

Cuts the **v5.1.0 release boundary** covering 17+ commits since v5.0.9 (2026-05-03).

### Headline changes since v5.0.9
- **Wolfi runtime rebase** (#601) — closes libc6 CVE-2026-5450, replaces distroless/cc-debian13
- **nix-strict gate** (#602) for release-grade reproducibility
- **nix-garnix baseline** (#598) integrating with the public Garnix.io build farm
- **openssl 0.10.79** across cargo workspace + fuzz harness (#599, #600)
- **GHA dependabot bumps** (#591/#592/#593/#594) hash-pinning all GHA refs
- **WOLFI_BASE build-arg** parameterization (#603) so cloud CI pulls Wolfi from cgr.dev while local + gitea-runner builds keep the LAN mirror
- **tauri 2.11.0 → 2.11.1** (GHSA-7gmj-67g7-phm9, CVSS 6.1)
- **devcontainer rust 1.94.1 → 1.95-bookworm** (#604)

### Version surfaces bumped
- `Cargo.toml` workspace.package.version
- `package.json`
- `parkhub-web/package.json`
- `Cargo.lock` (4 workspace crates regen via `cargo update --workspace --offline`)
- `helm/parkhub/Chart.yaml` appVersion (also fixes prior 4.13.0 → 5.1.0 drift)

git-cliff regenerates CHANGELOG.md via the changelog workflow PR after this lands.

After merge: tag `v5.1.0` on main → release.yml fires → multi-platform binaries + cosign + SBOM + GitHub Release.

## Test plan
- [x] Local lefthook full pre-push pass (10 gates green: cargo-check/clippy/test-fast/openapi-drift/osv-scanner/post-attestation/trivy-fs/types-drift/zizmor/image-scan)
- [x] Trivy 0 + Grype 0 on rebuilt runtime image
- [ ] CI: validate-tag job will check Cargo.toml/package.json/parkhub-web/package.json all match v5.1.0