### PR TITLE
fix(devcontainer): drop apt helm (not a Debian package)

### DIFF
--- a/.devcontainer/Containerfile
+++ b/.devcontainer/Containerfile
@@ -18,11 +18,14 @@ ARG GRYPE_VERSION=0.91.0
 ARG GITLEAKS_VERSION=8.30.1
 ARG ACTIONLINT_VERSION=1.7.12
 
-# Base apt deps — kept minimal, every install pinned where upstream supports it.
+# Base apt deps -- kept minimal, every install pinned where upstream supports it.
+# `helm` is NOT an apt package on Debian Bookworm; the version-pinned curl
+# install below (HELM_VERSION arg) is the canonical install path. yamllint
+# IS an apt package and stays here.
 RUN apt-get update && apt-get install -y --no-install-recommends \
         ca-certificates curl wget gnupg lsb-release jq git \
         python3 python3-pip python3-yaml \
-        helm yamllint \
+        yamllint \
         sudo less \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Summary

The `Publish dev container image` workflow has been failing nightly since 2026-05-04 with:

```
E: Unable to locate package helm
ERROR: process "/bin/sh -c apt-get update && apt-get install -y --no-install-recommends ... helm yamllint ..." did not complete successfully: exit code: 100
```

`helm` is **not** an apt package on Debian Bookworm. The Containerfile already has the canonical install path further down:

```dockerfile
ARG HELM_VERSION=v3.18.4
...
RUN curl -fsSLO "https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz" \
    && tar -xzf "helm-${HELM_VERSION}-linux-amd64.tar.gz" linux-amd64/helm \
    && mv linux-amd64/helm /usr/local/bin/helm ...
```

The `helm` reference in the apt-get list was leftover that should have been pruned when the curl install was added (commented "apt's helm is too old for Chart v2 features we use").

This PR removes `helm` from the apt-get list. `yamllint` IS an apt package and stays. No other changes.

## Why this is separate from #604

PR #604 bumped the rust base from `rust:1.94.1-bookworm` to `rust:1.95-bookworm` (image alignment). The apt-get failure mode persists across both base images because it's a Containerfile bug, not a base-image staleness issue.

## Test plan
- [x] Local lefthook full pre-push pass (9 gates green: cargo-check / clippy / test-fast / openapi-drift / osv-scanner / post-attestation / trivy-fs / types-drift / zizmor)
- [ ] CI: Publish dev container image should now succeed (apt-get layer completes; existing curl install of helm/trivy/grype/gitleaks/actionlint runs unchanged)