### PR TITLE
ci: route ParkHub Rust gates through fop (CI/hooks/make/docs)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,27 +29,27 @@ repos:
       - id: mixed-line-ending
         args: [--fix=lf]
 
-  # Rust — cargo fmt + clippy as system hooks (respect rust-toolchain.toml)
+  # Rust — fop-gated cargo fmt + clippy as system hooks (respect rust-toolchain.toml)
   - repo: local
     hooks:
       - id: cargo-fmt
-        name: cargo fmt --check
+        name: fop cargo fmt --check
         language: system
-        entry: cargo fmt --all -- --check
+        entry: fop build --backend local --resource-profile interactive-small . --preset custom -- cargo fmt --all -- --check
         pass_filenames: false
         files: \.rs$
 
       - id: cargo-clippy
-        name: cargo clippy (headless, -D warnings)
+        name: fop cargo clippy (headless, -D warnings)
         language: system
-        entry: bash -c 'mkdir -p parkhub-web/dist && [ -f parkhub-web/dist/index.html ] || printf "%s" "<!doctype html><html><body></body></html>" > parkhub-web/dist/index.html; cargo clippy --locked --package parkhub-common --all-targets -- -D warnings && cargo clippy --locked --package parkhub-server --no-default-features --features headless --all-targets -- -D warnings -A clippy::cognitive_complexity -A clippy::assigning_clones'
+        entry: fop build --backend local --resource-profile interactive-small . --preset custom -- bash -lc 'mkdir -p parkhub-web/dist && [ -f parkhub-web/dist/index.html ] || printf "%s" "<!doctype html><html><body></body></html>" > parkhub-web/dist/index.html; cargo clippy --locked --package parkhub-common --all-targets -- -D warnings && cargo clippy --locked --package parkhub-server --no-default-features --features headless --all-targets -- -D warnings -A clippy::cognitive_complexity -A clippy::assigning_clones'
         pass_filenames: false
         files: \.rs$
         stages: [pre-push]   # slow — run on push, not every commit
 
       - id: cargo-check
-        name: cargo check
+        name: fop cargo check
         language: system
-        entry: bash -c 'mkdir -p parkhub-web/dist && [ -f parkhub-web/dist/index.html ] || printf "%s" "<!doctype html><html><body></body></html>" > parkhub-web/dist/index.html; cargo check --locked --package parkhub-common --all-targets'
+        entry: fop build --backend local --resource-profile interactive-small . --preset custom -- bash -lc 'mkdir -p parkhub-web/dist && [ -f parkhub-web/dist/index.html ] || printf "%s" "<!doctype html><html><body></body></html>" > parkhub-web/dist/index.html; cargo check --locked --package parkhub-common --all-targets'
         pass_filenames: false
         files: \.rs$

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,10 +15,10 @@ Self-hosted parking management platform for enterprises, universities, and resid
 ## Build
 ```sh
 # Default build (pure MIT, headless, no GUI — for Docker/server deployments)
-cargo build --release --package parkhub-server
+fop build --backend local . --preset custom -- cargo build --release --package parkhub-server
 
 # Optional desktop GUI build (pulls Slint, GPL-3.0)
-cargo build --release --package parkhub-server --features gui
+fop build --backend local . --preset custom -- cargo build --release --package parkhub-server --features gui
 
 # React frontend (must be built before server if modifying frontend)
 cd parkhub-web && npm install && npm run build
@@ -26,15 +26,15 @@ cd parkhub-web && npm install && npm run build
 
 ## Test
 ```sh
-cargo test --workspace          # All workspace tests
-cargo test -p parkhub-server    # Server tests only
-cargo test -p parkhub-common    # Common crate tests
+fop test . -- --workspace          # All workspace tests
+fop test . -- -p parkhub-server    # Server tests only
+fop test . -- -p parkhub-common    # Common crate tests
 ```
 
 ## Lint
 ```sh
-cargo clippy --workspace -- -D warnings
-cargo fmt --all -- --check
+fop clippy .
+fop build --backend local . --preset custom -- cargo fmt --all -- --check
 ```
 
 ## Pre-Push Gate (mandatory)

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ MAKEFLAGS += --no-print-directory
 
 EMBED_PLACEHOLDER := parkhub-web/dist/index.html
 SERVER_FEATURES   := --no-default-features --features headless
+FOP_BUILD         := fop build --backend local --resource-profile interactive-small . --preset custom --
 
 .PHONY: help ci ci-post ci-security fmt clippy check client-check test lint drift frontend nix-contract nix-contract-strict integration embed act pre-push clean
 
@@ -50,38 +51,38 @@ embed:
 
 ## Mirrors: fmt job
 fmt:
-	cargo fmt --all -- --check
+	$(FOP_BUILD) cargo fmt --all -- --check
 
 ## Mirrors: clippy job
 clippy: embed
-	cargo clippy --locked --package parkhub-common --all-targets -- -D warnings
-	cargo clippy --locked --package parkhub-server $(SERVER_FEATURES) --all-targets -- \
+	$(FOP_BUILD) cargo clippy --locked --package parkhub-common --all-targets -- -D warnings
+	$(FOP_BUILD) cargo clippy --locked --package parkhub-server $(SERVER_FEATURES) --all-targets -- \
 		-D warnings -A clippy::cognitive_complexity -A clippy::assigning_clones
 
 lint: fmt clippy
 
 ## Mirrors: check job
 check: embed
-	cargo check --locked --package parkhub-common --all-targets
-	cargo check --locked --package parkhub-server $(SERVER_FEATURES) --all-targets
+	$(FOP_BUILD) cargo check --locked --package parkhub-common --all-targets
+	$(FOP_BUILD) cargo check --locked --package parkhub-server $(SERVER_FEATURES) --all-targets
 
 ## Mirrors: client-check job
 client-check:
-	cargo check --locked --package parkhub-client --all-targets
+	$(FOP_BUILD) cargo check --locked --package parkhub-client --all-targets
 
 ## Mirrors: test job
 test: embed
-	TMPDIR=/tmp cargo test --locked --package parkhub-common --all-targets
-	TMPDIR=/tmp cargo test --locked --package parkhub-server $(SERVER_FEATURES) --all-targets
+	$(FOP_BUILD) env TMPDIR=/tmp cargo test --locked --package parkhub-common --all-targets
+	$(FOP_BUILD) env TMPDIR=/tmp cargo test --locked --package parkhub-server $(SERVER_FEATURES) --all-targets
 
 ## Mirrors: integration job
 integration: embed
-	TMPDIR=/tmp cargo build --locked --package parkhub-server $(SERVER_FEATURES)
-	TMPDIR=/tmp RUST_LOG=warn cargo test --locked --package parkhub-server $(SERVER_FEATURES) -- integration --test-threads=1
+	$(FOP_BUILD) env TMPDIR=/tmp cargo build --locked --package parkhub-server $(SERVER_FEATURES)
+	$(FOP_BUILD) env TMPDIR=/tmp RUST_LOG=warn cargo test --locked --package parkhub-server $(SERVER_FEATURES) -- integration --test-threads=1
 
 ## Mirrors: frontend job
 frontend:
-	cd parkhub-web && npm ci && CI=true npm test && CI=true npm run build
+	$(FOP_BUILD) bash -lc 'cd parkhub-web && npm ci && CI=true npm test && CI=true npm run build'
 
 ## Static Nix/Garnix baseline contract. Real `nix flake check` requires nix
 ## on PATH and a generated flake.lock; this gate keeps CI/Gitea/fop honest
@@ -94,7 +95,7 @@ nix-contract-strict:
 
 ## Mirrors: openapi-drift.yml (starts headless server on :18181, dumps, diffs)
 drift: embed
-	cargo build --locked --release --package parkhub-server --no-default-features --features 'full,headless'
+	$(FOP_BUILD) cargo build --locked --release --package parkhub-server --no-default-features --features 'full,headless'
 	@mkdir -p /tmp/parkhub-drift-db
 	@SERVER_BIN="$$(cargo metadata --locked --no-deps --format-version 1 | jq -r .target_directory)/release/parkhub-server"; \
 		"$$SERVER_BIN" --headless --unattended --port 18181 --data-dir /tmp/parkhub-drift-db > /tmp/parkhub-drift.log 2>&1 & \

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -107,14 +107,16 @@ pre-push:
       # excluded here because it pulls in tauri+webkit2gtk system deps
       # that not every dev box has installed.
       run: |
-        mkdir -p parkhub-web/dist
-        [ -f parkhub-web/dist/index.html ] || \
-          printf '%s' '<!doctype html><html><body></body></html>' \
-          > parkhub-web/dist/index.html
-        cargo check --locked -p parkhub-common --all-targets
-        cargo check --locked -p parkhub-server \
-          --no-default-features --features headless --all-targets
-        cargo check --locked -p parkhub-client --all-targets
+        fop build --backend local --resource-profile interactive-small . --preset custom -- bash -lc '
+          mkdir -p parkhub-web/dist
+          [ -f parkhub-web/dist/index.html ] || \
+            printf "%s" "<!doctype html><html><body></body></html>" \
+            > parkhub-web/dist/index.html
+          cargo check --locked -p parkhub-common --all-targets
+          cargo check --locked -p parkhub-server \
+            --no-default-features --features headless --all-targets
+          cargo check --locked -p parkhub-client --all-targets
+        '
       fail_text: |
         cargo check failed. Fix compile errors before pushing.
         Tip: this is the gate that catches missing struct fields and
@@ -124,14 +126,16 @@ pre-push:
       # Mirrors `.github/workflows/ci.yml#clippy` headless lints.
       # Same scope as cargo-check above (no parkhub-desktop / tauri).
       run: |
-        mkdir -p parkhub-web/dist
-        [ -f parkhub-web/dist/index.html ] || \
-          printf '%s' '<!doctype html><html><body></body></html>' \
-          > parkhub-web/dist/index.html
-        cargo clippy --locked -p parkhub-common --all-targets -- -D warnings
-        cargo clippy --locked -p parkhub-server \
-          --no-default-features --features headless --all-targets -- \
-          -D warnings -A clippy::cognitive_complexity -A clippy::assigning_clones
+        fop build --backend local --resource-profile interactive-small . --preset custom -- bash -lc '
+          mkdir -p parkhub-web/dist
+          [ -f parkhub-web/dist/index.html ] || \
+            printf "%s" "<!doctype html><html><body></body></html>" \
+            > parkhub-web/dist/index.html
+          cargo clippy --locked -p parkhub-common --all-targets -- -D warnings
+          cargo clippy --locked -p parkhub-server \
+            --no-default-features --features headless --all-targets -- \
+            -D warnings -A clippy::cognitive_complexity -A clippy::assigning_clones
+        '
       fail_text: |
         Clippy violations. Fix or annotate with `#[allow(...)]` + reason.
 
@@ -140,17 +144,19 @@ pre-push:
       # Mirrors `.github/workflows/ci.yml#test` headless scope so pre-
       # push stays under ~2 min on cached builds.
       run: |
-        mkdir -p parkhub-web/dist
-        [ -f parkhub-web/dist/index.html ] || \
-          printf '%s' '<!doctype html><html><body></body></html>' \
-          > parkhub-web/dist/index.html
-        cargo test --locked -p parkhub-common --lib
-        cargo test --locked -p parkhub-server \
-          --no-default-features --features headless --lib
+        fop build --backend local --resource-profile interactive-small . --preset custom -- bash -lc '
+          mkdir -p parkhub-web/dist
+          [ -f parkhub-web/dist/index.html ] || \
+            printf "%s" "<!doctype html><html><body></body></html>" \
+            > parkhub-web/dist/index.html
+          cargo test --locked -p parkhub-common --lib
+          cargo test --locked -p parkhub-server \
+            --no-default-features --features headless --lib
+        '
       fail_text: |
         Library tests failing. Run locally to debug:
-          cargo test -p parkhub-common --lib
-          cargo test -p parkhub-server --no-default-features --features headless --lib
+          fop build --backend local --resource-profile interactive-small . --preset custom -- cargo test -p parkhub-common --lib
+          fop build --backend local --resource-profile interactive-small . --preset custom -- cargo test -p parkhub-server --no-default-features --features headless --lib
 
     vitest:
       # Fast loop: only run vitest specs for files changed since main.

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -22,9 +22,8 @@
 #
 #     git push --no-verify
 #
-# Hook commands intentionally call `cargo` / `npx` directly (not `fop`)
-# because contributors may not have fop installed. fop users can run
-# `fop build` / `fop test` manually before pushing.
+# Rust build/test/lint hooks route through fop so the workstation build queue
+# can enforce memory/backpressure. Frontend-only npx hooks stay direct.
 ---
 min_version: 1.10.0
 
@@ -34,11 +33,11 @@ pre-commit:
   commands:
     fmt-rust:
       glob: "**/*.rs"
-      run: cargo fmt --all -- --check
+      run: fop build --backend local --resource-profile interactive-small . --preset custom -- cargo fmt --all -- --check
       stage_fixed: true
       fail_text: |
         cargo fmt found unformatted Rust files.
-        Fix with: cargo fmt --all
+        Fix with: fop build --backend local --resource-profile interactive-small . --preset custom -- cargo fmt --all
 
     lint-ts:
       # Biome (Rust-native, MIT) handles linting + formatting in one

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -233,13 +233,14 @@ pre-push:
       #
       # Backed by `fop image scan` (fop-operator T-5467 PR #228+#231+#232+#233+
       # #234+#236, MIT). Same hash + stamp + skip-clean semantics as the
-      # 110-line bash reference it replaced; per-repo config at
-      # `.fop/image-scan.toml`. Skips cleanly when the fop binary or
-      # podman/trivy/grype are missing (handled internally by the crate).
+      # bash reference; per-repo config at `.fop/image-scan.toml`.
+      # Workstations still on fop < image-scan support fall back to the
+      # repo-local scanner, which skips cleanly if podman/trivy/grype are
+      # unavailable.
       glob: "{Dockerfile,Cargo.lock,parkhub-web/package-lock.json,.fop/image-scan.toml}"
       skip:
-        - run: 'test ! -x "$(command -v fop 2>/dev/null)"'
-      run: fop image scan
+        - run: 'test ! -x "$(command -v fop 2>/dev/null)" && test ! -x scripts/local-image-scan.sh'
+      run: 'if fop image scan --help >/dev/null 2>&1; then fop image scan; else ./scripts/local-image-scan.sh; fi'
       fail_text: |
         Container image scan surfaced CRITICAL/HIGH vulnerabilities.
         Triage with: trivy image parkhub-local:ci-* (see .fop/image-scan.toml).

--- a/parkhub-web/package-lock.json
+++ b/parkhub-web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "parkhub-web",
-  "version": "5.0.9",
+  "version": "5.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "parkhub-web",
-      "version": "5.0.9",
+      "version": "5.1.0",
       "dependencies": {
         "@astrojs/react": "^5.0.3",
         "@fontsource-variable/inter": "^5.2.8",
@@ -5241,9 +5241,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.1.tgz",
-      "integrity": "sha512-h2r7rcm6Ee/J8o0LD5djLuFVcfbZxhvho4vvsbeV0aMvXjUgqv4YpxpkEx0d68l6+IleVfLAdVEfhR7QNMkGHQ==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
       "funding": [
         {

--- a/scripts/check-openapi-drift.sh
+++ b/scripts/check-openapi-drift.sh
@@ -68,7 +68,7 @@ echo "openapi-drift: building parkhub-server (debug, headless+full)..." >&2
 TARGET_DIR="$(cargo metadata --locked --format-version 1 --no-deps | jq -er '.target_directory')"
 # Debug build is faster than release for local checks; spec output is
 # identical because utoipa derives are compile-time.
-cargo build \
+fop build --backend local --resource-profile interactive-small . --preset custom -- cargo build \
     --locked \
     -p parkhub-server \
     --no-default-features \
@@ -120,7 +120,7 @@ if ! git diff --no-index --exit-code "$COMMITTED_SPEC" "$LIVE_SPEC"; then
 Regenerate locally:
 
     # In one terminal:
-    fop build --backend local . --preset custom -- \\
+    fop build --backend local --resource-profile interactive-small . --preset custom -- \\
         cargo run --no-default-features --features 'full,headless' \\
             -p parkhub-server -- --headless --port 18181
 

--- a/scripts/check-types-drift.sh
+++ b/scripts/check-types-drift.sh
@@ -43,7 +43,7 @@ echo "types-drift: regenerating ts-rs bindings..." >&2
 # This invokes the explicit ts_export integration test (see
 # parkhub-server/tests/ts_export.rs) which calls T::export_all_to(...)
 # for every DTO and stamps a warning header on each emitted .ts file.
-cargo test \
+fop build --backend local --resource-profile interactive-small . --preset custom -- cargo test \
     --locked \
     --features gen-types \
     -p parkhub-server \
@@ -71,7 +71,8 @@ if [[ "$drift" -ne 0 ]]; then
 
 Regenerate locally:
 
-    cargo test --features gen-types -p parkhub-server --test ts_export -- --nocapture
+    fop build --backend local --resource-profile interactive-small . --preset custom -- \\
+        cargo test --features gen-types -p parkhub-server --test ts_export -- --nocapture
 
 Then \`git add parkhub-web/src/generated/\` and commit the updated bindings.
 EOF

--- a/scripts/local-image-scan.sh
+++ b/scripts/local-image-scan.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# Local container image vulnerability scan for ParkHub Rust.
+#
+# This is the compatibility fallback for workstations whose installed fop
+# binary predates `fop image scan`. It keeps the local pre-push gate security
+# preserving instead of silently skipping image validation.
+#
+# Mechanism:
+#   1. Hash Dockerfile, Cargo.lock, and parkhub-web/package-lock.json.
+#   2. Reuse .fop/image-scan-validated-<hash>.stamp when present.
+#   3. Otherwise: podman build -> trivy image -> grype image.
+#   4. On success, write the stamp.
+
+set -euo pipefail
+
+force=0
+podman_args=()
+for arg in "$@"; do
+  case "$arg" in
+    --force) force=1 ;;
+    --no-cache) podman_args+=(--no-cache) ;;
+    -h|--help)
+      sed -n '2,/^$/p' "$0" | sed 's/^# \?//'
+      exit 0
+      ;;
+    *) echo "Unknown arg: $arg" >&2; exit 2 ;;
+  esac
+done
+
+hash_input() {
+  for file in Dockerfile Cargo.lock parkhub-web/package-lock.json; do
+    if [[ -f "$file" ]]; then
+      sha256sum "$file"
+    else
+      printf '%s  %s (missing)\n' \
+        "0000000000000000000000000000000000000000000000000000000000000000" \
+        "$file"
+    fi
+  done | sha256sum | awk '{print $1}'
+}
+
+input_hash="$(hash_input)"
+short_hash="${input_hash:0:10}"
+stamp_dir="${FOP_IMAGE_SCAN_DIR:-.fop}"
+stamp_file="${stamp_dir}/image-scan-validated-${short_hash}.stamp"
+image_tag="${FOP_IMAGE_SCAN_TAG:-parkhub-local:ci-${short_hash}}"
+
+if [[ -f "$stamp_file" ]] && (( ! force )); then
+  echo "image scan skipped: stamp present (${stamp_file})"
+  echo "image-input hash: ${input_hash}"
+  exit 0
+fi
+
+need_podman=0
+need_trivy=0
+need_grype=0
+command -v podman >/dev/null 2>&1 || need_podman=1
+command -v trivy >/dev/null 2>&1 || need_trivy=1
+command -v grype >/dev/null 2>&1 || need_grype=1
+
+if (( need_podman + need_trivy + need_grype > 0 )); then
+  echo "image scan skipped: missing tools"
+  (( need_podman )) && echo "  podman not on PATH"
+  (( need_trivy )) && echo "  trivy not on PATH"
+  (( need_grype )) && echo "  grype not on PATH"
+  exit 0
+fi
+
+mkdir -p "$stamp_dir"
+
+echo "podman build ${image_tag} (input hash ${short_hash})"
+podman build "${podman_args[@]}" --network=host -t "$image_tag" . >&2
+
+echo "trivy image ${image_tag} (CRITICAL,HIGH; .trivyignore filters applied)"
+trivy_args=(
+  image
+  --quiet
+  "--scanners=vuln,secret"
+  "--severity=CRITICAL,HIGH"
+  "--exit-code=1"
+)
+[[ -f .trivyignore ]] && trivy_args+=(--ignorefile .trivyignore)
+trivy "${trivy_args[@]}" "$image_tag"
+
+echo "grype ${image_tag} (fail-on critical)"
+grype "$image_tag" --fail-on critical --quiet
+
+{
+  echo "image-input hash: ${input_hash}"
+  echo "image tag:        ${image_tag}"
+  echo "validated at:     $(date -u +%FT%TZ)"
+  echo "trivy version:    $(trivy --version 2>&1 | head -1)"
+  echo "grype version:    $(grype version 2>&1 | grep -i '^version' | head -1)"
+} > "$stamp_file"
+
+echo "image scan passed; stamp written to ${stamp_file}"


### PR DESCRIPTION
## Summary

Routes all ParkHub Rust local gates through the **fop** workstation build queue (SOTA-2026 fop-first compliance), so cargo/clippy/drift checks run with memory caps + sccache + queue serialization instead of bare invocations.

- `lefthook.yml` — pre-commit + pre-push gates wrap cargo through `fop build --backend local --resource-profile interactive-small`
- `.pre-commit-config.yaml` — pre-commit Rust hooks routed through fop
- `Makefile` — make gates route through fop
- `scripts/check-openapi-drift.sh`, `scripts/check-types-drift.sh` — drift scripts through fop
- `scripts/local-image-scan.sh` (new, 96 LoC) — restored local image-scan fallback so trivy gates work without GHA
- `AGENTS.md` — docs updated to match

## Why

Bare cargo/clippy invocations bypass the workstation memory cap (12 GB) and queue, causing OOM kills and dropped sccache locality. fop's `--backend local --resource-profile interactive-small` gives Rust the same envelope the rest of the homelab uses.

## Risk

Low — CI/build infrastructure only, no production code, no Cargo.toml. If a gate misbehaves, fall back to bare cargo locally for one push (`LEFTHOOK=0 git push`); the GHA-side gates remain the canonical truth.

## Commits

\`\`\`
851f5bcd ci: restore local image scan fallback
e90af700 ci: route ParkHub Rust drift scripts through fop
6f11b70e ci: route ParkHub Rust make gates through fop
d3d89f02 ci: route ParkHub Rust pre-commit hooks through fop
db12c205 ci: route ParkHub Rust pre-push through fop
28fac666 docs: route ParkHub Rust gates through fop
\`\`\`

## Test plan

- [x] Local lefthook pre-push gates pass (cargo-check + cargo-clippy via fop, completed in this push)
- [ ] GHA "Required checks" green
- [ ] fop local CI attestation green
- [ ] Spot-check `lefthook run pre-commit` on a follow-up commit