### PR TITLE
fix(ci): install Playwright browsers in parkhub-web before e2e

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -101,6 +101,15 @@ jobs:
           E2E_BASE_URL: http://localhost:8081
           CI: true
 
+      - name: Install Playwright browsers (parkhub-web)
+        # parkhub-web pins a different @playwright/test minor version than the
+        # repo root, so it bundles a different Chromium build. The root-level
+        # `npx playwright install` only fetches the root version's binary, and
+        # without this step the parkhub-web run fails 275 tests in 3ms each
+        # with "Executable doesn't exist at .../chromium_headless_shell-NNNN".
+        working-directory: parkhub-web
+        run: npx playwright install --with-deps chromium
+
       - name: Run E2E tests (parkhub-web v5 + admin)
         working-directory: parkhub-web
         run: npx playwright test --project=chromium


### PR DESCRIPTION
## Summary

Fixes the **E2E Tests** workflow that has been failing on `main` since 2026-05-06 (8 consecutive failures: `26dbf592`, `8f00f8c7`, `f971b9ca`, `c3918b44`, `e5a3fd79`, `b3ac1154`, `d92d3baf`, …).

## Root cause

The job runs Playwright tests in two stages:

1. \`Run E2E tests (root)\` — uses repo-root \`@playwright/test\` (currently \`^1.58.2\`) — **passing** 381/381 tests
2. \`Run E2E tests (parkhub-web v5 + admin)\` — \`working-directory: parkhub-web\`, uses parkhub-web's own \`@playwright/test\` (currently \`^1.59.1\`) — **failing 275/275 tests in 3ms each**

The single \`npx playwright install --with-deps chromium\` step before stage 1 only fetches the **root version's** Chromium binary. The parkhub-web stage 2 then can't find its bundled Chromium and dies before any test logic runs:

\`\`\`
Error: browserType.launch: Executable doesn't exist at
.../ms-playwright/chromium_headless_shell-1217/chrome-headless-shell-linux64/chrome-headless-shell

Looks like Playwright was just installed or updated.
Please run: npx playwright install
\`\`\`

(\`1217\` is parkhub-web's binary number; root has a different one.)

## Fix

Add a \`Install Playwright browsers (parkhub-web)\` step with \`working-directory: parkhub-web\` between the root tests and the parkhub-web tests, so each \`@playwright/test\` version installs its bundled Chromium.

## Risk

Minimal — workflow-only change, 9 lines added, no source code touched. Stage 1 still passes (no regression to the working path). Stage 2 will either succeed (likely) or surface a different real bug under the binary issue.

## Test plan

- [ ] E2E Tests workflow runs green on this PR
- [ ] After merge, E2E Tests on main is green for the first time since 2026-05-06