### PR TITLE
fix(devcontainer): drop npm self-upgrade that fails on NodeSource v22

### DIFF
--- a/.devcontainer/Containerfile
+++ b/.devcontainer/Containerfile
@@ -30,10 +30,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # Node.js 22 from NodeSource (matches GHA setup-node@v4 default).
+# We don't `npm install -g npm@latest` here — NodeSource v22 ships with a
+# recent npm and the self-upgrade fails with `MODULE_NOT_FOUND` on the
+# bundled `npm-cli.js` (https://github.com/nodesource/distributions/issues/1733).
 RUN curl -fsSL "https://deb.nodesource.com/setup_${NODE_MAJOR}.x" | bash - \
     && apt-get install -y --no-install-recommends nodejs \
-    && rm -rf /var/lib/apt/lists/* \
-    && npm install -g npm@latest
+    && rm -rf /var/lib/apt/lists/*
 
 # Helm pinned (apt's helm is too old for Chart v2 features we use).
 RUN curl -fsSLO "https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz" \


### PR DESCRIPTION
## Summary

Fixes the **Publish dev container image** workflow that has been failing on \`main\` since 2026-05-06.

## Root cause

\`.devcontainer/Containerfile\` runs:
\`\`\`dockerfile
RUN curl -fsSL "https://deb.nodesource.com/setup_22.x" | bash - \\
    && apt-get install -y --no-install-recommends nodejs \\
    && rm -rf /var/lib/apt/lists/* \\
    && npm install -g npm@latest
\`\`\`

The last line fails on the bundled-npm path layout that NodeSource ships:

\`\`\`
npm error code MODULE_NOT_FOUND
Cannot find module '/usr/lib/node_modules/npm/bin/npm-cli.js'
\`\`\`

This is a known NodeSource v22 issue ([nodesource/distributions#1733](https://github.com/nodesource/distributions/issues/1733)). The bundled npm (10.x) is recent enough; the self-upgrade is unneeded.

## Fix

Drop the \`&& npm install -g npm@latest\` line. Devcontainer build proceeds with NodeSource's bundled npm.

## Risk

Minimal — only the dev container image. Production runtime images use a different Dockerfile + don't run global npm upgrades.

## Test plan

- [ ] \`Publish dev container image\` workflow succeeds on this PR
- [ ] After merge, no devcontainer image regressions surface (image still has working npm)