### PR TITLE
fix(e2e): use API login for Admin UI Pages nav smoke tests

### DIFF
--- a/e2e/admin-crud-complete.spec.ts
+++ b/e2e/admin-crud-complete.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { gotoAppPage, loginBrowserViaApi, loginViaApi, waitForAppDomReady, DEMO_ADMIN } from './helpers';
+import { gotoAppPage, loginBrowserViaApi, loginViaApi, waitForAppDomReady } from './helpers';
 
 const BASE = process.env.E2E_BASE_URL || 'http://localhost:8082';
 

--- a/e2e/admin-crud-complete.spec.ts
+++ b/e2e/admin-crud-complete.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { gotoAppPage, loginViaApi, loginViaUi, waitForAppDomReady, DEMO_ADMIN } from './helpers';
+import { gotoAppPage, loginBrowserViaApi, loginViaApi, waitForAppDomReady, DEMO_ADMIN } from './helpers';
 
 const BASE = process.env.E2E_BASE_URL || 'http://localhost:8082';
 
@@ -285,35 +285,35 @@ test.describe('Admin CRUD — Complete Lifecycle', () => {
 
   test.describe('Admin UI Pages', () => {
     test('admin dashboard loads', async ({ page }) => {
-      await loginViaUi(page);
+      await loginBrowserViaApi(page);
       await gotoAppPage(page, '/admin');
       await waitForAppDomReady(page);
       await expect(page.locator('body')).not.toBeEmpty();
     });
 
     test('admin users page loads', async ({ page }) => {
-      await loginViaUi(page);
+      await loginBrowserViaApi(page);
       await gotoAppPage(page, '/admin/users');
       await waitForAppDomReady(page);
       await expect(page.locator('body')).toContainText(/user|admin|manage/i);
     });
 
     test('admin lots page loads', async ({ page }) => {
-      await loginViaUi(page);
+      await loginBrowserViaApi(page);
       await gotoAppPage(page, '/admin/lots');
       await waitForAppDomReady(page);
       await expect(page.locator('body')).toContainText(/lot|parking|manage/i);
     });
 
     test('admin settings page loads', async ({ page }) => {
-      await loginViaUi(page);
+      await loginBrowserViaApi(page);
       await gotoAppPage(page, '/admin/settings');
       await waitForAppDomReady(page);
       await expect(page.locator('body')).toContainText(/setting|config|general/i);
     });
 
     test('admin reports page loads', async ({ page }) => {
-      await loginViaUi(page);
+      await loginBrowserViaApi(page);
       await gotoAppPage(page, '/admin/reports');
       await waitForAppDomReady(page);
       await expect(page.locator('body')).not.toBeEmpty();


### PR DESCRIPTION
## Summary

Fixes the rust **Nightly Assurance** E2E failure pattern that has been firing for several nights, where 5 \"admin \<page\> loads\" tests in \`e2e/admin-crud-complete.spec.ts\` (Admin UI Pages describe block) timeout on **mobile-safari** at \`page.goto admin/lots Timeout 8000ms\`.

## Root cause (per sub-agent investigation)

WebKit-specific race in the existing test setup:

1. \`loginViaUi(page)\` triggers a full UI form-submit + redirect
2. The next \`gotoAppPage(page, '/admin/<page>')\` immediately races against:
   - WebKit \`document.startViewTransition()\` (App.tsx:210-213) holding the navigation commit during fade-out
   - Lazy chunk download for views like \`AdminLots.tsx\` (\`React.lazy\` in App.tsx:75)
   - The view's own \`useEffect\` firing \`api.getLots()\` (AdminLots.tsx:67-76)

Three competing I/O streams under WebKit's JSC + lazy-chunk overhead exceed the 8s \`APP_NAVIGATION_TIMEOUT_MS\` budget on heavier admin pages. Chromium + mobile-chrome are unaffected because Blink's View Transitions + V8 chunk parsing fit inside the budget.

The same pattern already-passing \`pages.spec.ts /admin/lots\` test uses \`loginBrowserViaApi\` and never times out — that's the proven path.

## Fix

These 5 tests are navigation smoke tests (assert the route mounts and renders); they don't validate the UI login form (\`security-flows.spec.ts\` covers that). Swap \`loginViaUi(page)\` → \`loginBrowserViaApi(page)\` for all 5: cookie injection direct, no UI redirect, no View Transition overhead.

## Risk

Low — only test infra. \`loginBrowserViaApi\` is the established pattern used elsewhere in the suite. No production code touched.

## Commits

\`\`\`
587aa886 fix(e2e): use API login for Admin UI Pages nav smoke tests
\`\`\`

## Test plan

- [ ] Nightly Assurance mobile-safari shard goes green for the Admin UI Pages tests
- [ ] chromium + mobile-chrome shards still pass (no regression)
- [ ] UI-login coverage stays in security-flows.spec.ts (verified by reviewer)