### PR TITLE
ci+docs: harden Gitea mirror jobs + mark GitHub canonical for ParkHub Rust

### DIFF
--- a/.gitea/workflows/ci.yml
+++ b/.gitea/workflows/ci.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: https://192.168.178.233/actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Install rustfmt
         run: rustup component add rustfmt
@@ -44,6 +46,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: https://192.168.178.233/actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Prepare embedded web placeholder
         run: |
@@ -67,6 +71,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: https://192.168.178.233/actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Install clippy
         run: rustup component add clippy
@@ -86,10 +92,16 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: rust:1.94.1-bookworm
+      # Resolve gitea.test (the in-cluster Gitea HTTP API at 192.168.178.233)
+      # so action ref rewrites + post-status calls work from inside the runner
+      # container. fop ci-audit flags missing-add-host on container blocks.
+      options: --add-host=gitea.test:192.168.178.233
     needs: [check]
     steps:
       - name: Checkout code
         uses: https://192.168.178.233/actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Prepare embedded web placeholder
         run: |

--- a/.gitea/workflows/ci.yml
+++ b/.gitea/workflows/ci.yml
@@ -18,13 +18,13 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: rust:1.94.1-bookworm
-      # Resolve gitea.test (the in-cluster Gitea HTTP API at 192.168.178.212)
+      # Resolve gitea.test (the in-cluster Gitea HTTP API at 192.168.178.233)
       # so action ref rewrites + post-status calls work from inside the runner
       # container. fop ci-audit flags missing-add-host on container blocks.
-      options: --add-host=gitea.test:192.168.178.212
+      options: --add-host=gitea.test:192.168.178.233
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: https://192.168.178.233/actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install rustfmt
         run: rustup component add rustfmt
@@ -37,13 +37,13 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: rust:1.94.1-bookworm
-      # Resolve gitea.test (the in-cluster Gitea HTTP API at 192.168.178.212)
+      # Resolve gitea.test (the in-cluster Gitea HTTP API at 192.168.178.233)
       # so action ref rewrites + post-status calls work from inside the runner
       # container. fop ci-audit flags missing-add-host on container blocks.
-      options: --add-host=gitea.test:192.168.178.212
+      options: --add-host=gitea.test:192.168.178.233
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: https://192.168.178.233/actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Prepare embedded web placeholder
         run: |
@@ -60,13 +60,13 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: rust:1.94.1-bookworm
-      # Resolve gitea.test (the in-cluster Gitea HTTP API at 192.168.178.212)
+      # Resolve gitea.test (the in-cluster Gitea HTTP API at 192.168.178.233)
       # so action ref rewrites + post-status calls work from inside the runner
       # container. fop ci-audit flags missing-add-host on container blocks.
-      options: --add-host=gitea.test:192.168.178.212
+      options: --add-host=gitea.test:192.168.178.233
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: https://192.168.178.233/actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install clippy
         run: rustup component add clippy
@@ -89,7 +89,7 @@ jobs:
     needs: [check]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: https://192.168.178.233/actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Prepare embedded web placeholder
         run: |

--- a/.github/workflows/devcontainer-publish.yml
+++ b/.github/workflows/devcontainer-publish.yml
@@ -27,8 +27,6 @@ concurrency:
 
 permissions:
   contents: read
-  packages: write
-  id-token: write   # for cosign keyless OIDC sign of the image
 
 env:
   REGISTRY: ghcr.io
@@ -39,6 +37,10 @@ jobs:
     name: Build & push devcontainer image
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      contents: read
+      packages: write
+      id-token: write   # for cosign keyless OIDC sign of the image
 
     steps:
       - name: Checkout

--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -12,7 +12,7 @@ name: PR title lint
 # Bot PRs (Dependabot, Copilot) are exempt — they use proper prefixes.
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, edited, reopened, synchronize]
 
 permissions: {}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,12 +45,15 @@ make act        # optional: run the actual workflow files locally via nektos/act
 ```
 Install pre-commit hooks once per clone: `pre-commit install` (config in `.pre-commit-config.yaml`). See [DEVELOPMENT.md](DEVELOPMENT.md) for the full loop. Mutation testing runs weekly via `.github/workflows/mutants.yml` (`.cargo/mutants.toml` gates survivors). OpenAPI parity with the PHP edition is enforced via [docs/openapi-parity.md](docs/openapi-parity.md) + `scripts/dump-openapi.sh` / `scripts/diff-openapi.sh`.
 
-## Dual-Remote Convention
-Two remotes are always configured on this repo:
-- `origin` — Gitea at `git@192.168.178.220:florian/parkhub-rust.git` (primary, source of truth)
-- `github` — `https://github.com/nash87/parkhub-rust.git` (public mirror)
+## Remote Convention
+GitHub `nash87/parkhub-rust` is the source of truth for this repo. Fresh clones
+should use GitHub as `origin`.
 
-Always `git push origin <branch>` first, then `git push github <branch>`. Never push only to GitHub. CI runs on GitHub; operator review happens on Gitea.
+Some workstation clones still have stale Gitea as `origin` and GitHub as
+`github`. In those clones, fetch/rebase/push via `github`; do not base ParkHub
+work on `origin/main`. Keep any Gitea remote as `gitea-restore` or similar
+unless an operator explicitly asks to restore mirroring. CI and PR review run
+from GitHub.
 
 ## Architecture
 ```

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -10,10 +10,12 @@ everything here exists to reproduce them locally before `git push`.
 ## 1. Quickstart
 
 ```bash
-# Clone (Gitea = origin, GitHub = github)
-git clone git@192.168.178.220:florian/parkhub-rust.git
+# Fresh clone: GitHub is canonical.
+git clone git@github.com:nash87/parkhub-rust.git
 cd parkhub-rust
-git remote add github https://github.com/nash87/parkhub-rust.git
+
+# Optional local restore mirror. Do not pull, rebase, or base PR work from it.
+git remote add gitea-restore git@192.168.178.220:florian/parkhub-rust.git
 
 # Bootstrap (rust-toolchain.toml pins 1.94.1 — rustup installs it automatically)
 cargo build --locked --package parkhub-common
@@ -123,25 +125,30 @@ act -l                       # list every job/workflow
 
 ---
 
-## 5. Dual-remote push convention
+## 5. Remote convention
 
-Gitea is `origin` (private canonical). GitHub (`nash87/parkhub-rust`) is a
-mirror for Actions + visibility.
+GitHub (`nash87/parkhub-rust`) is the source of truth. Fresh clones should use
+GitHub as `origin`.
 
 ```bash
-git push origin main
-git push github main
+git remote -v
+git pull --rebase origin main
+git push origin <branch>
 ```
 
-One-liner helper (add to `~/.gitconfig`):
+Some workstation clones still have stale Gitea as `origin` and GitHub as
+`github`. In those clones, use GitHub explicitly and do not base work on
+`origin/main`:
 
-```ini
-[alias]
-    pa = "!git push origin \"$(git rev-parse --abbrev-ref HEAD)\" && git push github \"$(git rev-parse --abbrev-ref HEAD)\""
+```bash
+git fetch github
+git pull --rebase github main
+git push github <branch>
 ```
 
-Then `git pa` pushes both. **Always `git pull --rebase origin main` before
-either push** — Flux-style automation may have rewritten tags.
+Keep any Gitea remote named `gitea-restore` or similar unless an operator
+explicitly asks to restore mirroring. Do not use it for PR bases, release
+preflight updates, or GitOps build inputs.
 
 ---
 
@@ -183,8 +190,9 @@ primitives ([docs.github.com/en/actions](https://docs.github.com/en/actions)):
   dependency-review, cargo-deny, OpenAPI drift, and the core build/test jobs;
   integration remains advisory until its known flake is retired. Set in GitHub
   Settings → Branches.
-- **Environments** — not wired yet (no external deploy targets on GitHub — we
-  deploy from Gitea via Flux). When we do wire them, use GitHub
+- **Environments** — not wired yet (no external deploy targets on GitHub; Flux
+  consumes ParkHub from the GitHub source-of-truth path). When we do wire them,
+  use GitHub
   [Environments](https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-deployments/managing-environments-for-deployment)
   with required reviewers + wait-timers.
 - **Dependency graph** — native (Cargo ecosystem supported since 2024), used

--- a/scripts/generate-vex.sh
+++ b/scripts/generate-vex.sh
@@ -16,7 +16,9 @@ set -euo pipefail
 TOOL="${1:-cargo-audit}"
 INPUT="${2:-/dev/stdin}"
 DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-REPO_URL="${GITHUB_SERVER_URL:-https://gitea.test}/${GITHUB_REPOSITORY:-parkhub-rust}"
+REPO_HOST="${GITHUB_SERVER_URL:-https://github.com}"
+REPO_PATH="${GITHUB_REPOSITORY:-nash87/parkhub-rust}"
+REPO_URL="${REPO_HOST}/${REPO_PATH}"
 COMMIT="${GITHUB_SHA:-unknown}"
 
 # ── Known accepted vulnerabilities (edit as baseline changes) ──

--- a/scripts/local-workflow-drift.sh
+++ b/scripts/local-workflow-drift.sh
@@ -41,6 +41,8 @@ EXEMPT_GITEA_MISSING=(
   auto-merge.yml                  # github-only auto-merge of dependabot PRs
   deploy.yml                      # github-only Render/Fly/Koyeb dispatch
   tauri-mobile.yml                # macOS+Windows runners for Tauri builds
+  pr-title-lint.yml               # github-only pull_request_target PR metadata lint
+  stale.yml                       # github-only actions/stale PR lifecycle automation
 )
 
 # Files that are documented as gitea-only (no github mirror needed).


### PR DESCRIPTION
## Summary

Restored from local-only branch — 6 commits hardening Gitea mirror CI + canonicalizing ParkHub Rust as GitHub-primary in docs/scripts. None of these subjects appear on \`main\`; verified via \`git log --grep\`.

## Commits

\`\`\`
8a2ddf78 ci: harden Rust Gitea mirror jobs
9c941efe ci: resolve Rust workflow security alerts
9e6a7245 ci: refresh Rust Gitea mirror checkout host
f4d696fa ci: document GitHub-only workflow drift exemptions
a43acbb3 ci: default Rust VEX metadata to GitHub
62835aeb docs: mark GitHub canonical for ParkHub Rust
\`\`\`

## Files

\`\`\`
.gitea/workflows/ci.yml                    | 32 +++++++++++++++--------
.github/workflows/devcontainer-publish.yml |  6 +++--
.github/workflows/pr-title-lint.yml        |  2 +-
AGENTS.md                                  | 15 +++++-----
DEVELOPMENT.md                             | 40 ++++++++++++++++----------
scripts/generate-vex.sh                    |  4 ++-
scripts/local-workflow-drift.sh            |  2 ++
\`\`\`

## Why now

This branch was preserved during a worktree cleanup audit; per-commit verification against \`main\` confirmed all 6 subjects are missing. Real work that should ship.

## Risk

Low — CI/docs/scripts only, no production code. The biggest changes are .gitea/workflows/ci.yml hardening (+22/-10 net) and DEVELOPMENT.md updates.

## Test plan

- [ ] CI green on this PR
- [ ] After merge, .gitea Gitea mirror runs work as documented