### PR TITLE
fix(ci): fall back to bare command when fop is missing (P1 from #611 review)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,10 +15,14 @@ Self-hosted parking management platform for enterprises, universities, and resid
 ## Build
 ```sh
 # Default build (pure MIT, headless, no GUI — for Docker/server deployments)
-fop build --backend local . --preset custom -- cargo build --release --package parkhub-server
+# `./scripts/fop-wrap.sh` runs through fop's queue with the
+# `interactive-small` resource profile when fop is on PATH; otherwise it
+# runs the command directly so contributors without fop installed can
+# still build.
+./scripts/fop-wrap.sh cargo build --release --package parkhub-server
 
 # Optional desktop GUI build (pulls Slint, GPL-3.0)
-fop build --backend local . --preset custom -- cargo build --release --package parkhub-server --features gui
+./scripts/fop-wrap.sh cargo build --release --package parkhub-server --features gui
 
 # React frontend (must be built before server if modifying frontend)
 cd parkhub-web && npm install && npm run build
@@ -34,7 +38,7 @@ fop test . -- -p parkhub-common    # Common crate tests
 ## Lint
 ```sh
 fop clippy .
-fop build --backend local . --preset custom -- cargo fmt --all -- --check
+./scripts/fop-wrap.sh cargo fmt --all -- --check
 ```
 
 ## Pre-Push Gate (mandatory)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,14 +30,14 @@ cd parkhub-web && npm install && npm run build
 
 ## Test
 ```sh
-fop test . -- --workspace          # All workspace tests
-fop test . -- -p parkhub-server    # Server tests only
-fop test . -- -p parkhub-common    # Common crate tests
+./scripts/fop-wrap.sh cargo test --workspace          # All workspace tests
+./scripts/fop-wrap.sh cargo test -p parkhub-server    # Server tests only
+./scripts/fop-wrap.sh cargo test -p parkhub-common    # Common crate tests
 ```
 
 ## Lint
 ```sh
-fop clippy .
+./scripts/fop-wrap.sh cargo clippy --workspace -- -D warnings
 ./scripts/fop-wrap.sh cargo fmt --all -- --check
 ```
 

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,14 @@ MAKEFLAGS += --no-print-directory
 
 EMBED_PLACEHOLDER := parkhub-web/dist/index.html
 SERVER_FEATURES   := --no-default-features --features headless
-FOP_BUILD         := fop build --backend local --resource-profile interactive-small . --preset custom --
+
+# FOP_BUILD wraps cargo/npx invocations with the fop build queue (memory cap +
+# sccache locality + queue accounting) when `fop` is on PATH. On machines
+# without fop (fresh clones following dev/SETUP.md, CI runners that don't
+# install the homelab toolchain) it falls back to running bare so `make ci`
+# still produces a correct pass/fail. See `scripts/fop-wrap.sh` for the same
+# pattern used in lefthook.
+FOP_BUILD := $(if $(shell command -v fop 2>/dev/null),fop build --backend local --resource-profile interactive-small . --preset custom --,)
 
 .PHONY: help ci ci-post ci-security fmt clippy check client-check test lint drift frontend nix-contract nix-contract-strict integration embed act pre-push clean
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -22,8 +22,12 @@
 #
 #     git push --no-verify
 #
-# Rust build/test/lint hooks route through fop so the workstation build queue
-# can enforce memory/backpressure. Frontend-only npx hooks stay direct.
+# Rust build/test/lint hooks route through `./scripts/fop-wrap.sh`, which
+# wraps the command with `fop build --backend local` when `fop` is on PATH and
+# falls back to running bare otherwise. This keeps gates working on machines
+# without the homelab toolchain (fresh clones, CI runners, contributors who
+# haven't installed fop) while still benefiting from the workstation build
+# queue when it's available. Frontend-only npx hooks stay direct.
 ---
 min_version: 1.10.0
 
@@ -33,11 +37,11 @@ pre-commit:
   commands:
     fmt-rust:
       glob: "**/*.rs"
-      run: fop build --backend local --resource-profile interactive-small . --preset custom -- cargo fmt --all -- --check
+      run: ./scripts/fop-wrap.sh cargo fmt --all -- --check
       stage_fixed: true
       fail_text: |
         cargo fmt found unformatted Rust files.
-        Fix with: fop build --backend local --resource-profile interactive-small . --preset custom -- cargo fmt --all
+        Fix with: ./scripts/fop-wrap.sh cargo fmt --all
 
     lint-ts:
       # Biome (Rust-native, MIT) handles linting + formatting in one
@@ -106,7 +110,7 @@ pre-push:
       # excluded here because it pulls in tauri+webkit2gtk system deps
       # that not every dev box has installed.
       run: |
-        fop build --backend local --resource-profile interactive-small . --preset custom -- bash -lc '
+        ./scripts/fop-wrap.sh bash -lc '
           mkdir -p parkhub-web/dist
           [ -f parkhub-web/dist/index.html ] || \
             printf "%s" "<!doctype html><html><body></body></html>" \
@@ -125,7 +129,7 @@ pre-push:
       # Mirrors `.github/workflows/ci.yml#clippy` headless lints.
       # Same scope as cargo-check above (no parkhub-desktop / tauri).
       run: |
-        fop build --backend local --resource-profile interactive-small . --preset custom -- bash -lc '
+        ./scripts/fop-wrap.sh bash -lc '
           mkdir -p parkhub-web/dist
           [ -f parkhub-web/dist/index.html ] || \
             printf "%s" "<!doctype html><html><body></body></html>" \
@@ -143,7 +147,7 @@ pre-push:
       # Mirrors `.github/workflows/ci.yml#test` headless scope so pre-
       # push stays under ~2 min on cached builds.
       run: |
-        fop build --backend local --resource-profile interactive-small . --preset custom -- bash -lc '
+        ./scripts/fop-wrap.sh bash -lc '
           mkdir -p parkhub-web/dist
           [ -f parkhub-web/dist/index.html ] || \
             printf "%s" "<!doctype html><html><body></body></html>" \
@@ -154,8 +158,8 @@ pre-push:
         '
       fail_text: |
         Library tests failing. Run locally to debug:
-          fop build --backend local --resource-profile interactive-small . --preset custom -- cargo test -p parkhub-common --lib
-          fop build --backend local --resource-profile interactive-small . --preset custom -- cargo test -p parkhub-server --no-default-features --features headless --lib
+          ./scripts/fop-wrap.sh cargo test -p parkhub-common --lib
+          ./scripts/fop-wrap.sh cargo test -p parkhub-server --no-default-features --features headless --lib
 
     vitest:
       # Fast loop: only run vitest specs for files changed since main.

--- a/scripts/check-openapi-drift.sh
+++ b/scripts/check-openapi-drift.sh
@@ -68,7 +68,7 @@ echo "openapi-drift: building parkhub-server (debug, headless+full)..." >&2
 TARGET_DIR="$(cargo metadata --locked --format-version 1 --no-deps | jq -er '.target_directory')"
 # Debug build is faster than release for local checks; spec output is
 # identical because utoipa derives are compile-time.
-fop build --backend local --resource-profile interactive-small . --preset custom -- cargo build \
+./scripts/fop-wrap.sh cargo build \
     --locked \
     -p parkhub-server \
     --no-default-features \
@@ -120,7 +120,7 @@ if ! git diff --no-index --exit-code "$COMMITTED_SPEC" "$LIVE_SPEC"; then
 Regenerate locally:
 
     # In one terminal:
-    fop build --backend local --resource-profile interactive-small . --preset custom -- \\
+    ./scripts/fop-wrap.sh \\
         cargo run --no-default-features --features 'full,headless' \\
             -p parkhub-server -- --headless --port 18181
 

--- a/scripts/check-types-drift.sh
+++ b/scripts/check-types-drift.sh
@@ -43,7 +43,7 @@ echo "types-drift: regenerating ts-rs bindings..." >&2
 # This invokes the explicit ts_export integration test (see
 # parkhub-server/tests/ts_export.rs) which calls T::export_all_to(...)
 # for every DTO and stamps a warning header on each emitted .ts file.
-fop build --backend local --resource-profile interactive-small . --preset custom -- cargo test \
+./scripts/fop-wrap.sh cargo test \
     --locked \
     --features gen-types \
     -p parkhub-server \
@@ -71,7 +71,7 @@ if [[ "$drift" -ne 0 ]]; then
 
 Regenerate locally:
 
-    fop build --backend local --resource-profile interactive-small . --preset custom -- \\
+    ./scripts/fop-wrap.sh \\
         cargo test --features gen-types -p parkhub-server --test ts_export -- --nocapture
 
 Then \`git add parkhub-web/src/generated/\` and commit the updated bindings.

--- a/scripts/fop-wrap.sh
+++ b/scripts/fop-wrap.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# fop-wrap.sh — wrap a command with `fop build --backend local ...` if `fop` is
+# on PATH; otherwise run the command directly.
+#
+# Used by `lefthook.yml` and `Makefile` so local CI gates work on machines
+# without `fop` installed (fresh clones, contributors who haven't installed
+# the homelab toolchain). When `fop` is present, the wrapper enforces the
+# memory cap + sccache locality + queue accounting we get in the Bazzite host
+# environment. When it isn't, the bare command runs — we lose the cap but
+# the gate still produces the correct pass/fail signal.
+#
+# Usage:
+#   ./scripts/fop-wrap.sh <cmd> [args...]
+#
+# Examples:
+#   ./scripts/fop-wrap.sh cargo fmt --all -- --check
+#   ./scripts/fop-wrap.sh bash -lc 'cargo check && cargo clippy'
+#
+# Override the resource profile via FOP_RESOURCE_PROFILE (default
+# `interactive-small`) when a heavier preset is needed for one-off runs.
+
+set -euo pipefail
+
+if [ "$#" -eq 0 ]; then
+  echo "usage: $0 <cmd> [args...]" >&2
+  exit 2
+fi
+
+profile="${FOP_RESOURCE_PROFILE:-interactive-small}"
+
+if command -v fop >/dev/null 2>&1; then
+  exec fop build --backend local --resource-profile "$profile" . --preset custom -- "$@"
+else
+  exec "$@"
+fi


### PR DESCRIPTION
## Summary

Addresses two P1 review comments from \`chatgpt-codex-connector[bot]\` on PR #611 (which I bulk-resolved at merge time but didn't fix at the time):

### 1. lefthook.yml — fop-missing fallback (P1)

> These Rust hook commands now invoke \`fop\` unconditionally, so a standard fresh setup that follows \`dev/SETUP.md\` / \`.mise.toml\` (which installs \`lefthook\` and Rust tooling but not \`fop\`) will fail every commit/push with \`fop: command not found\`.

### 2. Makefile — guard against missing fop (P1)

> Defining all CI-like Make targets through \`FOP_BUILD\` makes \`make ci\`, \`make lint\`, \`make check\`, etc. hard-fail on machines without \`fop\`, but repo bootstrap docs/tool pins do not provision \`fop\` by default.

## Fix

Introduce \`scripts/fop-wrap.sh\` — a small shell wrapper that:
- runs \`fop build --backend local --resource-profile interactive-small . --preset custom -- <cmd>\` when fop is on PATH
- falls back to running \`<cmd>\` directly when fop is missing

Wire it into:
- **\`lefthook.yml\`**: 7 invocations swapped + header doc updated
- **\`Makefile\`**: \`FOP_BUILD\` made conditional via \`$(if $(shell command -v fop ...))\`
- **\`AGENTS.md\`**: build + lint examples point at the wrapper

## Side-effects also addressed

- Closes the AGENTS.md doc gap noted by Copilot bot ("examples omit \`--resource-profile interactive-small\`") — the wrapper enforces the profile centrally, so doc examples stay simple.

## Risk

Low — wrapper is 16 lines, set -euo pipefail, exec semantics. On machines with fop, behavior is identical to before. On machines without fop, gates run bare instead of failing-with-not-found.

## Test plan

- [ ] On host with fop: \`make ci\` runs through fop queue (verify via \`fop tasks list\`)
- [ ] On host without fop: \`make ci\` runs bare, still produces correct pass/fail
- [ ] \`lefthook run pre-commit\` works on a fresh clone with only mise+lefthook
- [ ] CI gates green on this PR