### PR TITLE
fix(devcontainer): bump TRIVY_VERSION 0.59.0 → 0.70.0 (release retracted)

### DIFF
--- a/.devcontainer/Containerfile
+++ b/.devcontainer/Containerfile
@@ -13,7 +13,10 @@ FROM rust:1.95-bookworm
 ARG DEBIAN_FRONTEND=noninteractive
 ARG NODE_MAJOR=22
 ARG HELM_VERSION=v3.18.4
-ARG TRIVY_VERSION=0.59.0
+# aquasecurity/trivy retracts old releases — pinned versions stop resolving
+# on GitHub releases after a few months. Bump regularly. Latest tag at
+# https://github.com/aquasecurity/trivy/releases/latest.
+ARG TRIVY_VERSION=0.70.0
 ARG GRYPE_VERSION=0.91.0
 ARG GITLEAKS_VERSION=8.30.1
 ARG ACTIONLINT_VERSION=1.7.12


### PR DESCRIPTION
## Summary

Fixes the **Publish dev container image** workflow failing on main since 2026-05-09T21:46 (run 25612610658):

\`\`\`
curl: (22) The requested URL returned error: 404
> [ 5/14] RUN curl -fsSLO \"https://github.com/aquasecurity/trivy/
  releases/download/v0.59.0/trivy_0.59.0_Linux-64bit.tar.gz\"
\`\`\`

aquasecurity/trivy retracts old releases from GitHub after a few months. v0.59.0's tarball is no longer accessible. Latest is v0.70.0 (verified via API).

## Fix

Bump \`ARG TRIVY_VERSION=0.59.0\` → \`0.70.0\`. Asset naming convention unchanged (\`trivy_\${VERSION}_Linux-64bit.tar.gz\` — 302 redirect to S3 confirmed).

Added an inline comment documenting the retract pattern so the next bump doesn't take 30 min to diagnose.

## Risk

Minimal — devcontainer image only. Trivy CLI is API-stable across 0.59→0.70 (same flags + report formats).

## Test plan

- [ ] CI green on this PR (devcontainer build job)
- [ ] After merge, scheduled \`Publish dev container image\` workflow succeeds