### PR TITLE
test(e2e): avoid UI login race in parking smoke

### DIFF
--- a/e2e/parking.spec.ts
+++ b/e2e/parking.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { gotoAppPage, loginViaUi, loginViaApi, waitForAppDomReady } from './helpers';
+import { gotoAppPage, loginBrowserViaApi, loginViaUi, loginViaApi, waitForAppDomReady } from './helpers';
 
 test.describe('Parking — Booking Flow', () => {
   test('login with demo credentials', async ({ page }) => {
@@ -9,7 +9,7 @@ test.describe('Parking — Booking Flow', () => {
   });
 
   test('navigate to booking flow', async ({ page }) => {
-    await loginViaUi(page);
+    await loginBrowserViaApi(page);
     await gotoAppPage(page, '/book');
     await waitForAppDomReady(page);
     // Booking page should show lots or booking form
@@ -17,7 +17,7 @@ test.describe('Parking — Booking Flow', () => {
   });
 
   test('view bookings list', async ({ page }) => {
-    await loginViaUi(page);
+    await loginBrowserViaApi(page);
     await gotoAppPage(page, '/bookings');
     await waitForAppDomReady(page);
     // Should show booking list (possibly empty)
@@ -25,7 +25,7 @@ test.describe('Parking — Booking Flow', () => {
   });
 
   test('view dashboard KPIs', async ({ page }) => {
-    await loginViaUi(page);
+    await loginBrowserViaApi(page);
     await gotoAppPage(page, '/');
     await waitForAppDomReady(page);
     // Dashboard should show statistics or KPI cards


### PR DESCRIPTION
## Summary
- keep the dedicated UI login smoke test unchanged
- use the existing API-backed browser login helper for protected-route parking navigation checks
- avoids reusing the WebKit-sensitive UI login path before navigating to /book, /bookings, and dashboard

## Verification
- fop guard preflight --json: green before final push retry
- git diff --check
- fop build --backend local . --resource-profile interactive-small --preset custom -- playwright test e2e/parking.spec.ts --project=mobile-safari --list
- direct diagnostic list: 11 mobile-safari tests enumerated in e2e/parking.spec.ts
- lefthook run pre-push: pass; cargo-check, cargo-clippy, cargo-test-fast, openapi-drift, OSV, Trivy, types-drift, and Zizmor passed

Unblocks part of T-6048. Latest failed scheduled Nightly Assurance was run 25653672388 on 2ec3562bbe906faed7ea35fc9c0806abc63a5e65; failing job was mobile-safari shard 3 in e2e/parking.spec.ts.