### PR TITLE
feat: add OpenAPI alias tranche

### DIFF
--- a/docs/openapi-parity.md
+++ b/docs/openapi-parity.md
@@ -26,39 +26,43 @@ See also:
 
 ## Current parity (2026-05-12)
 
-Latest committed-dump comparison from `github/main`:
+Latest alias-tranche comparison from regenerated local OpenAPI dumps:
 
-- Rust input: `parkhub-rust@779eba97f8e6e8ff7e7b65cd1574bb04e4ae00e0`
+- Rust input: `parkhub-rust` branch `t-parkhub-openapi-alias-tranche`
+  based on `github/main@24b763193130f1761d018893ed46334390cfd6ae`
   (`docs/openapi/rust.json`)
-- PHP input: `parkhub-php@e0883df46d1b7c587b7798bddddbb3ae19f06cd8`
+- PHP input: `parkhub-php` branch `t-parkhub-openapi-alias-tranche`
+  based on `github/main@83a132283550d80e4a0553495bd05daf25093f8b`
   (`docs/openapi/php.json`)
 
 | Source | Path count (normalised) |
 |--------|-------------------------|
-| Rust (`utoipa`) | 233 |
-| PHP (Scramble) | 314 |
-| Shared | 201 |
-| Rust-only drift | 32 |
-| PHP-only drift | 113 |
-| Total drift | 145 |
+| Rust (`utoipa`) | 239 |
+| PHP (Scramble) | 318 |
+| Shared | 210 |
+| Rust-only drift | 29 |
+| PHP-only drift | 108 |
+| Total drift | 137 |
 
-The numbers above come from committed OpenAPI dumps, not grep/static route
-extractors. They still need a later live-server regeneration pass, but they are
-the current reviewable contract evidence on `github/main`.
+The numbers above come from regenerated OpenAPI dumps, not grep/static route
+extractors. This alias tranche reduced total drift from `145` to `137` by adding
+thin compatibility aliases for `login`, `register`, `refresh`,
+`auth/change-password`, `health/detailed`, `status`, and the public docs
+surfaces.
 
 Current drift clusters:
 
 | Cluster | Rust-only | PHP-only |
 |---|---:|---:|
-| Admin/reporting/settings | 12 | 35 |
-| Auth/profile aliases | 1 | 7 |
-| Booking/QR | 3 | 16 |
-| Demo/discovery/public | 0 | 6 |
-| Health/docs/status | 8 | 1 |
-| Import/export | 1 | 3 |
-| Payments/billing | 1 | 2 |
-| User/tenant/vehicle | 1 | 4 |
-| Other | 5 | 39 |
+| Admin/reporting/settings | 14 | 39 |
+| Auth/profile/setup aliases | 1 | 7 |
+| Booking/QR/calendar | 1 | 15 |
+| Health/docs/status | 5 | 3 |
+| Import/export | 1 | 4 |
+| Payments/billing/pricing | 4 | 1 |
+| Demo/discovery/public | 1 | 15 |
+| User/tenant/vehicle/notification | 2 | 12 |
+| Other | 0 | 12 |
 
 ## Methodology
 
@@ -107,8 +111,8 @@ review.
 With the current committed snapshots and the input-specific normalisation in
 `scripts/diff-openapi.sh`, the parity diff is still materially open:
 
-- Rust-only paths: `32`
-- PHP-only paths: `113`
+- Rust-only paths: `29`
+- PHP-only paths: `108`
 
 That means parity is **not** currently "just static-extractor noise". The
 remaining drift falls into four broad buckets:
@@ -125,9 +129,9 @@ extractor just didn't see them correctly.
 ### 2. Genuine Rust-only contract surfaces
 
 Rust still exposes paths the PHP contract does not currently publish, including
-top-level operational surfaces (`/status`, `/health/detailed`, docs endpoints),
-admin export/settings endpoints, booking QR under `/api/v1/bookings/{id}/qr`,
-and the Rust-style payments/config surface.
+top-level operational surfaces (`/status`, `/health*`, `/handshake`), admin
+export/settings endpoints, booking QR under `/api/v1/bookings/{id}/qr`, and the
+Rust-style payments/config surface.
 
 **Action**: close these in small batches instead of one mega-port:
 auth/profile/public aliases, health/docs surfaces, booking/payment aliases,
@@ -135,10 +139,9 @@ then admin/export/settings tails.
 
 ### 3. Genuine PHP-only contract surfaces
 
-PHP still publishes a substantially larger surface, including legacy public auth
-aliases (`/api/v1/login`, `/register`, `/refresh`), health/info aliases,
-demo/discovery endpoints, broader admin analytics/settings/reporting routes,
-and several booking/user convenience routes.
+PHP still publishes a substantially larger surface, including profile/setup
+aliases, demo/discovery endpoints, broader admin analytics/settings/reporting
+routes, and several booking/user convenience routes.
 
 **Action**: for each cluster decide whether it is
 (a) a missing Rust alias/annotation,
@@ -155,5 +158,7 @@ never appear in a real drift report.
 
 - **Truthful repo messaging**: README/AGENTS must say parity is tracked, not yet hard-enforced end-to-end.
 - **Real cross-repo CI gate**: current workflows check only self-snapshot drift; add a second-repo checkout and run `diff-openapi.sh` for real Rust-vs-PHP gating once the diff is smaller.
-- **Alias tranche**: eliminate the cheap path mismatches first (`login/register/refresh`, health/detail, QR/payment/config, import aliases).
+- **Alias tranche**: continue with the remaining cheap mismatches
+  (booking QR/payment/config, import aliases, profile/setup aliases) and classify
+  Rust top-level operational endpoints explicitly.
 - **Feature tranche**: close the remaining admin/reporting/demo/user feature gaps or explicitly classify intentional divergences.

--- a/docs/openapi-parity.md
+++ b/docs/openapi-parity.md
@@ -28,11 +28,13 @@ See also:
 
 Latest alias-tranche comparison from regenerated local OpenAPI dumps:
 
-- Rust input: `parkhub-rust` branch `t-parkhub-openapi-alias-tranche`
-  based on `github/main@24b763193130f1761d018893ed46334390cfd6ae`
+- Rust input: `parkhub-rust@65752756ea9c775abca0a317c0ff42ac4535891e`
+  on branch `t-parkhub-openapi-alias-tranche`, based on
+  `github/main@24b763193130f1761d018893ed46334390cfd6ae`
   (`docs/openapi/rust.json`)
-- PHP input: `parkhub-php` branch `t-parkhub-openapi-alias-tranche`
-  based on `github/main@83a132283550d80e4a0553495bd05daf25093f8b`
+- PHP input: `parkhub-php@63a7a5228039657938733538aa53a24b7cf0b352`
+  on branch `t-parkhub-openapi-alias-tranche`, based on
+  `github/main@83a132283550d80e4a0553495bd05daf25093f8b`
   (`docs/openapi/php.json`)
 
 | Source | Path count (normalised) |

--- a/docs/openapi/rust.json
+++ b/docs/openapi/rust.json
@@ -7392,6 +7392,36 @@
         ]
       }
     },
+    "/api/v1/auth/change-password": {
+      "patch": {
+        "description": "Compatibility alias for `/api/v1/users/me/password`.",
+        "operationId": "auth_change_password",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ChangePasswordRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ],
+        "summary": "Change password",
+        "tags": [
+          "Users"
+        ]
+      }
+    },
     "/api/v1/auth/forgot-password": {
       "post": {
         "description": "Send a password reset email. Always returns 200 to prevent user enumeration.",
@@ -8565,6 +8595,21 @@
         ]
       }
     },
+    "/api/v1/health/detailed": {
+      "get": {
+        "description": "Compatibility alias for `/health/detailed`.",
+        "operationId": "v1_health_detailed",
+        "responses": {
+          "200": {
+            "description": "Health check"
+          }
+        },
+        "summary": "Detailed health check",
+        "tags": [
+          "Health"
+        ]
+      }
+    },
     "/api/v1/health/info": {
       "get": {
         "description": "Compatibility endpoint carrying runtime metadata and the canonical module map.",
@@ -8653,6 +8698,37 @@
         "summary": "Get Impressum (public)",
         "tags": [
           "Public"
+        ]
+      }
+    },
+    "/api/v1/login": {
+      "post": {
+        "description": "Compatibility alias for `/api/v1/auth/login`.",
+        "operationId": "login_alias",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LoginRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Login successful"
+          },
+          "401": {
+            "description": "Invalid credentials"
+          },
+          "403": {
+            "description": "Account disabled"
+          }
+        },
+        "summary": "Log in",
+        "tags": [
+          "Authentication"
         ]
       }
     },
@@ -10627,6 +10703,68 @@
         ]
       }
     },
+    "/api/v1/refresh": {
+      "post": {
+        "description": "Compatibility alias for `/api/v1/auth/refresh`.",
+        "operationId": "refresh_token_alias",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RefreshTokenRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Token refreshed successfully"
+          },
+          "401": {
+            "description": "Invalid or expired refresh token"
+          }
+        },
+        "summary": "Refresh access token",
+        "tags": [
+          "Authentication"
+        ]
+      }
+    },
+    "/api/v1/register": {
+      "post": {
+        "description": "Compatibility alias for `/api/v1/auth/register`.",
+        "operationId": "register_alias",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RegisterRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Registration successful"
+          },
+          "400": {
+            "description": "Invalid input"
+          },
+          "403": {
+            "description": "Registration disabled"
+          },
+          "409": {
+            "description": "Email already exists"
+          }
+        },
+        "summary": "Register a new account",
+        "tags": [
+          "Authentication"
+        ]
+      }
+    },
     "/api/v1/setup": {
       "post": {
         "description": "Create the first admin user and configure the system. Only works before setup is completed.",
@@ -10667,6 +10805,21 @@
         "summary": "Get setup status",
         "tags": [
           "Setup"
+        ]
+      }
+    },
+    "/api/v1/status": {
+      "get": {
+        "description": "Compatibility alias for `/status`.",
+        "operationId": "v1_server_status",
+        "responses": {
+          "200": {
+            "description": "Server status"
+          }
+        },
+        "summary": "Server status overview",
+        "tags": [
+          "Health"
         ]
       }
     },

--- a/parkhub-server/src/api/auth.rs
+++ b/parkhub-server/src/api/auth.rs
@@ -317,6 +317,27 @@ pub async fn login(
 
 #[utoipa::path(
     post,
+    path = "/api/v1/login",
+    tag = "Authentication",
+    summary = "Log in",
+    description = "Compatibility alias for `/api/v1/auth/login`.",
+    request_body = LoginRequest,
+    responses(
+        (status = 200, description = "Login successful"),
+        (status = 401, description = "Invalid credentials"),
+        (status = 403, description = "Account disabled"),
+    )
+)]
+pub async fn login_alias(
+    State(state): State<SharedState>,
+    Extension(temp_token_store): Extension<Arc<TwoFactorTempTokenStore>>,
+    Json(request): Json<LoginRequest>,
+) -> Response {
+    login(State(state), Extension(temp_token_store), Json(request)).await
+}
+
+#[utoipa::path(
+    post,
     path = "/api/v1/auth/register",
     tag = "Authentication",
     summary = "Register a new account",
@@ -587,6 +608,27 @@ pub async fn register(
 
 #[utoipa::path(
     post,
+    path = "/api/v1/register",
+    tag = "Authentication",
+    summary = "Register a new account",
+    description = "Compatibility alias for `/api/v1/auth/register`.",
+    request_body = RegisterRequest,
+    responses(
+        (status = 201, description = "Registration successful"),
+        (status = 400, description = "Invalid input"),
+        (status = 403, description = "Registration disabled"),
+        (status = 409, description = "Email already exists"),
+    )
+)]
+pub async fn register_alias(
+    State(state): State<SharedState>,
+    Json(request): Json<RegisterRequest>,
+) -> Response {
+    register(State(state), Json(request)).await
+}
+
+#[utoipa::path(
+    post,
     path = "/api/v1/auth/refresh",
     tag = "Authentication",
     summary = "Refresh access token",
@@ -731,6 +773,25 @@ pub async fn refresh_token(
         })),
         &cookie,
     )
+}
+
+#[utoipa::path(
+    post,
+    path = "/api/v1/refresh",
+    tag = "Authentication",
+    summary = "Refresh access token",
+    description = "Compatibility alias for `/api/v1/auth/refresh`.",
+    request_body = RefreshTokenRequest,
+    responses(
+        (status = 200, description = "Token refreshed successfully"),
+        (status = 401, description = "Invalid or expired refresh token"),
+    )
+)]
+pub async fn refresh_token_alias(
+    State(state): State<SharedState>,
+    Json(request): Json<RefreshTokenRequest>,
+) -> Response {
+    refresh_token(State(state), Json(request)).await
 }
 
 /// `POST /api/v1/auth/forgot-password`

--- a/parkhub-server/src/api/mod.rs
+++ b/parkhub-server/src/api/mod.rs
@@ -504,9 +504,9 @@ async fn admin_middleware(
 // build (e.g. `--no-default-features`), and the booking/integration helpers
 // intentionally group many small route blocks by domain.
 
-/// Rate-limited, pre-auth `/api/v1/auth/*` routes (login, 2FA-login, register,
-/// forgot-password, refresh, reset-password, logout) and the standalone
-/// `/api/v1/bookings/{id}/qr` route.
+/// Rate-limited, pre-auth auth routes and aliases:
+/// `/api/v1/auth/*`, legacy `/api/v1/{login,register,refresh}`, and the
+/// standalone `/api/v1/bookings/{id}/qr` route.
 ///
 /// Each sub-router has its own per-IP + per-identity rate-limit layers applied
 /// via `route_layer` (so only that route is affected), and `two_fa_store` is

--- a/parkhub-server/src/api/mod.rs
+++ b/parkhub-server/src/api/mod.rs
@@ -237,7 +237,10 @@ use announcements::{
     admin_create_announcement, admin_delete_announcement, admin_list_announcements,
     admin_update_announcement, get_active_announcements,
 };
-use auth::{forgot_password, login, logout, refresh_token, register, reset_password};
+use auth::{
+    forgot_password, login, login_alias, logout, refresh_token, refresh_token_alias, register,
+    register_alias, reset_password,
+};
 #[cfg(feature = "mod-bookings")]
 pub use bookings::{
     booking_checkin, cancel_booking, create_booking, get_booking, get_booking_invoice,
@@ -377,8 +380,8 @@ pub use misc::{
     get_impressum, get_impressum_admin, public_display, public_occupancy, update_impressum,
 };
 pub use users::{
-    change_password, gdpr_delete_account, gdpr_export_data, get_current_user, get_my_settings,
-    get_user, get_user_preferences, update_current_user, update_my_settings,
+    auth_change_password, change_password, gdpr_delete_account, gdpr_export_data, get_current_user,
+    get_my_settings, get_user, get_user_preferences, update_current_user, update_my_settings,
     update_user_preferences, user_stats,
 };
 
@@ -518,6 +521,7 @@ fn auth_rate_limited_routes(
     let login_identity = identity_limiters.clone();
     let login_route = Router::new()
         .route("/api/v1/auth/login", post(login))
+        .route("/api/v1/login", post(login_alias))
         .layer(Extension(two_fa_store.clone()))
         .route_layer(middleware::from_fn(move |req, next| {
             identity_rate_limit_middleware(
@@ -554,6 +558,7 @@ fn auth_rate_limited_routes(
     let register_identity = identity_limiters.clone();
     let register_route = Router::new()
         .route("/api/v1/auth/register", post(register))
+        .route("/api/v1/register", post(register_alias))
         .route_layer(middleware::from_fn(move |req, next| {
             identity_rate_limit_middleware(
                 register_identity.clone(),
@@ -588,6 +593,7 @@ fn auth_rate_limited_routes(
     let refresh_identity = identity_limiters.clone();
     let refresh_route = Router::new()
         .route("/api/v1/auth/refresh", post(refresh_token))
+        .route("/api/v1/refresh", post(refresh_token_alias))
         .route_layer(middleware::from_fn(move |req, next| {
             identity_rate_limit_middleware(
                 refresh_identity.clone(),
@@ -660,8 +666,10 @@ fn public_routes(state: &SharedState, rate_limiters: &EndpointRateLimiters) -> R
         .route("/api/v1/health/live", get(v1_health_live))
         .route("/api/v1/health/ready", get(v1_health_ready))
         .route("/api/v1/health/info", get(v1_health_info))
+        .route("/api/v1/health/detailed", get(v1_health_detailed))
         .route("/handshake", post(handshake))
         .route("/status", get(server_status))
+        .route("/api/v1/status", get(v1_server_status))
         .route("/api/v1/discover", get(v1_discover))
         // Legal — public (DDG § 5 requires Impressum to be freely accessible)
         .route("/api/v1/legal/impressum", get(get_impressum))
@@ -877,6 +885,10 @@ fn user_core_routes() -> Router<SharedState> {
         .route(
             "/api/v1/users/me/password",
             axum::routing::patch(change_password),
+        )
+        .route(
+            "/api/v1/auth/change-password",
+            axum::routing::patch(auth_change_password),
         )
         // Admin-only: retrieve any user by ID
         .route("/api/v1/users/{id}", get(get_user))
@@ -2397,7 +2409,8 @@ async fn protected_identity_rate_limit_middleware(
 // Health & system handler re-exports from system module
 use system::{
     handshake, health_check, liveness_check, readiness_check, server_status, system_maintenance,
-    system_version, v1_discover, v1_health, v1_health_info, v1_health_live, v1_health_ready,
+    system_version, v1_discover, v1_health, v1_health_detailed, v1_health_info, v1_health_live,
+    v1_health_ready, v1_server_status,
 };
 
 // ═══════════════════════════════════════════════════════════════════════════════

--- a/parkhub-server/src/api/system.rs
+++ b/parkhub-server/src/api/system.rs
@@ -297,6 +297,21 @@ pub async fn v1_health_info(
     }))
 }
 
+/// PHP-compatible alias for the detailed health response.
+#[utoipa::path(
+    get,
+    path = "/api/v1/health/detailed",
+    tag = "Health",
+    summary = "Detailed health check",
+    description = "Compatibility alias for `/health/detailed`.",
+    responses((status = 200, description = "Health check"))
+)]
+pub async fn v1_health_detailed(
+    State(state): State<SharedState>,
+) -> Json<crate::api::admin_ext::ExtendedHealthResponse> {
+    crate::api::admin_ext::detailed_health_check(State(state)).await
+}
+
 /// PHP-compatible discovery handshake.
 #[utoipa::path(
     get,
@@ -449,6 +464,18 @@ pub async fn server_status(State(state): State<SharedState>) -> Json<ApiResponse
         total_bookings: u32::try_from(db_stats.bookings).unwrap_or(u32::MAX),
         database_size_bytes: 0,
     }))
+}
+
+#[utoipa::path(
+    get,
+    path = "/api/v1/status",
+    tag = "Health",
+    summary = "Server status overview",
+    description = "Compatibility alias for `/status`.",
+    responses((status = 200, description = "Server status"))
+)]
+pub async fn v1_server_status(State(state): State<SharedState>) -> Json<ApiResponse<ServerStatus>> {
+    server_status(State(state)).await
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════

--- a/parkhub-server/src/api/users.rs
+++ b/parkhub-server/src/api/users.rs
@@ -662,6 +662,21 @@ pub async fn change_password(
     (StatusCode::OK, Json(ApiResponse::success(())))
 }
 
+/// `PATCH /api/v1/auth/change-password` — compatibility alias for password change.
+#[utoipa::path(patch, path = "/api/v1/auth/change-password", tag = "Users",
+    summary = "Change password",
+    description = "Compatibility alias for `/api/v1/users/me/password`.",
+    security(("bearer_auth" = [])),
+    responses((status = 200, description = "Success"))
+)]
+pub async fn auth_change_password(
+    State(state): State<SharedState>,
+    Extension(auth_user): Extension<AuthUser>,
+    Json(req): Json<ChangePasswordRequest>,
+) -> (StatusCode, Json<ApiResponse<()>>) {
+    change_password(State(state), Extension(auth_user), Json(req)).await
+}
+
 // ═══════════════════════════════════════════════════════════════════════════════
 // USER STATS
 // ═══════════════════════════════════════════════════════════════════════════════

--- a/parkhub-server/src/openapi.rs
+++ b/parkhub-server/src/openapi.rs
@@ -253,8 +253,11 @@ use crate::{
     paths(
         // Authentication
         crate::api::auth::login,
+        crate::api::auth::login_alias,
         crate::api::auth::register,
+        crate::api::auth::register_alias,
         crate::api::auth::refresh_token,
+        crate::api::auth::refresh_token_alias,
         crate::api::auth::forgot_password,
         crate::api::auth::reset_password,
 
@@ -318,15 +321,18 @@ use crate::{
         crate::api::system::v1_health_live,
         crate::api::system::v1_health_ready,
         crate::api::system::v1_health_info,
+        crate::api::system::v1_health_detailed,
         crate::api::system::v1_discover,
         crate::api::system::handshake,
         crate::api::system::server_status,
+        crate::api::system::v1_server_status,
 
         // Users (mod.rs)
         crate::api::users::get_current_user,
         crate::api::users::update_current_user,
         crate::api::users::get_user,
         crate::api::users::change_password,
+        crate::api::users::auth_change_password,
         crate::api::users::user_stats,
         crate::api::users::get_user_preferences,
         crate::api::users::update_user_preferences,
@@ -752,6 +758,22 @@ mod tests {
     }
 
     #[test]
+    fn test_openapi_has_compat_alias_paths() {
+        let doc = ApiDoc::openapi();
+        let json = doc.to_json().unwrap();
+        for path in [
+            "/api/v1/login",
+            "/api/v1/register",
+            "/api/v1/refresh",
+            "/api/v1/auth/change-password",
+            "/api/v1/health/detailed",
+            "/api/v1/status",
+        ] {
+            assert!(json.contains(path), "Missing path: {path}");
+        }
+    }
+
+    #[test]
     fn test_openapi_has_lot_paths() {
         let doc = ApiDoc::openapi();
         let json = doc.to_json().unwrap();
@@ -933,7 +955,13 @@ mod tests {
     fn test_openapi_has_health_paths() {
         let doc = ApiDoc::openapi();
         let json = doc.to_json().unwrap();
-        for path in ["/health", "/health/live", "/health/ready", "/status"] {
+        for path in [
+            "/health",
+            "/health/live",
+            "/health/ready",
+            "/status",
+            "/api/v1/status",
+        ] {
             assert!(json.contains(path), "Missing path: {path}");
         }
     }


### PR DESCRIPTION
## Summary
- add Rust compatibility aliases for /api/v1 login, register, refresh, auth/change-password, health/detailed, and status
- regenerate docs/openapi/rust.json and update parity docs with the alias-tranche totals
- reduce measured cross-repo OpenAPI drift as part of T-6061

## Verification
- git diff --check
- fop cargo check --locked --package parkhub-server --no-default-features --features headless --all-targets
- fop cargo test --locked --package parkhub-server --no-default-features --features headless test_openapi_has_compat_alias_paths -- --nocapture
- normal pre-push hooks passed on push to GitHub