### PR TITLE
fix(ci): run required checks for merge queue

### DIFF
--- a/.github/scripts/fop-local-ci.sh
+++ b/.github/scripts/fop-local-ci.sh
@@ -449,6 +449,7 @@ if (( diff_touch_workflows )) || [[ "${FOP_LOCAL_CI_RUN_LINTERS:-}" == "1" ]]; t
   if command -v actionlint >/dev/null 2>&1; then
     run_direct "actionlint" "actionlint -color"
   fi
+  run_direct "CI workflow policy" "bash scripts/check-ci-workflow-policy.sh"
   if command -v zizmor >/dev/null 2>&1; then
     # Audit-mode: surface findings, don't fail the gate yet
     run_direct "zizmor (audit)" "zizmor --no-progress --persona auditor .github/workflows/ || true"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ on:
       - .github/ISSUE_TEMPLATE/**
       - .github/PULL_REQUEST_TEMPLATE.md
       - .github/agents/**
+  merge_group:
+    types: [checks_requested]
   workflow_dispatch:
 
 concurrency:
@@ -56,6 +58,9 @@ jobs:
         run: |
           python3 -m pip install --user yamllint
           ~/.local/bin/yamllint -d relaxed .github/workflows docker-compose.yml docker-compose.test.yml render.yaml koyeb.yaml
+
+      - name: Validate CI workflow policy
+        run: bash scripts/check-ci-workflow-policy.sh
 
       - name: Validate Fly config
         run: python3 -c "import pathlib, tomllib; tomllib.loads(pathlib.Path('fly.toml').read_text())"
@@ -255,7 +260,7 @@ jobs:
 
   fmt:
     name: Cargo Format Check
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository || contains(github.event.pull_request.labels.*.name, 'github-ci-full')
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.type == 'Bot' || contains(github.event.pull_request.labels.*.name, 'github-ci-full')
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -274,7 +279,7 @@ jobs:
 
   check:
     name: Cargo Check (headless)
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository || contains(github.event.pull_request.labels.*.name, 'github-ci-full')
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.type == 'Bot' || contains(github.event.pull_request.labels.*.name, 'github-ci-full')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -301,7 +306,7 @@ jobs:
 
   client-check:
     name: Desktop Client Check
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository || contains(github.event.pull_request.labels.*.name, 'github-ci-full')
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.type == 'Bot' || contains(github.event.pull_request.labels.*.name, 'github-ci-full')
     runs-on: ubuntu-latest
     timeout-minutes: 35
     steps:
@@ -327,7 +332,7 @@ jobs:
 
   clippy:
     name: Cargo Clippy (headless)
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository || contains(github.event.pull_request.labels.*.name, 'github-ci-full')
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.type == 'Bot' || contains(github.event.pull_request.labels.*.name, 'github-ci-full')
     runs-on: ubuntu-latest
     timeout-minutes: 40
     steps:
@@ -356,7 +361,7 @@ jobs:
 
   test:
     name: Cargo Test (headless)
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository || contains(github.event.pull_request.labels.*.name, 'github-ci-full')
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.type == 'Bot' || contains(github.event.pull_request.labels.*.name, 'github-ci-full')
     runs-on: ubuntu-latest
     timeout-minutes: 45
     needs: [check]
@@ -384,7 +389,7 @@ jobs:
 
   frontend:
     name: Frontend Build & Test
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository || contains(github.event.pull_request.labels.*.name, 'github-ci-full')
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.type == 'Bot' || contains(github.event.pull_request.labels.*.name, 'github-ci-full')
     runs-on: ubuntu-latest
     timeout-minutes: 25
     defaults:
@@ -413,7 +418,7 @@ jobs:
 
   integration:
     name: Integration Tests
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository || contains(github.event.pull_request.labels.*.name, 'github-ci-full')
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.type == 'Bot' || contains(github.event.pull_request.labels.*.name, 'github-ci-full')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     needs: [test]
@@ -445,7 +450,7 @@ jobs:
 
   types-drift:
     name: TypeScript types drift
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository || contains(github.event.pull_request.labels.*.name, 'github-ci-full')
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.type == 'Bot' || contains(github.event.pull_request.labels.*.name, 'github-ci-full')
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -504,7 +509,7 @@ jobs:
 
   openapi-drift:
     name: OpenAPI drift
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository || contains(github.event.pull_request.labels.*.name, 'github-ci-full')
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.type == 'Bot' || contains(github.event.pull_request.labels.*.name, 'github-ci-full')
     runs-on: ubuntu-latest
     timeout-minutes: 25
     steps:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2174,7 +2174,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2595,7 +2595,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3214,7 +3214,7 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.2.1",
+ "windows-link 0.1.3",
  "windows-result 0.4.1",
 ]
 
@@ -4006,7 +4006,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -5037,9 +5037,9 @@ dependencies = [
 
 [[package]]
 name = "lettre"
-version = "0.11.21"
+version = "0.11.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dabda5859ee7c06b995b9d1165aa52c39110e079ef609db97178d86aeb051fa7"
+checksum = "0da65617f6cb926332d039cb578aad56178da86e128db6a1b09f4c94fa5b3349"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5651,7 +5651,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5808,7 +5808,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6540,7 +6540,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -7667,7 +7667,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.2",
  "rustls",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -7705,7 +7705,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -8471,7 +8471,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8529,7 +8529,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -9356,7 +9356,7 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -9390,7 +9390,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -10330,7 +10330,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -11001,7 +11001,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -11022,7 +11022,7 @@ dependencies = [
  "once_cell",
  "png 0.18.1",
  "thiserror 2.0.18",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -11130,7 +11130,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -12059,7 +12059,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Makefile
+++ b/Makefile
@@ -136,6 +136,7 @@ ci-post:
 ## trivy-image or grype-image. Mirrors parkhub-php's ci-security target so the
 ## same mental model spans both repos.
 ci-security:
+	bash scripts/check-ci-workflow-policy.sh
 	scripts/ci/local-security-audit.sh --profile cd --strict-tools --fail-advisory
 
 pre-push: ci

--- a/parkhub-server/fuzz/Cargo.lock
+++ b/parkhub-server/fuzz/Cargo.lock
@@ -1174,7 +1174,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1337,7 +1337,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2033,7 +2033,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -2464,9 +2464,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "lettre"
-version = "0.11.21"
+version = "0.11.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dabda5859ee7c06b995b9d1165aa52c39110e079ef609db97178d86aeb051fa7"
+checksum = "0da65617f6cb926332d039cb578aad56178da86e128db6a1b09f4c94fa5b3349"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2823,7 +2823,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3081,7 +3081,7 @@ dependencies = [
 
 [[package]]
 name = "parkhub-common"
-version = "5.0.9"
+version = "5.1.0"
 dependencies = [
  "chrono",
  "serde",
@@ -3093,7 +3093,7 @@ dependencies = [
 
 [[package]]
 name = "parkhub-server"
-version = "5.0.9"
+version = "5.1.0"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -3552,7 +3552,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.2",
  "rustls",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -3590,7 +3590,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -3991,7 +3991,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4049,7 +4049,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4373,7 +4373,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4560,7 +4560,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5490,7 +5490,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/parkhub-server/src/booking_tests.rs
+++ b/parkhub-server/src/booking_tests.rs
@@ -957,11 +957,15 @@ async fn test_rate_limit_register() {
     let app = router(state);
 
     let mut last_status = StatusCode::OK;
-    for i in 0..4 {
+    for _ in 0..4 {
+        // Use a validation-failing payload so this test measures only the
+        // route-local rate limiter. Successful registration hashes passwords
+        // and writes users; under full-suite load that can take long enough
+        // for the per-minute bucket to refill before the fourth request.
         let body = serde_json::json!({
-            "email": format!("ratelimit{i}@example.com"),
-            "password": "SecurePass1!",
-            "password_confirmation": "SecurePass1!",
+            "email": "not-an-email",
+            "password": "short",
+            "password_confirmation": "mismatch",
             "name": "RL User",
         });
         let resp = app

--- a/parkhub-web/package-lock.json
+++ b/parkhub-web/package-lock.json
@@ -4942,9 +4942,9 @@
       "license": "MIT"
     },
     "node_modules/devalue": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.7.1.tgz",
-      "integrity": "sha512-MUbZ586EgQqdRnC4yDrlod3BEdyvE4TapGYHMW2CiaW+KkkFmWEFqBUaLltEZCGi0iFXCEjRF0OjF0DV2QHjOA==",
+      "version": "5.8.1",
+      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.8.1.tgz",
+      "integrity": "sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==",
       "license": "MIT"
     },
     "node_modules/devlop": {

--- a/parkhub-web/src/design-v5/screens/Kalender.test.tsx
+++ b/parkhub-web/src/design-v5/screens/Kalender.test.tsx
@@ -86,12 +86,13 @@ describe('KalenderV5', () => {
     const { events } = makeEvents();
     mockCalendarEvents.mockResolvedValue({ success: true, data: events });
     renderScreen();
-    await waitFor(() => expect(screen.getByText('Parkhaus Nord')).toBeInTheDocument());
+    const grid = await screen.findByRole('grid', { name: /Kalender/ });
+    await waitFor(() => expect(within(grid).getByText('Parkhaus Nord')).toBeInTheDocument());
     // Event title visible in the grid
-    expect(screen.getByText('Urlaub')).toBeInTheDocument();
+    expect(within(grid).getByText('Urlaub')).toBeInTheDocument();
     // Summary stats (label + count)
-    expect(screen.getByText('Buchungen')).toBeInTheDocument();
-    expect(screen.getByText('Abwesenheit')).toBeInTheDocument();
+    expect(screen.getByText('Buchungen', { selector: 'div' })).toBeInTheDocument();
+    expect(screen.getByText('Abwesenheit', { selector: 'div' })).toBeInTheDocument();
   });
 
   it('shows selected-day detail card on click', async () => {

--- a/scripts/check-ci-workflow-policy.sh
+++ b/scripts/check-ci-workflow-policy.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+python3 - <<'PY'
+import pathlib
+import re
+import sys
+
+try:
+    import yaml
+except ModuleNotFoundError:
+    print("PyYAML is required for CI workflow policy checks", file=sys.stderr)
+    raise
+
+workflow_dir = pathlib.Path(".github/workflows")
+ci_path = workflow_dir / "ci.yml"
+ci = yaml.safe_load(ci_path.read_text())
+
+errors = []
+
+on = ci.get("on") or ci.get(True) or {}
+merge_group = on.get("merge_group") if isinstance(on, dict) else None
+merge_group_types = []
+if isinstance(merge_group, dict):
+    raw_types = merge_group.get("types") or []
+    merge_group_types = raw_types if isinstance(raw_types, list) else [raw_types]
+if "checks_requested" not in merge_group_types:
+    errors.append("ci.yml must trigger on merge_group.types: [checks_requested]")
+
+jobs = ci.get("jobs") or {}
+required = jobs.get("required") or {}
+if required.get("name") != "Required checks":
+    errors.append("jobs.required.name must be 'Required checks'")
+if required.get("if") != "always()":
+    errors.append("jobs.required.if must be always()")
+
+needs = required.get("needs") or []
+if isinstance(needs, str):
+    needs = [needs]
+actual_needs = sorted(needs)
+
+expected_needs = sorted(
+    job_id
+    for job_id, job in jobs.items()
+    if job_id != "required" and not bool((job or {}).get("continue-on-error"))
+)
+if actual_needs != expected_needs:
+    errors.append(f"jobs.required.needs drift expected={expected_needs} actual={actual_needs}")
+
+required_steps = required.get("steps") or []
+env_values = []
+for step in required_steps:
+    env = (step or {}).get("env") or {}
+    env_values.extend(str(value) for value in env.values())
+covered_needs = sorted(set(re.findall(r"needs\.([A-Za-z0-9_-]+)\.result", "\n".join(env_values))))
+missing_env = [job_id for job_id in actual_needs if job_id not in covered_needs]
+if missing_env:
+    errors.append(f"jobs.required env missing needs result coverage for {missing_env}")
+
+for job_id, job in sorted(jobs.items()):
+    condition = str((job or {}).get("if") or "")
+    if (
+        "github.event.pull_request.head.repo.full_name != github.repository" in condition
+        and "contains(github.event.pull_request.labels.*.name, 'github-ci-full')" in condition
+        and "github.event.pull_request.user.type == 'Bot'" not in condition
+    ):
+        errors.append(
+            f"jobs.{job_id}.if must run full GitHub CI for same-repo bot PRs "
+            "instead of skipping both local attestation and heavy jobs"
+        )
+
+def walk_uses(node, path):
+    if isinstance(node, dict):
+        for key, value in node.items():
+            if key == "uses" and isinstance(value, str):
+                yield value, path + ["uses"]
+            else:
+                yield from walk_uses(value, path + [str(key)])
+    elif isinstance(node, list):
+        for index, value in enumerate(node):
+            yield from walk_uses(value, path + [str(index)])
+
+for workflow in sorted(workflow_dir.glob("*.yml")) + sorted(workflow_dir.glob("*.yaml")):
+    data = yaml.safe_load(workflow.read_text())
+    for uses, path in walk_uses(data, [str(workflow)]):
+        if uses.startswith("./") or uses.startswith("docker://"):
+            continue
+        if "@" not in uses:
+            errors.append(f"{workflow}: unpinned action {uses}")
+            continue
+        ref = uses.rsplit("@", 1)[1]
+        if not re.fullmatch(r"[0-9a-fA-F]{40}", ref):
+            errors.append(f"{workflow}: action must be pinned to full commit SHA: {uses}")
+
+if errors:
+    for error in errors:
+        print(f"ERROR: {error}", file=sys.stderr)
+    sys.exit(1)
+
+print("CI workflow policy OK")
+PY

--- a/scripts/local-workflow-drift.sh
+++ b/scripts/local-workflow-drift.sh
@@ -13,6 +13,8 @@
 #   2. For each matched pair: same `on:` triggers, same `jobs:` keys.
 #      Step bodies are NOT compared (they intentionally differ —
 #      gitea uses local action mirrors, github uses public).
+#   3. GitHub's required aggregate CI workflow keeps merge-queue coverage:
+#      `merge_group: { types: [checks_requested] }`.
 #
 # Usage:
 #   scripts/local-workflow-drift.sh [--strict]
@@ -67,6 +69,7 @@ norm() { printf '%s' "$1" | sed -E 's/\.(yml|yaml)$//'; }
 
 declare -a missing_in_gitea=()
 declare -a missing_in_github=()
+declare -a policy_violations=()
 declare -a trigger_drift=()
 declare -a job_drift=()
 
@@ -113,13 +116,26 @@ for f in "${gh_files[@]}"; do
     continue
   fi
 
-  drift=$(python3 - "$gh_path" "$gt_path" <<'PY' 2>/dev/null || true
+  drift=$(python3 - "$gh_path" "$gt_path" "$base" <<'PY' 2>/dev/null || true
 import sys, yaml
-gh, gt = sys.argv[1], sys.argv[2]
+gh, gt, base = sys.argv[1], sys.argv[2], sys.argv[3]
 with open(gh) as f: gh_y = yaml.safe_load(f)
 with open(gt) as f: gt_y = yaml.safe_load(f)
-gh_on = sorted((gh_y.get('on') or gh_y.get(True) or {}).keys()) if isinstance(gh_y.get('on') or gh_y.get(True), dict) else []
-gt_on = sorted((gt_y.get('on') or gt_y.get(True) or {}).keys()) if isinstance(gt_y.get('on') or gt_y.get(True), dict) else []
+gh_on_raw = gh_y.get('on') or gh_y.get(True) or {}
+gt_on_raw = gt_y.get('on') or gt_y.get(True) or {}
+gh_on_cmp = dict(gh_on_raw) if isinstance(gh_on_raw, dict) else {}
+if base == 'ci':
+    merge_group = gh_on_cmp.get('merge_group')
+    types = []
+    if isinstance(merge_group, dict):
+        raw_types = merge_group.get('types') or []
+        types = raw_types if isinstance(raw_types, list) else [raw_types]
+    if 'checks_requested' not in types:
+        print('policy:github-ci-missing-merge_group-checks_requested')
+    # GitHub Merge Queue has no Gitea equivalent; compare remaining triggers.
+    gh_on_cmp.pop('merge_group', None)
+gh_on = sorted(gh_on_cmp.keys()) if isinstance(gh_on_cmp, dict) else []
+gt_on = sorted(gt_on_raw.keys()) if isinstance(gt_on_raw, dict) else []
 if gh_on != gt_on:
     print(f"on:gh={gh_on} on:gt={gt_on}")
 gh_jobs = sorted((gh_y.get('jobs') or {}).keys())
@@ -131,17 +147,22 @@ if gh_only or gt_only:
 PY
 )
   if [[ -n "$drift" ]]; then
-    if [[ "$drift" == on:* ]]; then
-      trigger_drift+=("$base: $drift")
-    else
-      job_drift+=("$base: $drift")
-    fi
+    while IFS= read -r line; do
+      [[ -z "$line" ]] && continue
+      if [[ "$line" == policy:* ]]; then
+        policy_violations+=("$base: ${line#policy:}")
+      elif [[ "$line" == on:* ]]; then
+        trigger_drift+=("$base: $line")
+      else
+        job_drift+=("$base: $line")
+      fi
+    done <<< "$drift"
   fi
 done
 
 # Report.
 exit_code=0
-total_drift=$((${#missing_in_gitea[@]} + ${#missing_in_github[@]} + ${#trigger_drift[@]} + ${#job_drift[@]}))
+total_drift=$((${#missing_in_gitea[@]} + ${#missing_in_github[@]} + ${#policy_violations[@]} + ${#trigger_drift[@]} + ${#job_drift[@]}))
 
 if (( total_drift == 0 )); then
   echo "✓ no workflow drift detected (gh:${#gh_files[@]} files, gt:${#gt_files[@]} files)"
@@ -157,6 +178,12 @@ fi
 if (( ${#missing_in_github[@]} > 0 )); then
   echo "✗ in .gitea/workflows but missing from .github/workflows:"
   for f in "${missing_in_github[@]}"; do echo "    $f"; done
+  exit_code=1
+fi
+
+if (( ${#policy_violations[@]} > 0 )); then
+  echo "✗ workflow policy violations:"
+  for d in "${policy_violations[@]}"; do echo "    $d"; done
   exit_code=1
 fi
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -34,16 +34,50 @@ fn free_port() -> u16 {
 
 /// Locate the `parkhub-server` binary.
 ///
-/// Looks for:
-///  1. `target/debug/parkhub-server`
-///  2. `target/release/parkhub-server`
+/// Looks next to the current test executable first, then Cargo's configured
+/// target directory and finally the repository target directories. Local
+/// `fop build` routes Cargo artifacts to `/var/tmp/florian-offload`, so
+/// integration tests must not assume the default `target/` path.
 fn server_binary() -> PathBuf {
+    let mut searched = Vec::new();
+    if let Ok(current_exe) = std::env::current_exe()
+        && let Some(debug_dir) = current_exe.parent().and_then(|deps| deps.parent())
+    {
+        let debug = debug_dir.join("parkhub-server");
+        searched.push(debug.clone());
+        if debug.exists() {
+            return debug;
+        }
+        if let Some(target_dir) = debug_dir.parent() {
+            let release = target_dir.join("release/parkhub-server");
+            searched.push(release.clone());
+            if release.exists() {
+                return release;
+            }
+        }
+    }
+
+    if let Some(target_dir) = std::env::var_os("CARGO_TARGET_DIR").map(PathBuf::from) {
+        let debug = target_dir.join("debug/parkhub-server");
+        searched.push(debug.clone());
+        if debug.exists() {
+            return debug;
+        }
+        let release = target_dir.join("release/parkhub-server");
+        searched.push(release.clone());
+        if release.exists() {
+            return release;
+        }
+    }
+
     let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let debug = root.join("target/debug/parkhub-server");
+    searched.push(debug.clone());
     if debug.exists() {
         return debug;
     }
     let release = root.join("target/release/parkhub-server");
+    searched.push(release.clone());
     if release.exists() {
         return release;
     }
@@ -52,15 +86,18 @@ fn server_binary() -> PathBuf {
         .parent()
         .map(|p| p.join("target/debug/parkhub-server"))
         .unwrap_or_default();
+    searched.push(ws_debug.clone());
     if ws_debug.exists() {
         return ws_debug;
     }
     panic!(
         "parkhub-server binary not found. Build with `cargo build -p parkhub-server` first.\n\
-         Searched: {}, {}, {}",
-        debug.display(),
-        release.display(),
-        ws_debug.display()
+         Searched: {}",
+        searched
+            .iter()
+            .map(|path| path.display().to_string())
+            .collect::<Vec<_>>()
+            .join(", ")
     );
 }
 


### PR DESCRIPTION
Adds merge_group coverage for required workflows, tightens the local CI policy guard, keeps same-repo bot PRs on the full heavy GitHub path, and fixes the local pre-push blockers found while publishing the branch. Also updates devalue to 5.8.1 and lettre to 0.11.22 so Trivy/OSV stay clean. Verification on ee576970: make ci passed; lefthook run pre-push passed; OSV and Trivy gates clean.