### PR TITLE
fix(v5): NutzerV5 hydration — clear stale KNOWN_BROKEN anchors

### DIFF
--- a/parkhub-web/e2e/v5-happy-paths.spec.ts
+++ b/parkhub-web/e2e/v5-happy-paths.spec.ts
@@ -126,13 +126,6 @@ const ANCHORS: Record<V5Screen, Anchor> = {
   },
   nutzer: {
     note: 'Nutzer banner',
-    // KNOWN BROKEN on github/main (a8fba08): NutzerV5 throws
-    // "h.filter is not a function" during hydration, the v5 shell never
-    // mounts and <header><h1> is never emitted. Bug lives in the screen
-    // component (not this test), so this anchor is correct as-written —
-    // we skip instead of tightening / relaxing. Raised in coverage PR so
-    // it's visible; fix is tracked separately.
-    // TODO: flip back to assert once NutzerV5 renders again.
     assert: async (p) =>
       expect(p.locator('main').getByText('Nutzer', { exact: true }).first()).toBeVisible(),
   },

--- a/parkhub-web/e2e/v5-visual.spec.ts
+++ b/parkhub-web/e2e/v5-visual.spec.ts
@@ -26,7 +26,8 @@ import { loginAsAdmin, openV5, V5_MODES, V5_SCREENS } from './v5-helpers';
 // blank PNGs — useless as a regression signal. Mirror set of the
 // v5-happy-paths KNOWN_BROKEN; fixme'd here so snapshot capture stays
 // no-op until the screen is repaired.
-const KNOWN_BROKEN = new Set<string>(['nutzer']);
+// nutzer was removed here after d91998c1 fixed the PaginatedResponse unwrap.
+const KNOWN_BROKEN = new Set<string>();
 
 test.describe('v5 visual regression', () => {
   test.beforeEach(async ({ page }, testInfo) => {


### PR DESCRIPTION
## Summary

Removes nutzer from KNOWN_BROKEN in e2e/v5-visual.spec.ts so the visual baseline is captured again. Drops the stale KNOWN_BROKEN comment block and TODO in e2e/v5-happy-paths.spec.ts.

## Root cause

The runtime crash (users.filter is not a function, minified as h.filter) was caused by adminUsers() being typed as User[] while the Rust handler returns PaginatedResponse<User>. Fixed in d91998c1 (PR #384, T-1954): client.ts now uses PaginatedResponse<User> and Nutzer.tsx unwraps via res.data?.items ?? [].

W2 audit identified two surviving skip anchors not cleaned up after the component fix: v5-visual.spec.ts:29 still had nutzer in KNOWN_BROKEN, and v5-happy-paths.spec.ts:129-135 still had the KNOWN BROKEN + TODO comment (the assert itself was already correct).

## Test plan

- v5-happy-paths.spec.ts nutzer anchor re-arms: nutzer - Nutzer banner no longer skipped
- v5-visual.spec.ts nutzer baselines re-arm: nutzer marble_light and void no longer fixme
- CI Playwright run confirms the nutzer screen renders