### PR TITLE
fix(v5): NutzerV5 hydration markers cleanup (v2 — rebased post-#648)

### DIFF
--- a/parkhub-web/e2e/v5-happy-paths.spec.ts
+++ b/parkhub-web/e2e/v5-happy-paths.spec.ts
@@ -126,13 +126,6 @@ const ANCHORS: Record<V5Screen, Anchor> = {
   },
   nutzer: {
     note: 'Nutzer banner',
-    // KNOWN BROKEN on github/main (a8fba08): NutzerV5 throws
-    // "h.filter is not a function" during hydration, the v5 shell never
-    // mounts and <header><h1> is never emitted. Bug lives in the screen
-    // component (not this test), so this anchor is correct as-written —
-    // we skip instead of tightening / relaxing. Raised in coverage PR so
-    // it's visible; fix is tracked separately.
-    // TODO: flip back to assert once NutzerV5 renders again.
     assert: async (p) =>
       expect(p.locator('main').getByText('Nutzer', { exact: true }).first()).toBeVisible(),
   },

--- a/parkhub-web/e2e/v5-visual.spec.ts
+++ b/parkhub-web/e2e/v5-visual.spec.ts
@@ -26,7 +26,8 @@ import { loginAsAdmin, openV5, V5_MODES, V5_SCREENS } from './v5-helpers';
 // blank PNGs — useless as a regression signal. Mirror set of the
 // v5-happy-paths KNOWN_BROKEN; fixme'd here so snapshot capture stays
 // no-op until the screen is repaired.
-const KNOWN_BROKEN = new Set<string>(['nutzer']);
+// nutzer was removed here after d91998c1 fixed the PaginatedResponse unwrap.
+const KNOWN_BROKEN = new Set<string>();
 
 test.describe('v5 visual regression', () => {
   test.beforeEach(async ({ page }, testInfo) => {


### PR DESCRIPTION
Supersedes #643. Rebased onto post-#648 main. Clears the stale KNOWN_BROKEN test markers for the NutzerV5 hydration bug that was already fixed on main as commit `d91998c1`.

Per E5 agent's phantom-finding analysis: the actual `h.filter is not a function` bug was fixed before this PR was authored. This PR clears the test-marker debt so the v5-visual regression suite re-arms and the v5-happy-paths TODO comment is removed.

Pushed via HTTPS (SSH from this flatpak sandbox has been dropping mid-push for parkhub-rust).