### PR TITLE
fix(ci): keep zizmor advisory without sarif upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,6 @@ on:
       - .github/ISSUE_TEMPLATE/**
       - .github/PULL_REQUEST_TEMPLATE.md
       - .github/agents/**
-  merge_group:
-    types: [checks_requested]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -222,7 +222,6 @@ jobs:
       - name: Install zizmor
         run: |
           python3 -m pip install --user --disable-pip-version-check 'zizmor==1.24.1'
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
       - name: Run zizmor
         continue-on-error: true
         run: |
@@ -231,7 +230,7 @@ jobs:
           # with .github/scripts/fop-local-ci.sh: offline, high-severity-only,
           # and scoped to workflow manifests so PR audits cannot hang on live
           # GitHub API checks.
-          zizmor \
+          python3 -m zizmor \
             --persona=auditor \
             --min-severity=high \
             --no-online-audits \
@@ -240,7 +239,7 @@ jobs:
             .gitea/workflows
       - name: Mark advisory success
         # Guarantee job conclusion = success regardless of zizmor exit code.
-        # continue-on-error at job level prevents the workflow from being
+        # continue-on-error on the advisory step prevents the workflow from being
         # blocked but does NOT change the individual job's check-run
         # conclusion (GitHub API behaviour, confirmed upstream). This step
         # runs unconditionally and always exits 0 so the check shows green.

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -219,26 +219,25 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
+      - name: Install zizmor
+        run: |
+          python3 -m pip install --user --disable-pip-version-check 'zizmor==1.24.1'
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
       - name: Run zizmor
-        uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3
         continue-on-error: true
-        with:
+        run: |
           # auditor persona surfaces low-severity findings useful for hardening
           # without flooding the PR with regular-user noise. Keep this aligned
           # with .github/scripts/fop-local-ci.sh: offline, high-severity-only,
           # and scoped to workflow manifests so PR audits cannot hang on live
           # GitHub API checks.
-          inputs: .github/workflows .gitea/workflows
-          persona: auditor
-          online-audits: false
-          min-severity: high
-          # Keep the repository selected-actions allowlist tight. The action's
-          # default Advanced Security path invokes github/codeql-action/upload-sarif
-          # internally, which is intentionally not allowlisted for this advisory
-          # job. Annotation mode still surfaces findings in PRs without granting
-          # security-events: write.
-          advanced-security: false
-          annotations: true
+          zizmor \
+            --persona=auditor \
+            --min-severity=high \
+            --no-online-audits \
+            --format=github \
+            .github/workflows \
+            .gitea/workflows
       - name: Mark advisory success
         # Guarantee job conclusion = success regardless of zizmor exit code.
         # continue-on-error at job level prevents the workflow from being

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -215,7 +215,6 @@ jobs:
     # inventory has been triaged and a .zizmor.yaml baseline is committed.
     permissions:
       contents: read  # checkout
-      security-events: write  # upload SARIF (when enabled by zizmor-action)
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -233,6 +232,13 @@ jobs:
           persona: auditor
           online-audits: false
           min-severity: high
+          # Keep the repository selected-actions allowlist tight. The action's
+          # default Advanced Security path invokes github/codeql-action/upload-sarif
+          # internally, which is intentionally not allowlisted for this advisory
+          # job. Annotation mode still surfaces findings in PRs without granting
+          # security-events: write.
+          advanced-security: false
+          annotations: true
       - name: Mark advisory success
         # Guarantee job conclusion = success regardless of zizmor exit code.
         # continue-on-error at job level prevents the workflow from being

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6424,9 +6424,9 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.79"
+version = "0.10.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf0b434746ee2832f4f0baf10137e1cabb18cbe6912c69e2e33263c45250f542"
+checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
 dependencies = [
  "bitflags 2.11.1",
  "cfg-if",
@@ -6470,9 +6470,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.115"
+version = "0.9.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "158fe5b292746440aa6e7a7e690e55aeb72d41505e2804c23c6973ad0e9c9781"
+checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
 dependencies = [
  "cc",
  "libc",

--- a/parkhub-server/fuzz/Cargo.lock
+++ b/parkhub-server/fuzz/Cargo.lock
@@ -2962,9 +2962,9 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl"
-version = "0.10.79"
+version = "0.10.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf0b434746ee2832f4f0baf10137e1cabb18cbe6912c69e2e33263c45250f542"
+checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -3008,9 +3008,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.115"
+version = "0.9.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "158fe5b292746440aa6e7a7e690e55aeb72d41505e2804c23c6973ad0e9c9781"
+checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
 dependencies = [
  "cc",
  "libc",


### PR DESCRIPTION
## Summary
- switch the advisory Zizmor job to annotation mode with advanced-security disabled
- remove the hidden upload-sarif dependency from the Zizmor action path so selected-actions can stay tight
- remove the duplicate merge_group trigger from CI after Zizmor reported the parse warning

## Verification
- NO_COLOR=true fop build --backend local . --resource-profile interactive-small --preset custom -- bash scripts/check-ci-workflow-policy.sh
- NO_COLOR=true fop build --backend local . --resource-profile interactive-small --preset custom -- zizmor --persona=auditor --min-severity=high --no-online-audits .github/workflows .gitea/workflows
- NO_COLOR=true fop build --backend local . --resource-profile interactive-small --preset custom -- actionlint .github/workflows/ci.yml .github/workflows/security.yml
- git diff --check

## Notes
- This keeps Zizmor advisory-only and avoids relaxing the repository allowed-actions policy for github/codeql-action/upload-sarif.
- Source references: zizmor-action supports advanced-security=false + annotations=true; GitHub SARIF upload requires github/codeql-action/upload-sarif.