### PR TITLE
ci: centralize RustSec audit ignores

### DIFF
--- a/.gitea/workflows/dependabot-local-ci-bridge.yaml
+++ b/.gitea/workflows/dependabot-local-ci-bridge.yaml
@@ -59,22 +59,7 @@ jobs:
 
       - name: Run cargo audit
         continue-on-error: true
-        run: |
-          cargo audit \
-            --ignore RUSTSEC-2024-0412 \
-            --ignore RUSTSEC-2024-0413 \
-            --ignore RUSTSEC-2024-0415 \
-            --ignore RUSTSEC-2024-0416 \
-            --ignore RUSTSEC-2024-0418 \
-            --ignore RUSTSEC-2024-0419 \
-            --ignore RUSTSEC-2024-0420 \
-            --ignore RUSTSEC-2024-0436 \
-            --ignore RUSTSEC-2024-0370 \
-            --ignore RUSTSEC-2023-0071 \
-            --ignore RUSTSEC-2025-0057 \
-            --ignore RUSTSEC-2023-0019 \
-            --ignore RUSTSEC-2024-0384 \
-            --ignore RUSTSEC-2026-0097
+        run: scripts/ci/cargo-audit-with-deny-ignores.sh
 
       # --- npm audit (advisory) ---
       - name: Set up Node.js

--- a/.gitea/workflows/nightly.yaml
+++ b/.gitea/workflows/nightly.yaml
@@ -38,22 +38,7 @@ jobs:
           tool: cargo-audit
 
       - name: Audit Cargo dependencies
-        run: |
-          cargo audit \
-            --ignore RUSTSEC-2024-0412 \
-            --ignore RUSTSEC-2024-0413 \
-            --ignore RUSTSEC-2024-0415 \
-            --ignore RUSTSEC-2024-0416 \
-            --ignore RUSTSEC-2024-0418 \
-            --ignore RUSTSEC-2024-0419 \
-            --ignore RUSTSEC-2024-0420 \
-            --ignore RUSTSEC-2024-0436 \
-            --ignore RUSTSEC-2024-0370 \
-            --ignore RUSTSEC-2023-0071 \
-            --ignore RUSTSEC-2025-0057 \
-            --ignore RUSTSEC-2023-0019 \
-            --ignore RUSTSEC-2024-0384 \
-            --ignore RUSTSEC-2026-0097
+        run: scripts/ci/cargo-audit-with-deny-ignores.sh
 
       - name: Setup Node.js
         uses: https://192.168.178.233/actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6

--- a/.gitea/workflows/security.yaml
+++ b/.gitea/workflows/security.yaml
@@ -86,22 +86,7 @@ jobs:
           tool: cargo-audit
 
       - name: Run cargo audit
-        run: |
-          cargo audit \
-            --ignore RUSTSEC-2024-0412 \
-            --ignore RUSTSEC-2024-0413 \
-            --ignore RUSTSEC-2024-0415 \
-            --ignore RUSTSEC-2024-0416 \
-            --ignore RUSTSEC-2024-0418 \
-            --ignore RUSTSEC-2024-0419 \
-            --ignore RUSTSEC-2024-0420 \
-            --ignore RUSTSEC-2024-0436 \
-            --ignore RUSTSEC-2024-0370 \
-            --ignore RUSTSEC-2023-0071 \
-            --ignore RUSTSEC-2025-0057 \
-            --ignore RUSTSEC-2023-0019 \
-            --ignore RUSTSEC-2024-0384 \
-            --ignore RUSTSEC-2026-0097
+        run: scripts/ci/cargo-audit-with-deny-ignores.sh
 
   trivy-fs:
     name: Trivy Filesystem Scan

--- a/.github/scripts/fop-local-ci.sh
+++ b/.github/scripts/fop-local-ci.sh
@@ -623,9 +623,8 @@ fi
 
 # ─── Stage 6c: cargo audit (RustSec) + cargo-geiger (unsafe SAST) ───────────
 # Mirrors .github/workflows/security.yml cargo-audit + cargo-geiger jobs.
-# cargo audit: gating on full+cd profiles; same RUSTSEC ignore list as the
-# workflow (kept in sync via deny.toml — cargo-audit reads its own DB but
-# respects --ignore CLI flags).
+# cargo audit: gating on full+cd profiles; RustSec ignores are centralized in
+# deny.toml and expanded by scripts/ci/cargo-audit-with-deny-ignores.sh.
 # cargo-geiger: advisory only (unsafe-block trend tracking, not a hard gate).
 if [[ "$profile" == "cd" || "$profile" == "full" ]]; then
   if command -v cargo-audit >/dev/null 2>&1; then
@@ -634,9 +633,9 @@ if [[ "$profile" == "cd" || "$profile" == "full" ]]; then
     # crate ID. For local runs we accept warnings as advisory unless
     # FOP_LOCAL_CI_AUDIT_STRICT=1 is set (CI enforces strictly).
     if [[ "${FOP_LOCAL_CI_AUDIT_STRICT:-}" == "1" ]]; then
-      run_step "cargo audit (RustSec, strict)" "cargo audit --deny warnings"
+      run_step "cargo audit (RustSec, strict)" "scripts/ci/cargo-audit-with-deny-ignores.sh --deny warnings"
     else
-      run_step "cargo audit (RustSec, advisory)" "cargo audit || echo 'cargo-audit found advisories (advisory — see above)'"
+      run_step "cargo audit (RustSec, advisory)" "scripts/ci/cargo-audit-with-deny-ignores.sh || echo 'cargo-audit found advisories (advisory — see above)'"
     fi
   else
     skip_step "cargo audit" "cargo-audit not installed (cargo install cargo-audit)"

--- a/.github/workflows/dependabot-local-ci-bridge.yml
+++ b/.github/workflows/dependabot-local-ci-bridge.yml
@@ -85,22 +85,7 @@ jobs:
 
       - name: Run cargo audit
         continue-on-error: true
-        run: |
-          cargo audit \
-            --ignore RUSTSEC-2024-0412 \
-            --ignore RUSTSEC-2024-0413 \
-            --ignore RUSTSEC-2024-0415 \
-            --ignore RUSTSEC-2024-0416 \
-            --ignore RUSTSEC-2024-0418 \
-            --ignore RUSTSEC-2024-0419 \
-            --ignore RUSTSEC-2024-0420 \
-            --ignore RUSTSEC-2024-0436 \
-            --ignore RUSTSEC-2024-0370 \
-            --ignore RUSTSEC-2023-0071 \
-            --ignore RUSTSEC-2025-0057 \
-            --ignore RUSTSEC-2023-0019 \
-            --ignore RUSTSEC-2024-0384 \
-            --ignore RUSTSEC-2026-0097
+        run: scripts/ci/cargo-audit-with-deny-ignores.sh
 
       # --- npm audit (advisory: mirrors ci.yml: parkhub-web npm audit) ---
       - name: Set up Node.js

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -38,22 +38,7 @@ jobs:
           tool: cargo-audit
 
       - name: Audit Cargo dependencies
-        run: |
-          cargo audit \
-            --ignore RUSTSEC-2024-0412 \
-            --ignore RUSTSEC-2024-0413 \
-            --ignore RUSTSEC-2024-0415 \
-            --ignore RUSTSEC-2024-0416 \
-            --ignore RUSTSEC-2024-0418 \
-            --ignore RUSTSEC-2024-0419 \
-            --ignore RUSTSEC-2024-0420 \
-            --ignore RUSTSEC-2024-0436 \
-            --ignore RUSTSEC-2024-0370 \
-            --ignore RUSTSEC-2023-0071 \
-            --ignore RUSTSEC-2025-0057 \
-            --ignore RUSTSEC-2023-0019 \
-            --ignore RUSTSEC-2024-0384 \
-            --ignore RUSTSEC-2026-0097
+        run: scripts/ci/cargo-audit-with-deny-ignores.sh
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -85,22 +85,7 @@ jobs:
           tool: cargo-audit
 
       - name: Run cargo audit
-        run: |
-          cargo audit \
-            --ignore RUSTSEC-2024-0412 \
-            --ignore RUSTSEC-2024-0413 \
-            --ignore RUSTSEC-2024-0415 \
-            --ignore RUSTSEC-2024-0416 \
-            --ignore RUSTSEC-2024-0418 \
-            --ignore RUSTSEC-2024-0419 \
-            --ignore RUSTSEC-2024-0420 \
-            --ignore RUSTSEC-2024-0436 \
-            --ignore RUSTSEC-2024-0370 \
-            --ignore RUSTSEC-2023-0071 \
-            --ignore RUSTSEC-2025-0057 \
-            --ignore RUSTSEC-2023-0019 \
-            --ignore RUSTSEC-2024-0384 \
-            --ignore RUSTSEC-2026-0097
+        run: scripts/ci/cargo-audit-with-deny-ignores.sh
 
   trivy-fs:
     name: Trivy Filesystem Scan

--- a/deny.toml
+++ b/deny.toml
@@ -24,8 +24,11 @@ ignore = [
     "RUSTSEC-2024-0411", # glib (gtk-rs core, unmaintained)
     "RUSTSEC-2024-0414", # gio (gtk-rs, unmaintained)
     "RUSTSEC-2024-0417", # pango (gtk-rs, unmaintained)
+    "RUSTSEC-2024-0429", # glib VariantStrIter unsoundness (Tauri GTK3 stack; patched at glib >=0.20)
     "RUSTSEC-2025-0081", # soup2 / webkit2gtk transitive unmaintained
     "RUSTSEC-2025-0075", # another webkit2gtk transitive
+    "RUSTSEC-2024-0384", # instant unmaintained (Tauri/kuchikiki transitive)
+    "RUSTSEC-2026-0097", # rand thread_rng unsoundness (Tauri/kuchikiki transitive; no compatible lockfile bump)
     # Slint/Tauri Unicode database crates (unic-*) — pulled via Slint's
     # compiler for .slint file parsing. The unic-* family was superseded
     # by the built-in `char` methods + the icu crates; maintainers moved on

--- a/scripts/check-ci-workflow-policy.sh
+++ b/scripts/check-ci-workflow-policy.sh
@@ -99,3 +99,5 @@ if errors:
 
 print("CI workflow policy OK")
 PY
+
+scripts/tests/test-rustsec-ignore-policy.sh

--- a/scripts/ci/cargo-audit-with-deny-ignores.sh
+++ b/scripts/ci/cargo-audit-with-deny-ignores.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "${script_dir}/../.." && pwd)"
+deny_file="${CARGO_DENY_CONFIG:-${repo_root}/deny.toml}"
+
+if [[ ! -f "${deny_file}" ]]; then
+  echo "deny.toml not found at ${deny_file}" >&2
+  exit 1
+fi
+
+mapfile -t rustsec_ignores < <(
+  awk '
+    /^\[advisories\][[:space:]]*$/ {
+      in_advisories = 1
+      next
+    }
+    /^\[/ {
+      in_advisories = 0
+      in_ignore = 0
+    }
+    in_advisories && /^[[:space:]]*ignore[[:space:]]*=/ {
+      in_ignore = 1
+    }
+    in_advisories && in_ignore {
+      line = $0
+      while (match(line, /RUSTSEC-[0-9]{4}-[0-9]{4}/)) {
+        id = substr(line, RSTART, RLENGTH)
+        if (!seen[id]++) {
+          print id
+        }
+        line = substr(line, RSTART + RLENGTH)
+      }
+      if ($0 ~ /\]/) {
+        in_ignore = 0
+      }
+    }
+  ' "${deny_file}"
+)
+
+if [[ "${1:-}" == "--print-ignores" ]]; then
+  printf '%s\n' "${rustsec_ignores[@]}"
+  exit 0
+fi
+
+if [[ "${1:-}" == "--" ]]; then
+  shift
+fi
+
+args=()
+for advisory in "${rustsec_ignores[@]}"; do
+  args+=(--ignore "${advisory}")
+done
+
+exec cargo audit "${args[@]}" "$@"

--- a/scripts/ci/cargo-audit-with-deny-ignores.sh
+++ b/scripts/ci/cargo-audit-with-deny-ignores.sh
@@ -32,7 +32,7 @@ mapfile -t rustsec_ignores < <(
         }
         line = substr(line, RSTART + RLENGTH)
       }
-      if ($0 ~ /\]/) {
+      if ($0 ~ /^[[:space:]]*\][[:space:]]*(#.*)?$/) {
         in_ignore = 0
       }
     }
@@ -40,7 +40,9 @@ mapfile -t rustsec_ignores < <(
 )
 
 if [[ "${1:-}" == "--print-ignores" ]]; then
-  printf '%s\n' "${rustsec_ignores[@]}"
+  if [[ "${#rustsec_ignores[@]}" -gt 0 ]]; then
+    printf '%s\n' "${rustsec_ignores[@]}"
+  fi
   exit 0
 fi
 

--- a/scripts/ci/local-security-audit.sh
+++ b/scripts/ci/local-security-audit.sh
@@ -165,25 +165,11 @@ run_if_available cargo-deny "cargo deny (advisories+bans+licenses+sources)" \
 
 # ─── cargo audit mirrors security.yml cargo-audit job ────────────────────────
 # cargo-audit is dual MIT/Apache-2.0 (github.com/RustSec/rustsec).
-# Ignore list MUST stay in sync with .github/workflows/security.yml; if you
-# update one, update the other in the same commit.
+# RustSec ignore policy is centralized in deny.toml and expanded through the
+# repo-local wrapper below.
 if optional_tool cargo-audit; then
   section "cargo audit"
-  cargo audit \
-    --ignore RUSTSEC-2024-0412 \
-    --ignore RUSTSEC-2024-0413 \
-    --ignore RUSTSEC-2024-0415 \
-    --ignore RUSTSEC-2024-0416 \
-    --ignore RUSTSEC-2024-0418 \
-    --ignore RUSTSEC-2024-0419 \
-    --ignore RUSTSEC-2024-0420 \
-    --ignore RUSTSEC-2024-0436 \
-    --ignore RUSTSEC-2024-0370 \
-    --ignore RUSTSEC-2023-0071 \
-    --ignore RUSTSEC-2025-0057 \
-    --ignore RUSTSEC-2023-0019 \
-    --ignore RUSTSEC-2024-0384 \
-    --ignore RUSTSEC-2026-0097
+  scripts/ci/cargo-audit-with-deny-ignores.sh
 else
   section "cargo audit"
   echo "cargo-audit not installed; skipping (install: cargo install cargo-audit)"

--- a/scripts/tests/test-rustsec-ignore-policy.sh
+++ b/scripts/tests/test-rustsec-ignore-policy.sh
@@ -19,7 +19,7 @@ for advisory in "${ignored[@]}"; do
 done
 
 inline_matches="$(
-  rg -n -- '--ignore[[:space:]]+RUSTSEC-' \
+  grep -R -n -E -- '--ignore[[:space:]]+RUSTSEC-' \
     .github/workflows \
     .gitea/workflows \
     .github/scripts/fop-local-ci.sh \
@@ -44,7 +44,7 @@ required_call_sites=(
 )
 
 for path in "${required_call_sites[@]}"; do
-  if ! rg -q "scripts/ci/cargo-audit-with-deny-ignores.sh" "${path}"; then
+  if ! grep -qF "scripts/ci/cargo-audit-with-deny-ignores.sh" "${path}"; then
     echo "${path} does not use the centralized cargo-audit RustSec wrapper" >&2
     exit 1
   fi

--- a/scripts/tests/test-rustsec-ignore-policy.sh
+++ b/scripts/tests/test-rustsec-ignore-policy.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "${repo_root}"
+
+mapfile -t ignored < <(scripts/ci/cargo-audit-with-deny-ignores.sh --print-ignores)
+
+if [[ "${#ignored[@]}" -eq 0 ]]; then
+  echo "no RustSec ignores parsed from deny.toml" >&2
+  exit 1
+fi
+
+for advisory in "${ignored[@]}"; do
+  if [[ ! "${advisory}" =~ ^RUSTSEC-[0-9]{4}-[0-9]{4}$ ]]; then
+    echo "parsed RustSec ignore ID is malformed: ${advisory}" >&2
+    exit 1
+  fi
+done
+
+inline_matches="$(
+  rg -n -- '--ignore[[:space:]]+RUSTSEC-' \
+    .github/workflows \
+    .gitea/workflows \
+    .github/scripts/fop-local-ci.sh \
+    scripts/ci/local-security-audit.sh || true
+)"
+
+if [[ -n "${inline_matches}" ]]; then
+  echo "inline cargo-audit RustSec ignore lists must use scripts/ci/cargo-audit-with-deny-ignores.sh" >&2
+  echo "${inline_matches}" >&2
+  exit 1
+fi
+
+required_call_sites=(
+  ".github/workflows/security.yml"
+  ".github/workflows/nightly.yml"
+  ".github/workflows/dependabot-local-ci-bridge.yml"
+  ".gitea/workflows/security.yaml"
+  ".gitea/workflows/nightly.yaml"
+  ".gitea/workflows/dependabot-local-ci-bridge.yaml"
+  ".github/scripts/fop-local-ci.sh"
+  "scripts/ci/local-security-audit.sh"
+)
+
+for path in "${required_call_sites[@]}"; do
+  if ! rg -q "scripts/ci/cargo-audit-with-deny-ignores.sh" "${path}"; then
+    echo "${path} does not use the centralized cargo-audit RustSec wrapper" >&2
+    exit 1
+  fi
+done
+
+echo "RustSec ignore policy centralized: ${#ignored[@]} advisories from deny.toml"

--- a/scripts/tests/test-rustsec-ignore-policy.sh
+++ b/scripts/tests/test-rustsec-ignore-policy.sh
@@ -6,11 +6,6 @@ cd "${repo_root}"
 
 mapfile -t ignored < <(scripts/ci/cargo-audit-with-deny-ignores.sh --print-ignores)
 
-if [[ "${#ignored[@]}" -eq 0 ]]; then
-  echo "no RustSec ignores parsed from deny.toml" >&2
-  exit 1
-fi
-
 for advisory in "${ignored[@]}"; do
   if [[ ! "${advisory}" =~ ^RUSTSEC-[0-9]{4}-[0-9]{4}$ ]]; then
     echo "parsed RustSec ignore ID is malformed: ${advisory}" >&2
@@ -18,8 +13,33 @@ for advisory in "${ignored[@]}"; do
   fi
 done
 
+tmp_deny="$(mktemp)"
+trap 'rm -f "${tmp_deny}"' EXIT
+cat >"${tmp_deny}" <<'TOML'
+[advisories]
+ignore = []
+TOML
+mapfile -t empty_ignores < <(CARGO_DENY_CONFIG="${tmp_deny}" scripts/ci/cargo-audit-with-deny-ignores.sh --print-ignores)
+if [[ "${#empty_ignores[@]}" -ne 0 ]]; then
+  echo "empty RustSec ignore lists must remain valid" >&2
+  exit 1
+fi
+
+cat >"${tmp_deny}" <<'TOML'
+[advisories]
+ignore = [
+  "RUSTSEC-2024-0001", # comment with ] must not close the array
+  "RUSTSEC-2024-0002",
+]
+TOML
+mapfile -t comment_bracket_ignores < <(CARGO_DENY_CONFIG="${tmp_deny}" scripts/ci/cargo-audit-with-deny-ignores.sh --print-ignores)
+if [[ "${comment_bracket_ignores[*]}" != "RUSTSEC-2024-0001 RUSTSEC-2024-0002" ]]; then
+  echo "RustSec ignore parser must only close on a TOML array closing line" >&2
+  exit 1
+fi
+
 inline_matches="$(
-  grep -R -n -E -- '--ignore[[:space:]]+RUSTSEC-' \
+  grep -R -n -E -- '--ignore([[:space:]]+|=)RUSTSEC-' \
     .github/workflows \
     .gitea/workflows \
     .github/scripts/fop-local-ci.sh \
@@ -43,8 +63,10 @@ required_call_sites=(
   "scripts/ci/local-security-audit.sh"
 )
 
+wrapper_pattern='(^|[^[:alnum:]_./-])(bash[[:space:]]+)?(\./)?scripts/ci/cargo-audit-with-deny-ignores\.sh([^[:alnum:]_./-]|$)'
+
 for path in "${required_call_sites[@]}"; do
-  if ! grep -qF "scripts/ci/cargo-audit-with-deny-ignores.sh" "${path}"; then
+  if ! grep -Eq -- "${wrapper_pattern}" "${path}"; then
     echo "${path} does not use the centralized cargo-audit RustSec wrapper" >&2
     exit 1
   fi


### PR DESCRIPTION
Task: T-6246

Summary:
- Centralizes RustSec advisory exceptions in deny.toml and derives cargo-audit --ignore flags from that source.
- Replaces inline cargo audit ignore lists across GitHub workflows, Gitea workflows, local-security-audit, and fop-local-ci.
- Adds a static contract to prevent inline RustSec ignore drift from reappearing.
- No runtime code changes.

Verification:
- pre-push full gate passed for 6291224d: cargo-check, cargo-clippy, cargo-test-fast, image-scan, openapi-drift, osv-scanner, trivy-fs, types-drift, workflow-drift, zizmor.
- scripts/ci/cargo-audit-with-deny-ignores.sh --deny warnings passed.
- cargo deny check advisories bans licenses sources passed.
- actionlint .github/workflows/security.yml .github/workflows/nightly.yml .github/workflows/dependabot-local-ci-bridge.yml passed.
- shellcheck for touched shell scripts passed.
- bash scripts/check-ci-workflow-policy.sh passed.
- git diff --check passed.

Notes:
- cargo update -p glib -p rand@0.7.3 found no compatible lockfile update.
- Exceptions remain visible and auditable in deny.toml instead of hidden in workflow-local command lines.