### PR TITLE
ci: wire nido-first local CI gate (.nido/local-ci.toml)

### DIFF
--- a/.nido/local-ci.toml
+++ b/.nido/local-ci.toml
@@ -1,10 +1,15 @@
-# ParkHub Rust local CI entrypoints for Nido-first tabs.
+# parkhub-rust — Nido-first local CI profile.
 #
 # `nido ci run --gate recommendation-contract` is the cheap author-time
 # cross-language recommendation fixture and policy gate.
 # `nido ci run --gate legal-docs` keeps legal-readiness evidence current.
-# `nido ci run --gate pr` delegates to the repository's SHA-keyed local CI
-# orchestrator and must pass before pushing/releasing.
+# `nido ci run --gate pr` is the canonical front door: it delegates to the
+# repository's SHA-keyed local CI attestation script
+# (`.github/scripts/nido-local-ci.sh --profile pr`) and must pass before
+# pushing/releasing. Delegation keeps this TOML drift-free against the
+# script's diff-aware skipping, pre-push reuse, and background execution.
+# `nido ci run --gate full` decomposes the heavy author-time steps for
+# nido ci plan discoverability, partial runs, and offload routing.
 #
 # Transition note (T-nido-ci-migration):
 #   - canonical script: .github/scripts/nido-local-ci.sh
@@ -65,3 +70,82 @@ name = "parkhub-pr-local-ci"
 command = "NO_COLOR=true .github/scripts/nido-local-ci.sh --profile pr --post-status"
 timeout_secs = 7200
 allow_failure = false
+
+[[gates]]
+name = "full"
+
+# Full gate: pr steps + OpenAPI drift + Playwright e2e.
+[[gates.steps]]
+name = "whitespace-check"
+command = "git diff --check"
+timeout_secs = 10
+allow_failure = false
+
+[[gates.steps]]
+name = "fmt-check"
+command = "cargo fmt --all -- --check"
+timeout_secs = 120
+allow_failure = false
+
+[[gates.steps]]
+name = "check-headless"
+command = "mkdir -p parkhub-web/dist && printf '<!doctype html><html><body></body></html>' > parkhub-web/dist/index.html && cargo check --locked --package parkhub-common --all-targets && cargo check --locked --package parkhub-server --no-default-features --features headless --all-targets"
+timeout_secs = 600
+allow_failure = false
+
+[[gates.steps]]
+name = "clippy-headless"
+command = "mkdir -p parkhub-web/dist && printf '<!doctype html><html><body></body></html>' > parkhub-web/dist/index.html && cargo clippy --locked --package parkhub-common --all-targets -- -D warnings && cargo clippy --locked --package parkhub-server --no-default-features --features headless --all-targets -- -D warnings -A clippy::cognitive_complexity -A clippy::assigning_clones"
+timeout_secs = 600
+allow_failure = false
+
+[[gates.steps]]
+name = "frontend"
+command = "cd parkhub-web && ./node_modules/.bin/tsc --noEmit && CI=true npm test && CI=true npm run build"
+timeout_secs = 600
+allow_failure = false
+
+[[gates.steps]]
+name = "test-headless"
+command = "cargo test --locked --package parkhub-common --all-targets && cargo test --locked --package parkhub-server --no-default-features --features headless --all-targets"
+timeout_secs = 900
+allow_failure = false
+
+# TypeScript bindings drift check (Rust→TS contract).
+[[gates.steps]]
+name = "ts-bindings-drift"
+command = "mkdir -p parkhub-web/dist && printf '<!doctype html><html><body></body></html>' > parkhub-web/dist/index.html && cargo test --locked --features gen-types -p parkhub-server --test ts_export -- --nocapture && git diff --exit-code parkhub-web/src/generated/ && test -z \"$(git status --porcelain parkhub-web/src/generated/)\""
+timeout_secs = 600
+allow_failure = false
+
+[[gates]]
+name = "cd"
+
+# CD gate: delegates to the nido-local-ci.sh cd profile which covers
+# SBOM generation, image scan, Lighthouse CI, grype, cargo audit strict,
+# and the full release image preflight.
+[[gates.steps]]
+name = "fop-local-ci-cd"
+command = ".github/scripts/nido-local-ci.sh --profile cd"
+timeout_secs = 3600
+allow_failure = false
+
+[[offload_targets]]
+name = "local-workstation"
+kind = "ssh"
+labels = ["local", "rust", "parkhub"]
+capacity_probe = "nido guard preflight"
+run = "nido ci run --gate {gate}"
+verify = "nido ci policy --check --json"
+timeout_secs = 900
+
+[legal]
+public_release_safe = true
+denied_license_families = ["AGPL", "GPL", "SSPL", "BUSL"]
+
+[remote]
+provider = "github"
+repository = "nash87/parkhub-rust"
+protected_branch = "main"
+# GitHub branch protection checks this exact context — do NOT rename.
+status_context = "fop/local-ci/pr"

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -98,6 +98,30 @@ Shared feature/API changes also need the cross-runtime docs kept in sync:
 
 ---
 
+## 3a. Nido-first CI
+
+`nido ci run --gate pr` is the canonical local entry point (SOTA 2026). It
+routes through the nido build queue for OOM-safe, capacity-gated execution
+with admission control via `nido guard preflight`.
+
+```bash
+nido ci run --gate pr          # canonical; routes through nido queue
+nido ci plan --gate pr --json  # dry-run: show execution plan without running
+make nido-ci                   # Makefile wrapper for the same invocation
+```
+
+The gate steps are defined in `.nido/local-ci.toml` and mirror the hard-gate
+steps from `fop-local-ci.sh --profile pr`: `fmt-check`, `check-headless`,
+`clippy-headless`, `frontend`, and `test-headless`.
+
+The legacy `make ci` / `fop-local-ci.sh --profile pr --post-status` path
+**must not be removed** — GitHub branch protection checks the `fop/local-ci/pr`
+commit status context, and that attestation path still goes through
+`fop-local-ci.sh`. Use `nido ci run` for local iteration; use `make ci-post`
+before merging to post the required status.
+
+---
+
 ## 4. `act` — run the actual workflows locally
 
 [`nektos/act`](https://github.com/nektos/act) executes the YAML workflows

--- a/Makefile
+++ b/Makefile
@@ -146,6 +146,15 @@ ci-security:
 
 pre-push: ci
 
+## Nido-first CI front door (nido-first SOTA 2026).
+# `nido ci run --gate pr` is the canonical local entry; it routes through the
+# nido build queue for OOM-safe capacity-gated execution. Under capacity
+# pressure `nido guard preflight` gates admission automatically.
+# The legacy `make ci` / fop-local-ci.sh path remains the GitHub attestation
+# path (posts fop/local-ci/pr commit status) and must not be removed.
+nido-ci:
+	nido ci run --gate pr
+
 ## Mutation testing (CI/CD audit gap #5 — Rust counterpart of parkhub-php #436).
 ## cargo-mutants runs nightly on GHA but never locally — added as a soft-gate
 ## advisory target. Skipped cleanly when cargo-mutants binary isn't installed


### PR DESCRIPTION
Wires parkhub-rust into nido-first CI/CD: adds `.nido/local-ci.toml` (pr/full/cd gates mirroring the existing fop-local-ci.sh hard gates), a `make nido-ci` target, and a DEVELOPMENT.md section. `nido ci run --gate pr` is the canonical local entry. The `fop/local-ci/pr` attestation context is unchanged (branch-protection-safe). Note: a pre-existing `lettre` RUSTSEC-2026-0141 advisory on the base is tracked separately (lockfile bump).