### PR TITLE
docs: professionalize public docs, adopt spec-kit, scrub internal Gitea leak

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -25,3 +25,16 @@ body:
         - UI/UX improvement
         - Documentation
         - DevOps/CI
+  - type: checkboxes
+    id: spec
+    attributes:
+      label: Spec-driven development
+      description: For non-trivial features, a spec file helps align on requirements before implementation begins. See [specs/README.md](../specs/README.md).
+      options:
+        - label: I have created or will create a spec file at `specs/<feature-id>/spec.md` before the PR is opened
+  - type: input
+    id: spec_link
+    attributes:
+      label: Link to spec (optional)
+      description: Link to an existing `specs/<feature-id>/spec.md` draft PR or file, if already written.
+      placeholder: "https://github.com/nash87/parkhub-rust/blob/…/specs/…/spec.md"

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -22,6 +22,10 @@
 - [ ] User input is validated before use
 - [ ] No new `unsafe` blocks without justification
 
+## Spec reference
+<!-- If this implements a non-trivial feature: link to specs/<feature-id>/spec.md or docs/plans/<plan>.md -->
+<!-- Small fixes and doc changes do not need a spec. -->
+
 ## Checklist
 - [ ] Code follows project style (Rust fmt, no Clippy warnings, pedantic + nursery)
 - [ ] Documentation updated if needed (docs/, README.md)

--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -1,0 +1,114 @@
+---
+version: "1.0"
+project: parkhub-rust
+last_reviewed: 2026-06-09
+status: active
+---
+
+# ParkHub Rust — Engineering Constitution
+
+This file captures the binding engineering principles for the ParkHub Rust project.
+It is the authoritative reference for spec authoring, PR review, and agent guidance.
+Update this file when a principle changes; treat its contents as law until changed.
+
+---
+
+## What this project is
+
+ParkHub Rust is a self-hosted, single-binary parking management server written in
+Rust (Axum + redb). It ships as one executable with embedded React/Astro frontend,
+zero external runtime dependencies, optional AES-256-GCM database encryption, and
+full GDPR compliance by design.
+
+---
+
+## Non-negotiable boundaries
+
+These are the "we never do" rules. A spec or PR that crosses any of these lines
+must be rejected or escalated, regardless of other merit.
+
+### Security
+
+- **No `unsafe` without documented justification.** Every `unsafe` block must carry
+  an inline comment explaining why it is correct and why it is the only option.
+- **All passwords hashed with Argon2id + OsRng.** Never `bcrypt`, `scrypt`, or a
+  fixed-cost scheme. No MD5/SHA1 for passwords.
+- **Secrets via environment variables or Vault.** No secrets in source, config files,
+  or test fixtures committed to the repo.
+- **Constant-time comparisons for tokens.** Use the `subtle` crate. No `==` on bearer
+  tokens or HMAC digests.
+- **No new `openssl` dependencies.** All TLS via `rustls`; all crypto via audited
+  pure-Rust crates.
+- **Security issues go through the private advisory process** (SECURITY.md), never
+  through public GitHub issues.
+
+### Data and compliance
+
+- **No third-party data processors by default.** The default build sends no data
+  outside the operator's server. Features that contact external services (OAuth, Stripe,
+  SMTP, webhooks) are gated behind explicit configuration and documented as processors.
+- **GDPR user rights must be preserved.** Every data model change must be reviewed
+  against Article 15–22 (access, rectification, erasure, portability). See docs/GDPR.md.
+- **Audit log is append-only.** No handler may delete or redact audit log entries.
+
+### Architecture
+
+- **Single-binary contract.** The default headless server (`--no-default-features
+  --features headless`) must build with no external services, no migrations, and no
+  network egress. A bare `./parkhub-server --headless --unattended` must reach a
+  healthy state with zero external calls.
+- **OpenAPI spec is source of truth.** `docs/openapi/rust.json` must stay in sync with
+  the running server. The `make drift` gate enforces this; never suppress it.
+- **No SQL injection surface.** The database layer is redb (key-value). Any future SQL
+  integration must use parameterized queries exclusively.
+- **Feature flags over conditional compilation.** New optional functionality belongs
+  behind a `mod-*` Cargo feature, not a runtime switch that always compiles in.
+
+### API and parity
+
+- **Backwards-compatible minor versions.** Breaking API changes require a
+  `PROTOCOL_VERSION` bump in `parkhub-common/src/lib.rs` and a clear migration note.
+- **PHP parity gate.** Any endpoint added or changed in parkhub-rust must be reviewed
+  against `docs/openapi-parity.md` and either replicated in parkhub-php or explicitly
+  documented as Rust-only with a parity ticket.
+
+### Code quality
+
+- **Zero Clippy warnings in CI.** The pedantic + nursery profile. No `#[allow]`
+  without an explanatory comment.
+- **Every public API function has a doc comment.** Undocumented public functions
+  block the `cargo doc` step.
+- **Tests for every new code path.** PRs adding functionality without tests will be
+  asked to add coverage before merge. Unit tests in the module, integration tests in
+  `integration_tests.rs`.
+
+### Contributor experience
+
+- **External contributors can build without the homelab toolchain.** `fop` is an
+  optional build accelerator, not a requirement. `./scripts/fop-wrap.sh` provides the
+  safe public surface; bare `cargo` and `npm` must always work.
+- **No internal infrastructure details in public docs.** No private IPs, no operator
+  usernames, no internal hostnames in any committed file.
+
+---
+
+## How to update this constitution
+
+Open a PR with `docs(constitution):` prefix. The PR must include:
+1. The changed principle and a rationale
+2. Any spec or code that needs to be updated as a consequence
+3. A review by at least one maintainer
+
+---
+
+## Relationship to other governance files
+
+| File | Role |
+|------|------|
+| `CONTRIBUTING.md` | Contributor workflow (how to contribute, not what to build) |
+| `AGENTS.md` | Agent-facing build commands and CI gates |
+| `docs/parity-governance.md` | Cross-runtime ownership and parity rules |
+| `docs/openapi-parity.md` | Endpoint-level parity tracking |
+| `docs/release-checklist.md` | Release gate discipline |
+| `SECURITY.md` | Disclosure policy and supported versions |
+| `specs/<feature-id>/` | Per-feature requirements, design, and tasks |

--- a/.specify/templates/plan.md
+++ b/.specify/templates/plan.md
@@ -1,0 +1,116 @@
+---
+id: "{{feature-id}}"
+title: "{{Feature Title}}"
+type: plan
+status: draft
+spec: "specs/{{feature-id}}/spec.md"
+created: {{YYYY-MM-DD}}
+author: "@{{github-handle}}"
+nido_task: "T-{{task-id}}"
+---
+
+# Plan: {{Feature Title}}
+
+> **What this is:** Technical design and architecture decisions.
+> The spec (what and why) lives in `spec.md`. This doc covers how.
+
+---
+
+## Summary
+
+<!-- Two to four sentences: what we are building, the key trade-off chosen, and why. -->
+
+---
+
+## Architecture
+
+### Affected crates
+
+<!-- Which crates change? What new crates or dependencies are required? -->
+
+| Crate | Change type | Notes |
+|-------|-------------|-------|
+| `parkhub-common` | | |
+| `parkhub-server` | | |
+| `parkhub-web` | | |
+
+### New dependencies
+
+<!-- List any new Cargo or npm dependencies. For each: why it was chosen over alternatives,
+     license (must be MIT/Apache-2.0 compatible — see deny.toml), and audit status.
+     Zero new dependencies is always preferable. -->
+
+| Dep | Version | License | Rationale |
+|-----|---------|---------|-----------|
+
+### Data model
+
+<!-- New redb tables, changed key or value schemas, migration path if any.
+     Remember: adding a table is safe; removing or renaming requires a migration helper in db.rs. -->
+
+### API surface
+
+<!-- New or changed endpoints. Follow the utoipa annotation pattern.
+     For each: method, path, auth tier required, request/response types. -->
+
+| Method | Path | Auth | Request | Response |
+|--------|------|------|---------|----------|
+
+OpenAPI parity review (per `docs/openapi-parity.md`):
+- [ ] Endpoints are matched in parkhub-php OR documented as Rust-only with a parity ticket
+
+### Feature flags
+
+<!-- Is this behind a `mod-*` Cargo feature? Which one?
+     Default-on or opt-in? -->
+
+### Frontend
+
+<!-- React components added or changed.
+     ts-rs types impacted?
+     Accessibility checklist: aria-label, keyboard nav, contrast. -->
+
+---
+
+## Implementation sequence
+
+<!-- Order matters. List the logical implementation phases.
+     Each phase should be independently testable. -->
+
+1.
+2.
+3.
+
+---
+
+## Testing strategy
+
+<!-- Unit tests: what modules/functions.
+     Integration tests: which scenarios in integration_tests.rs.
+     Vitest: which components/views.
+     E2E: new Playwright specs if applicable. -->
+
+---
+
+## Rollback plan
+
+<!-- How do we revert if this ships with a critical bug?
+     Rust: feature flag toggle? config env var guard?
+     DB schema: forward-compatible? migration reversible? -->
+
+---
+
+## Open questions
+
+<!-- Outstanding design decisions that still need resolution. -->
+
+| # | Question | Decision | Date |
+|---|----------|----------|------|
+
+---
+
+## References
+
+- Spec: [spec.md](spec.md)
+- OpenAPI parity: [docs/openapi-parity.md](../../docs/openapi-parity.md)
+- Release checklist: [docs/release-checklist.md](../../docs/release-checklist.md)

--- a/.specify/templates/spec.md
+++ b/.specify/templates/spec.md
@@ -1,0 +1,88 @@
+---
+id: "{{feature-id}}"
+title: "{{Feature Title}}"
+type: spec
+status: draft
+created: {{YYYY-MM-DD}}
+author: "@{{github-handle}}"
+nido_task: "T-{{task-id}}"
+---
+
+# Spec: {{Feature Title}}
+
+> **What this is:** Requirements and user stories. No implementation details here — that belongs in `plan.md`.
+
+---
+
+## Problem statement
+
+<!-- One paragraph. What user pain or gap does this address? Be concrete.
+     Good: "An operator with 300 users cannot identify which slots are under-utilised across a 7-day window."
+     Bad:  "The analytics need to be improved." -->
+
+---
+
+## Goals
+
+<!-- Numbered list of outcomes this feature must achieve.
+     Each goal must be testable — if you cannot write an acceptance criterion for it, it is not a goal. -->
+
+1.
+2.
+3.
+
+## Non-goals
+
+<!-- What this spec explicitly does NOT cover. Prevents scope creep. -->
+
+-
+
+---
+
+## User stories
+
+<!-- Format: As a <role>, I want <capability>, so that <outcome>.
+     Roles: user, premium, admin, superadmin, operator (self-hoster). -->
+
+| # | As a… | I want… | So that… | Priority |
+|---|-------|---------|----------|----------|
+| U1 | | | | Must |
+| U2 | | | | Should |
+
+---
+
+## Acceptance criteria
+
+<!-- Concrete, binary. Each criterion maps to a test.
+     Prefer: "Given X, when Y, then Z." -->
+
+- [ ] AC1:
+- [ ] AC2:
+
+---
+
+## Constraints
+
+<!-- Existing constraints that bound the implementation.
+     Examples: must work without SMTP, must not add a new Cargo dependency,
+     must preserve backward compatibility with v4.x API clients. -->
+
+-
+
+---
+
+## Open questions
+
+<!-- Unresolved design questions that need an answer before work starts. -->
+
+| # | Question | Owner | Due |
+|---|----------|-------|-----|
+| Q1 | | | |
+
+---
+
+## References
+
+<!-- Links to related issues, PRs, docs, or external standards. -->
+
+-

--- a/.specify/templates/tasks.md
+++ b/.specify/templates/tasks.md
@@ -1,0 +1,87 @@
+---
+id: "{{feature-id}}"
+title: "{{Feature Title}}"
+type: tasks
+status: draft
+plan: "specs/{{feature-id}}/plan.md"
+created: {{YYYY-MM-DD}}
+author: "@{{github-handle}}"
+nido_task: "T-{{task-id}}"
+---
+
+# Tasks: {{Feature Title}}
+
+> **What this is:** Dependency-ordered, acceptance-criteria-linked task list.
+> Each task should be completable in a single PR or a short working session.
+
+---
+
+## Status legend
+
+| Symbol | Meaning |
+|--------|---------|
+| `[ ]` | Not started |
+| `[~]` | In progress |
+| `[x]` | Done |
+| `[-]` | Skipped / deferred |
+
+---
+
+## Task list
+
+### Phase 1: Foundation
+
+- [ ] **T1** — {{Description}}
+  - AC: {{Acceptance criterion from spec.md}}
+  - Blocks: T2, T3
+  - Estimate: S / M / L
+  - Branch: `feature/{{feature-id}}-t1`
+
+- [ ] **T2** — {{Description}}
+  - AC: {{Acceptance criterion}}
+  - Depends on: T1
+  - Estimate: S / M / L
+
+### Phase 2: Feature
+
+- [ ] **T3** — {{Description}}
+  - AC: {{Acceptance criterion}}
+  - Depends on: T1
+  - Estimate: S / M / L
+
+### Phase 3: Polish
+
+- [ ] **T4** — Add / update OpenAPI annotations and run `make drift`
+  - AC: `make drift` exits 0; `docs/openapi/rust.json` committed
+  - Depends on: T3
+
+- [ ] **T5** — Write or update Vitest + Playwright tests
+  - AC: `make frontend` green; new test covers the happy path and one error path
+
+- [ ] **T6** — Update docs (API.md, CONFIGURATION.md, or CHANGELOG.md as applicable)
+  - AC: docs updated, no broken links
+
+---
+
+## Dependency graph
+
+```
+T1 → T2 → T3 → T4
+          ↓
+          T5
+          ↓
+          T6
+```
+
+---
+
+## Definition of done
+
+A task is done when:
+- Code is merged to `main`
+- `make ci` is green (fmt + clippy + check + test + frontend + drift)
+- The linked acceptance criterion from spec.md is met
+- CHANGELOG.md has an entry under `[Unreleased]`
+
+The feature is done when all tasks are `[x]` and the spec's acceptance criteria are
+all met on `main`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,6 +53,43 @@ duplicate work.
 
 ---
 
+## Spec-Driven Development
+
+For non-trivial features and API changes, we follow a spec-first workflow before
+writing implementation code. The goal is to align on requirements and design early —
+before a large PR is opened — so review stays focused on correctness rather than scope.
+
+**When a spec is required:**
+
+- PRs labeled `feature` or `enhancement`
+- Any new API endpoint or breaking change to an existing one
+- Changes that affect the PHP parity contract (`docs/openapi-parity.md`)
+
+**When a spec is not required:**
+
+- Bug fixes
+- Documentation updates
+- Dependency bumps
+- Tooling and CI changes
+
+**The workflow:**
+
+1. Create `specs/<feature-id>/spec.md` using the template in
+   [`.specify/templates/spec.md`](.specify/templates/spec.md).
+   Open a draft PR so maintainers can comment on requirements.
+2. After the spec is agreed, add `specs/<feature-id>/plan.md` with the technical design.
+3. Use `specs/<feature-id>/tasks.md` to track implementation slices.
+4. Link the spec from the PR template's "Spec reference" field.
+
+The [`specs/`](specs/) directory contains a full index and the workflow description.
+The [`.specify/memory/constitution.md`](.specify/memory/constitution.md) captures the
+binding engineering principles for this project.
+
+For large features, the `/speckit.specify` slash command in Claude Code or Copilot
+can scaffold the three spec files from the templates automatically.
+
+---
+
 ## Development Setup
 
 ### Prerequisites

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -14,8 +14,8 @@ everything here exists to reproduce them locally before `git push`.
 git clone git@github.com:nash87/parkhub-rust.git
 cd parkhub-rust
 
-# Optional local restore mirror. Do not pull, rebase, or base PR work from it.
-git remote add gitea-restore git@192.168.178.220:florian/parkhub-rust.git
+# Optional: add a local mirror remote here if you maintain an internal Gitea instance.
+# git remote add gitea-restore git@<internal-gitea-host>/<owner>/parkhub-rust.git
 
 # Bootstrap (rust-toolchain.toml pins 1.94.1 — rustup installs it automatically)
 cargo build --locked --package parkhub-common

--- a/README.md
+++ b/README.md
@@ -448,6 +448,15 @@ Contributions are very welcome! Here's how to get started:
 
 ---
 
+## Built on the Securanido Platform
+
+ParkHub is developed and maintained by the [Securanido](https://securanido.com) team —
+a platform for self-hosted, privacy-first software. If you are interested in the
+infrastructure, agent orchestration, and compliance tooling behind ParkHub,
+visit [securanido.com](https://securanido.com).
+
+---
+
 ## 📄 License
 
 MIT — see [LICENSE](LICENSE).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,9 +4,9 @@
 
 | Version | Supported              |
 |---------|------------------------|
-| 4.9.x   | Yes (current)          |
-| 4.8.x   | Security fixes only    |
-| < 4.8   | No                     |
+| 5.1.x   | Yes (current)          |
+| 5.0.x   | Security fixes only    |
+| < 5.0   | No                     |
 
 ## Known Accepted Advisories
 

--- a/specs/README.md
+++ b/specs/README.md
@@ -1,0 +1,69 @@
+---
+title: "Specs — Spec-Driven Development index"
+type: reference
+status: active
+last_reviewed: 2026-06-09
+---
+
+# Specs
+
+This directory contains spec-driven development artifacts for ParkHub Rust features.
+Each feature gets its own subdirectory with three files:
+
+```
+specs/<feature-id>/
+├── spec.md    — Requirements and user stories (what + why)
+├── plan.md    — Technical design and architecture (how)
+└── tasks.md   — Dependency-ordered task list with acceptance criteria
+```
+
+Templates for each file live in [`.specify/templates/`](../.specify/templates/).
+
+---
+
+## Workflow
+
+1. **Before opening a PR for a non-trivial feature**, create `specs/<feature-id>/spec.md`
+   using the template. Open a draft PR so reviewers can comment on requirements before
+   implementation begins.
+
+2. **After the spec is agreed**, add `plan.md` with the technical design. Get maintainer
+   sign-off before writing the bulk of the code.
+
+3. **Use `tasks.md`** to track implementation slices. Each task maps to one PR or one
+   focused working session.
+
+4. **Link the spec from the GitHub issue or PR** using the Spec reference field in the
+   PR template.
+
+For small bug fixes and documentation changes, no spec is required.
+For features labeled `enhancement` or `feature`, a spec is expected.
+
+---
+
+## Relationship to the nido task lifecycle
+
+ParkHub uses the nido task system for internal work tracking. The relationship is:
+
+- `nido_task: T-xxx` in the spec/plan/tasks frontmatter links the spec artifact to the
+  task board entry.
+- `nido tasks checkpoint T-xxx "spec authored at specs/<id>/spec.md"` records progress
+  for cross-session handoff.
+- The spec files are the public-facing artifact; the nido task is the internal tracking
+  record. Both are maintained in parallel.
+
+---
+
+## Existing plans
+
+Pre-spec-kit planning documents live in [`docs/plans/`](../docs/plans/). They follow an
+earlier convention and are not being migrated retroactively. New features use the
+`specs/<feature-id>/` layout.
+
+---
+
+## Index
+
+| Feature ID | Title | Status |
+|------------|-------|--------|
+| *(no specs yet — add the first one!)* | | |


### PR DESCRIPTION
## Summary

- **SECURITY.md**: corrected supported-versions table from stale `4.9.x` to current `5.1.x` / `5.0.x`
- **README.md**: added "Built on the Securanido Platform" section linking securanido.com (launch tie-in)
- **DEVELOPMENT.md**: redacted internal Gitea restore remote (`192.168.178.220` + `florian` username) → neutral placeholder comment. *Note: prior commits still contain the original value; history rewrite requires a force-push which is operator-gated and deferred.*
- **Spec-kit bootstrap**: created `.specify/memory/constitution.md` (versioned engineering principles extracted from CONTRIBUTING.md + AGENTS.md), `.specify/templates/{spec,plan,tasks}.md` (Rust/Axum/OpenAPI-customised templates), and `specs/README.md` (contributor index)
- **GitHub templates**: added "Spec reference" field to PR template, added `spec_written` checkbox + `spec_link` field to `feature_request.yml`
- **CONTRIBUTING.md**: added "Spec-Driven Development" section after "Good First Issues" linking the constitution, templates, and workflow

## Deferred items

- **History rewrite** for the `DEVELOPMENT.md` internal IP: the redaction lands in HEAD but prior commit objects still contain `git@192.168.178.220:florian/parkhub-rust.git`. A `git filter-repo` pass + force-push to rewrite history is operator-gated (irreversible public effect). Filed as a follow-up.
- **`.gitea/workflows/` runner IP** (`192.168.178.233`, 205 occurrences): flagged in the audit as a separate deferred pass — changing these would break the internal Gitea runner if not coordinated.

## Make CI status

`make ci` blocked by fop capacity gate (external build pressure from other tabs: 8 active builds, load1=3.4, pressure=55-63%). `fop guard preflight` reports `push_allowed: true`, `commit_gated: false`. Gates confirmed clean manually:
- `cargo fmt --check`: passed (exit 0, confirmed via `FOP_CAPACITY_WAIT_SOFT=1` run)
- Typos: no hits in authored files (2 pre-existing German-word false-positives in lines not touched by this PR)
- Leak scan: clean — no IPs, operator paths, or secrets in any changed or new file
- YAML validation: `feature_request.yml` parses clean

GitHub CI will run the full suite on this PR.

## Test plan

- [ ] Verify SECURITY.md version table shows 5.1.x as current
- [ ] Verify README.md has the Securanido section before License
- [ ] Verify DEVELOPMENT.md has no internal IP in the restore remote line
- [ ] Verify `.specify/memory/constitution.md` renders correctly on GitHub
- [ ] Verify `.specify/templates/` files are complete and usable
- [ ] Verify `specs/README.md` index is accurate
- [ ] Verify PR template and feature_request.yml render correctly on GitHub issues/PRs
- [ ] GitHub CI (gitleaks, cargo-deny, scorecard) passes green

🤖 Generated with [Claude Code](https://claude.com/claude-code)