### PR TITLE
fix(ci): bump wolfi-base digest — old digest GC'd by Chainguard

### DIFF
--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -32,7 +32,7 @@ jobs:
           # Cloud runners can't reach the homelab LAN mirror; pull the same
           # Wolfi base from Chainguard's public registry. Dockerfile defaults
           # to the LAN mirror for local + gitea-runner builds.
-          WOLFI_BASE: cgr.dev/chainguard/wolfi-base@sha256:4973aa3c2ccbe13fe2049aab539b0ab342ec584bd5b54a269d55d4891091c639
+          WOLFI_BASE: cgr.dev/chainguard/wolfi-base@sha256:865267010fd5c6a45c7ab456848573010ec521b0d2677a0a966f3f2211b71eda
         run: |
           # Step 2 — set admin password
           echo "PARKHUB_ADMIN_PASSWORD=$(openssl rand -base64 24)" > .env

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@
 # the "never pull from Docker Hub" convention for local + gitea-runner
 # builds. GitHub Actions cloud runners pass the same digest against
 # cgr.dev/chainguard/wolfi-base so release builds never depend on a mutable tag.
-ARG WOLFI_BASE=192.168.178.250:5000/wolfi-base@sha256:4973aa3c2ccbe13fe2049aab539b0ab342ec584bd5b54a269d55d4891091c639
+ARG WOLFI_BASE=192.168.178.250:5000/wolfi-base@sha256:865267010fd5c6a45c7ab456848573010ec521b0d2677a0a966f3f2211b71eda
 
 # ---------------------------------------------------------------------------
 # Stage 1: Frontend build (Astro/Vite)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
       dockerfile: Dockerfile
       args:
         # Default to the digest-pinned LAN mirror; cloud CI may override.
-        WOLFI_BASE: ${WOLFI_BASE:-192.168.178.250:5000/wolfi-base@sha256:4973aa3c2ccbe13fe2049aab539b0ab342ec584bd5b54a269d55d4891091c639}
+        WOLFI_BASE: ${WOLFI_BASE:-192.168.178.250:5000/wolfi-base@sha256:865267010fd5c6a45c7ab456848573010ec521b0d2677a0a966f3f2211b71eda}
     container_name: parkhub
     restart: unless-stopped
     # Pass CLI flags so the server runs headless on port 8080.


### PR DESCRIPTION
Twin of the parkhub-php fix: cgr.dev GC'd the pinned digest → image builds on main fail (`not found`). Bumps Dockerfile, docker-compose, install-smoke to the current digest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)